### PR TITLE
Adding support for GROUP_MEMBERSHIP_ADMIN & REPORT_ADMIN

### DIFF
--- a/examples/okta_group_roles/all_roles.tf
+++ b/examples/okta_group_roles/all_roles.tf
@@ -15,6 +15,7 @@ resource okta_group_roles test {
     "MOBILE_ADMIN",
     "READ_ONLY_ADMIN",
     "HELP_DESK_ADMIN",
+    "GROUP_MEMBERSHIP_ADMIN"
   ]
 }
 

--- a/examples/okta_group_roles/all_roles.tf
+++ b/examples/okta_group_roles/all_roles.tf
@@ -15,6 +15,7 @@ resource okta_group_roles test {
     "MOBILE_ADMIN",
     "READ_ONLY_ADMIN",
     "HELP_DESK_ADMIN",
+    "REPORT_ADMIN",
     "GROUP_MEMBERSHIP_ADMIN"
   ]
 }

--- a/okta/resource_okta_group_roles_test.go
+++ b/okta/resource_okta_group_roles_test.go
@@ -29,7 +29,7 @@ func TestAccOktaGroupAdminRoles_crud(t *testing.T) {
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "9"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "10"),
 				),
 			},
 		},

--- a/okta/resource_okta_group_roles_test.go
+++ b/okta/resource_okta_group_roles_test.go
@@ -29,7 +29,7 @@ func TestAccOktaGroupAdminRoles_crud(t *testing.T) {
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "8"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "9"),
 				),
 			},
 		},

--- a/sdk/group_role.go
+++ b/sdk/group_role.go
@@ -16,7 +16,7 @@ type (
 	}
 )
 
-var ValidAdminRoles = []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN"}
+var ValidAdminRoles = []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN", "GROUP_MEMBERSHIP_ADMIN"}
 
 func (m *ApiSupplement) DeleteAdminRole(id, roleId string) (*okta.Response, error) {
 	url := fmt.Sprintf("/api/v1/groups/%s/roles/%s", id, roleId)

--- a/sdk/group_role.go
+++ b/sdk/group_role.go
@@ -16,7 +16,7 @@ type (
 	}
 )
 
-var ValidAdminRoles = []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN", "GROUP_MEMBERSHIP_ADMIN"}
+var ValidAdminRoles = []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN", "REPORT_ADMIN", "GROUP_MEMBERSHIP_ADMIN"}
 
 func (m *ApiSupplement) DeleteAdminRole(id, roleId string) (*okta.Response, error) {
 	url := fmt.Sprintf("/api/v1/groups/%s/roles/%s", id, roleId)

--- a/website/docs/r/group_roles.html.markdown
+++ b/website/docs/r/group_roles.html.markdown
@@ -29,7 +29,6 @@ The following arguments are supported:
 
 * `admin_roles` - (Required) Admin roles associated with the group. It can be any of the following values `"SUPER_ADMIN"`, `"ORG_ADMIN"`, `"APP_ADMIN"`, `"USER_ADMIN"`, `"HELP_DESK_ADMIN"`, `"READ_ONLY_ADMIN"`, `"MOBILE_ADMIN"`, `"API_ACCESS_MANAGEMENT_ADMIN"`, `"REPORT_ADMIN"`, `"GROUP_MEMBERSHIP_ADMIN"`.
 
-> Group membership admin requires [activating the feature](https://help.okta.com/en/prod/Content/Topics/Security/admin-role-groupmembershipadmin.htm) in your tenant.
 
 ## Attributes Reference
 

--- a/website/docs/r/group_roles.html.markdown
+++ b/website/docs/r/group_roles.html.markdown
@@ -27,7 +27,9 @@ The following arguments are supported:
 
 * `group_id` - (Required) The ID of group to attach admin roles to.
 
-* `admin_roles` - (Required) Admin roles associated with the group. It can be any of the following values `"SUPER_ADMIN"`, `"ORG_ADMIN"`, `"APP_ADMIN"`, `"USER_ADMIN"`, `"HELP_DESK_ADMIN"`, `"READ_ONLY_ADMIN"`, `"MOBILE_ADMIN"`, `"API_ACCESS_MANAGEMENT_ADMIN"`, `"REPORT_ADMIN"`.
+* `admin_roles` - (Required) Admin roles associated with the group. It can be any of the following values `"SUPER_ADMIN"`, `"ORG_ADMIN"`, `"APP_ADMIN"`, `"USER_ADMIN"`, `"HELP_DESK_ADMIN"`, `"READ_ONLY_ADMIN"`, `"MOBILE_ADMIN"`, `"API_ACCESS_MANAGEMENT_ADMIN"`, `"REPORT_ADMIN"`, `"GROUP_MEMBERSHIP_ADMIN"`.
+
+> Group membership admin requires [activating the feature](https://help.okta.com/en/prod/Content/Topics/Security/admin-role-groupmembershipadmin.htm) in your tenant.
 
 ## Attributes Reference
 


### PR DESCRIPTION
With the Release of the GROUP_MEMBERSHIP_ADMIN role to the Okta ecosystem, this role can now also be used with the Terraform provider. 

I'm adding this documentation indicating it can be used, I've also added a block quote with links to the supporting documentation due to the need to manually activate this feature with a feature flag on a per tenant basis.