### PR TITLE
Fix terraform import command for okta_mfa_policy

### DIFF
--- a/website/docs/r/policy_mfa.html.markdown
+++ b/website/docs/r/policy_mfa.html.markdown
@@ -85,5 +85,5 @@ All MFA settings above have the following structure.
 An MFA Policy can be imported via the Okta ID.
 
 ```
-$ terraform import okta_policy_mfa.example <app id>
+$ terraform import okta_policy_mfa.example <policy id>
 ```


### PR DESCRIPTION
To import `okta_mfa_policy` the policy ID is required, an app ID will not work.