### PR TITLE
Add group_whitelist to schema & make scope_whitelist required

### DIFF
--- a/examples/okta_app_oauth/service_with_jwks.tf
+++ b/examples/okta_app_oauth/service_with_jwks.tf
@@ -1,8 +1,8 @@
 resource "okta_app_oauth" "test" {
-  label          = "testAcc_replace_with_uuid"
-  type           = "service"
-  response_types = ["token"]
-  grant_types    = ["client_credentials"]
+  label                      = "testAcc_replace_with_uuid"
+  type                       = "service"
+  response_types             = ["token"]
+  grant_types                = ["client_credentials"]
   token_endpoint_auth_method = "private_key_jwt"
 
   jwks {

--- a/examples/okta_auth_server_policy_rule/basic.tf
+++ b/examples/okta_auth_server_policy_rule/basic.tf
@@ -10,6 +10,7 @@ resource "okta_auth_server_policy_rule" "test" {
   priority             = 1
   group_whitelist      = ["${data.okta_group.all.id}"]
   grant_type_whitelist = ["implicit"]
+  scope_whitelist      = ["openid","profile"]
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_policy_rule/basic.tf
+++ b/examples/okta_auth_server_policy_rule/basic.tf
@@ -10,7 +10,7 @@ resource "okta_auth_server_policy_rule" "test" {
   priority             = 1
   group_whitelist      = ["${data.okta_group.all.id}"]
   grant_type_whitelist = ["implicit"]
-  scope_whitelist      = ["openid","profile"]
+  scope_whitelist      = ["openid", "profile"]
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_policy_rule/basic_updated.tf
+++ b/examples/okta_auth_server_policy_rule/basic_updated.tf
@@ -9,7 +9,8 @@ resource "okta_auth_server_policy_rule" "test" {
   name                 = "test_updated"
   priority             = 1
   group_whitelist      = ["${data.okta_group.all.id}"]
-  grant_type_whitelist = ["password"]
+  grant_type_whitelist = ["password", "authorization_code"]
+  scope_whitelist      = ["*"]
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_template_sms/basic.tf
+++ b/examples/okta_template_sms/basic.tf
@@ -1,5 +1,5 @@
 resource "okta_template_sms" test {
-  type = "SMS_VERIFY_CODE"
+  type     = "SMS_VERIFY_CODE"
   template = "Your $${org.name} code is: $${code}"
   translations {
     language = "en"

--- a/examples/okta_template_sms/updated.tf
+++ b/examples/okta_template_sms/updated.tf
@@ -1,5 +1,5 @@
 resource "okta_template_sms" test {
-  type = "SMS_VERIFY_CODE"
+  type     = "SMS_VERIFY_CODE"
   template = "Your $${org.name} updated code is: $${code}"
   translations {
     language = "en"

--- a/examples/okta_user/deprovisioned.tf
+++ b/examples/okta_user/deprovisioned.tf
@@ -1,7 +1,7 @@
 resource "okta_user" "test" {
-  first_name  = "TestAcc"
-  last_name   = "Smith"
-  login       = "test-acc-replace_with_uuid@example.com"
-  email       = "test-acc-replace_with_uuid@example.com"
-  status      = "DEPROVISIONED"
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "test-acc-replace_with_uuid@example.com"
+  email      = "test-acc-replace_with_uuid@example.com"
+  status     = "DEPROVISIONED"
 }

--- a/okta/resource_okta_auth_server_policy_rule.go
+++ b/okta/resource_okta_auth_server_policy_rule.go
@@ -53,15 +53,13 @@ func resourceAuthServerPolicyRule() *schema.Resource {
 			},
 			"scope_whitelist": &schema.Schema{
 				Type:     schema.TypeSet,
-				Optional: true,
+				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Default:  ("*"),
 			},
 			"group_whitelist": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Default:  ("EVERYONE"),
 			},
 			"access_token_lifetime_minutes": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/okta/resource_okta_auth_server_policy_rule.go
+++ b/okta/resource_okta_auth_server_policy_rule.go
@@ -49,12 +49,18 @@ func resourceAuthServerPolicyRule() *schema.Resource {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Accepted grant type values: authorization_code, implicit, password.",
+				Description: "Accepted grant type values: authorization_code, implicit, password, and client_credentials.",
 			},
 			"scope_whitelist": &schema.Schema{
 				Type:     schema.TypeSet,
-				Optional: true,
+				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"group_whitelist": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Default:  "EVERYONE",
 			},
 			"access_token_lifetime_minutes": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/okta/resource_okta_auth_server_policy_rule.go
+++ b/okta/resource_okta_auth_server_policy_rule.go
@@ -53,12 +53,13 @@ func resourceAuthServerPolicyRule() *schema.Resource {
 			},
 			"scope_whitelist": &schema.Schema{
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Default:  "*",
 			},
 			"group_whitelist": &schema.Schema{
 				Type:     schema.TypeSet,
-				Required: false,
+				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Default:  "EVERYONE",
 			},

--- a/okta/resource_okta_auth_server_policy_rule.go
+++ b/okta/resource_okta_auth_server_policy_rule.go
@@ -55,13 +55,13 @@ func resourceAuthServerPolicyRule() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Default:  "*",
+				Default:  ("*"),
 			},
 			"group_whitelist": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Default:  "EVERYONE",
+				Default:  ("EVERYONE"),
 			},
 			"access_token_lifetime_minutes": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -46,8 +46,6 @@ The following arguments are supported:
 
 * `group_whitelist` - (Optional) Groups of users allowed for this policy rule. They can be whitelisted by id or you can use the reference `"EVERYONE"` as an alias for the everyone group.
 
-* `group_blacklist` - (Optional) Groups of users denied for this policy rule. They can be black by id or you can use the reference `"EVERYONE"` as an alias for the everyone group.
-
 * `access_token_lifetime_minutes` - (Optional) Lifetime of access token. Can be set to a value between 5 and 1440.
 
 * `refresh_token_lifetime_minutes` - (Optional) Lifetime of refresh token.

--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -40,9 +40,13 @@ The following arguments are supported:
 
 * `priority` - (Required) Priority of the auth server policy rule.
 
-* `grant_type_whitelist` - (Required) Accepted grant type values, `"authorization_code"`, `"implicit"`, `"password"`
+* `grant_type_whitelist` - (Required) Accepted grant type values: `"authorization_code"`, `"implicit"`, `"password"`, and `"client_credentials"`
 
 * `scope_whitelist` - (Required) Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with `"*"`.
+
+* `group_whitelist` - (Optional) Groups of users allowed for this policy rule. They can be whitelisted by id or you can use the reference `"EVERYONE"` as an alias for the everyone group.
+
+* `group_blacklist` - (Optional) Groups of users denied for this policy rule. They can be black by id or you can use the reference `"EVERYONE"` as an alias for the everyone group.
 
 * `access_token_lifetime_minutes` - (Optional) Lifetime of access token. Can be set to a value between 5 and 1440.
 

--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `grant_type_whitelist` - (Required) Accepted grant type values: `"authorization_code"`, `"implicit"`, `"password"`, and `"client_credentials"`
 
-* `scope_whitelist` - (Required) Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with `"*"`.
+* `scope_whitelist` - (Optional) Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with `"*"`.
 
 * `group_whitelist` - (Optional) Groups of users allowed for this policy rule. They can be whitelisted by id or you can use the reference `"EVERYONE"` as an alias for the everyone group.
 

--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `grant_type_whitelist` - (Required) Accepted grant type values: `"authorization_code"`, `"implicit"`, `"password"`, and `"client_credentials"`
 
-* `scope_whitelist` - (Optional) Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with `"*"`.
+* `scope_whitelist` - (Required) Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with `"*"`.
 
 * `group_whitelist` - (Optional) Groups of users allowed for this policy rule. They can be whitelisted by id or you can use the reference `"EVERYONE"` as an alias for the everyone group.
 


### PR DESCRIPTION
This PR is for a number of related items:

1. Adds "group_whitelist" into the schema and the docs, it's already used in the examples however not documented and fully implemented in the resource scheme. All of the condition object items are worth a re-visit to cleanup, ideally after Okta SDK upgrade, since there's odd behavior like using the "GroupRule" conditionals versus the generic conditionals. We can also add "user_whitelist" and "{type}_blacklist" as well.

2. This makes scope_whitelist required in the resource scheme to match the docs. Technically the API does not require it, however since the default for this is empty, the created resource is unusable in that state (according to my testing).

3. I've updated the policy rule examples / tests to include scope_whitelist (also add auth code to the updated test since that'll be one of the most used settings for these).

4. I've updated the docs around "grant_type_whitelist" to reflect that "client_credentials" is also valid.

5. I ran `terraform fmt` on the examples DIR while working on this.