### PR TITLE
Remove default value for key_years_valid in okta_app_saml

### DIFF
--- a/okta/resource_okta_app_saml.go
+++ b/okta/resource_okta_app_saml.go
@@ -68,7 +68,6 @@ func resourceAppSaml() *schema.Resource {
 			"key_years_valid": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      1,
 				ValidateFunc: validation.IntAtLeast(1),
 				Description:  "Number of years the certificate is valid.",
 			},


### PR DESCRIPTION
I've tested in on production, nothing change for current configuration (where I had to set this value because default value was 1 which is incorrect), also working perfectly fine for config where I removed this field.

IMO there is no need to test it in unit tests because we are using external library (helpers from terraform plugins sdk which should be tested enough).

This issue closing #73 

This is not a braking change