### PR TITLE
Add issuer to data.okta_auth_server

### DIFF
--- a/okta/data_source_okta_auth_server.go
+++ b/okta/data_source_okta_auth_server.go
@@ -48,7 +48,7 @@ func dataSourceAuthServer() *schema.Resource {
 			"issuer": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The complete URL the authorization server. This becomes the `iss` claim in an access token.",
+				Description: "The complete URL of the authorization server. This becomes the `iss` claim in an access token.",
 			},
 			"issuer_mode": &schema.Schema{
 				Type:     schema.TypeString,

--- a/okta/data_source_okta_auth_server.go
+++ b/okta/data_source_okta_auth_server.go
@@ -45,6 +45,15 @@ func dataSourceAuthServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"issuer": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The complete URL the authorization server. This becomes the `iss` claim in an access token.",
+			},
+			"issuer_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -67,6 +76,8 @@ func dataSourceAuthServerRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("credentials_next_rotation", authServer.Credentials.Signing.NextRotation.String())
 	d.Set("credentials_last_rotated", authServer.Credentials.Signing.LastRotated.String())
 	d.Set("status", authServer.Status)
+	d.Set("issuer", authServer.Issuer)
+	d.Set("issuer_mode", authServer.IssuerMode)
 
 	return nil
 }

--- a/okta/data_source_okta_auth_server_test.go
+++ b/okta/data_source_okta_auth_server_test.go
@@ -25,6 +25,7 @@ func TestAccOktaDataSourceAuthServer_read(t *testing.T) {
 					resource.TestCheckResourceAttrSet("okta_auth_server.test", "id"),
 					resource.TestCheckResourceAttr("data.okta_auth_server.test", "name", fmt.Sprintf("testAcc_%d", ri)),
 					resource.TestCheckResourceAttr("data.okta_auth_server.test", "status", "ACTIVE"),
+					resource.TestCheckResourceAttrSet("data.okta_auth_server.test", "issuer"),
 				),
 			},
 		},

--- a/website/docs/d/auth_server.html.markdown
+++ b/website/docs/d/auth_server.html.markdown
@@ -41,3 +41,7 @@ data "okta_auth_server" "example" {
  * `credentials_rotation_mode` - mode of credential rotation, auto or manual.
 
  * `status` - the activation status of the authorization server.
+
+ * `issuer` - The complete URL for a Custom Authorization Server. This becomes the `iss` claim in an access token.
+
+ * `issuer_mode` - Can be set to `"CUSTOM_URL"` or `"ORG_URL"`

--- a/website/docs/d/auth_server.html.markdown
+++ b/website/docs/d/auth_server.html.markdown
@@ -42,6 +42,6 @@ data "okta_auth_server" "example" {
 
  * `status` - the activation status of the authorization server.
 
- * `issuer` - The complete URL for a Custom Authorization Server. This becomes the `iss` claim in an access token.
+ * `issuer` - The complete URL of the authorization server. This becomes the `iss` claim in an access token.
 
  * `issuer_mode` - Can be set to `"CUSTOM_URL"` or `"ORG_URL"`


### PR DESCRIPTION
Changes:

* Adds `issuer` and `issuer_mode` to `data.okta_auth_server` source & updates the data docs

Tested locally against my default auth server. Let me know if there are any programatic tests I should add. Thanks!

fixes #101 