### PR TITLE
Added missing argument description

### DIFF
--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `priority` - (Required) Priority of the auth server policy rule.
 
+* `group_whitelist` - (Required) The list of group ids to whitelist. Can be set to group id or to the following: "EVERYONE".
+
 * `grant_type_whitelist` - (Required) Accepted grant type values, `"authorization_code"`, `"implicit"`, `"password"`
 
 * `scope_whitelist` - (Required) Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with `"*"`.


### PR DESCRIPTION
Adding the missing description of `grant_type_whitelist` argument. Spent some time researching how it works especially that I needed to use it in conjunction with the EVERYONE group.