### PR TITLE
Adds users element to the Okta groups resource docs.

### DIFF
--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -29,6 +29,8 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the Okta Group.
 
+* `users` - (Optional) The users associated with the group. This can also be done per user.
+
 ## Attributes Reference
 
 * `id` - The ID of the Okta Group.


### PR DESCRIPTION
Adds `users` to the docs as defined here https://github.com/articulate/terraform-provider-okta/blob/master/okta/resource_okta_group.go#L33