### PR TITLE
Doc: id is an output of app_oauth

### DIFF
--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -80,6 +80,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
+* `id` - ID of the application.
+
 * `name` - Name assigned to the application by Okta.
 
 * `sign_on_mode` - Sign on mode of application.


### PR DESCRIPTION
I have verified that `id` is a valid output of `okta_app_oauth` resource in `terraform-provider-okta_v3.1.1`.

```terraform
resource "okta_app_group_assignment" "oidc" {
  app_id   = "${okta_app_oauth.oidc.id}"
  group_id = "${data.okta_group.engineering.id}"
}
```

```
# terraform apply
......
module.oidc.okta_app_group_assignment.oidc: Creating...
  app_id:   "" => "0oa531dkaUsFGY10B4x6"
  group_id: "" => "00g50b0z3lGuaLUTX4x6"
  profile:  "" => "{}"
module.oidc.okta_app_group_assignment.oidc: Creation complete after 1s (ID: 00g50b0z3lGuaLUTX4x6)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```