### PR TITLE
Fixed provider_id typo in okta_factor in web documentation

### DIFF
--- a/website/docs/r/factor.html.markdown
+++ b/website/docs/r/factor.html.markdown
@@ -16,7 +16,7 @@ This resource allows you to manage Okta MFA methods.
 
 ```hcl
 resource "okta_factor" "example" {
-  provider = "google_otp"
+  provider_id = "google_otp"
 }
 ```
 
@@ -24,10 +24,10 @@ resource "okta_factor" "example" {
 
 The following arguments are supported:
 
-* `provider` - (Required) The MFA provider name.
+* `provider_id` - (Required) The MFA provider name.
 
 * `active` - (Optional) Whether or not to activate the provider, by default it is set to `true`.
 
 ## Attributes Reference
 
-* `provider` - MFA provider name.
+* `provider_id` - MFA provider name.

--- a/website/docs/r/factor.html.markdown
+++ b/website/docs/r/factor.html.markdown
@@ -25,6 +25,7 @@ resource "okta_factor" "example" {
 The following arguments are supported:
 
 * `provider_id` - (Required) The MFA provider name.
+Allowed values are `"duo"`, `"fido_u2f"`, `"fido_webauthn"`, `"google_otp"`, `"okta_call"`, `"okta_otp"`, `"okta_push"`, `"okta_question"`, `"okta_sms"`, `"rsa_token"`, `"symantec_vip"` or `"yubikey_token"`.
 
 * `active` - (Optional) Whether or not to activate the provider, by default it is set to `true`.
 


### PR DESCRIPTION
Taken from https://github.com/articulate/terraform-provider-okta/blob/master/okta/resource_okta_factor.go and https://github.com/articulate/oktasdk-go/blob/master/okta/org.go

Web documentation is misleading and wrong. `provider` is a reserved keyword and will create errors in Terraform that will be connected with the Okta provider and not this particular resource. Hence will be very confusing for beginners.

Checking in code its name is `provider_id` and have a list of allowed values.

I'm fixing those two important information here.