### PR TITLE
Fix validation false positive when api_token is set via environment variable

### DIFF
--- a/okta/provider.go
+++ b/okta/provider.go
@@ -73,7 +73,7 @@ func Provider() terraform.ResourceProvider {
 			},
 			"api_token": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OKTA_API_TOKEN", nil),
 				Description: "API Token granting privileges to Okta API.",
 			},


### PR DESCRIPTION
Terraform validate fails when api_token is not specified but `OKTA_API_TOKEN` environment variable is specified. This should fix validation in that case. If this is not the preferred method to fix that bug, please let me know and I'd be happy to alter the change accordingly!