### PR TITLE
Fix population of the user 'status' attribute

### DIFF
--- a/okta/user.go
+++ b/okta/user.go
@@ -425,6 +425,8 @@ func flattenUser(u *okta.User, d *schema.ResourceData) (map[string]interface{}, 
 		}
 	}
 
+	attrs["status"] = mapStatus(u.Status)
+
 	data, err := json.Marshal(customAttributes)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load custom_attributes to JSON")


### PR DESCRIPTION
The `status` attribute on the `okta_user` and `okta_users` data providers was not set; this patch corrects that.