### PR TITLE
Remove requirement for priority in resource_okta_auth_server_policy

### DIFF
--- a/okta/resource_okta_auth_server_policy.go
+++ b/okta/resource_okta_auth_server_policy.go
@@ -34,7 +34,7 @@ func resourceAuthServerPolicy() *schema.Resource {
 			"status": statusSchema,
 			"priority": &schema.Schema{
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
 				Description: "Priority of the auth server policy",
 			},
 			"description": &schema.Schema{

--- a/website/docs/r/auth_server_policy.html.markdown
+++ b/website/docs/r/auth_server_policy.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `status` - (Optional) The status of the Auth Server Policy.
 
-* `priority` - (Required) The priority of the Auth Server Policy.
+* `priority` - (Optional) The priority of the Auth Server Policy.
 
 * `description` - (Optional) The description of the Auth Server Policy.
 


### PR DESCRIPTION
According to the policy API object, priority is not required: https://developer.okta.com/docs/reference/api/policy/#policy-object

This change just simply switches this to optional so you don't need to specify priority which often shows as changed in terraform is objects are added or removed.

I tried to dig around to see if anything was needed in the SDK layer and such but didn't appear so, let me know if I missed something!