### PR TITLE
chore: format terraform examples to pass `terraform fmt -recursive .`

### DIFF
--- a/examples/oidc-cognito-stack.tf
+++ b/examples/oidc-cognito-stack.tf
@@ -22,22 +22,22 @@ data "okta_user" "garth" {
   last_name         = "B"
   login             = "garth@something.com"
   email             = "garth@something.com"
-  group_memberships = ["${okta_group.peeps.id}"]
+  group_memberships = [okta_group.peeps.id]
 }
 
 resource "okta_app_oauth" "app" {
   label          = "G Studios"
   type           = "browser"
-  client_uri     = "${local.uri}"
-  redirect_uris  = ["${local.uri}"]
-  groups         = ["${okta_group.peeps.id}"]
+  client_uri     = local.uri
+  redirect_uris  = [local.uri]
+  groups         = [okta_group.peeps.id]
   response_types = ["token", "id_token"]
   grant_types    = ["implicit"]
 }
 
 resource "okta_trusted_origin" "app" {
   name   = "Something"
-  origin = "${local.uri}"
+  origin = local.uri
   scopes = ["CORS", "REDIRECT"]
 }
 
@@ -46,18 +46,18 @@ resource "aws_cognito_identity_pool" "slick_idpool" {
   identity_pool_name               = "Cool Stuff Neat Stuff Slick stuff"
   allow_unauthenticated_identities = false
 
-  openid_connect_provider_arns = ["${aws_iam_openid_connect_provider.openid.arn}"]
+  openid_connect_provider_arns = [aws_iam_openid_connect_provider.openid.arn]
 }
 
 resource "aws_iam_openid_connect_provider" "openid" {
   url = "https://articulate.okta.com"
 
   client_id_list = [
-    "${okta_app_oauth.app.id}",
+    okta_app_oauth.app.id,
   ]
 
   thumbprint_list = [
-    "${local.jwk_thumbprint}",
+    local.jwk_thumbprint,
   ]
 }
 
@@ -90,7 +90,7 @@ EOF
 
 resource "aws_iam_role_policy" "authenticated" {
   name = "auth"
-  role = "${aws_iam_role.authenticated.id}"
+  role = aws_iam_role.authenticated.id
 
   policy = <<EOF
 {
@@ -121,31 +121,31 @@ EOF
 }
 
 resource "aws_cognito_identity_pool_roles_attachment" "role_attachment" {
-  identity_pool_id = "${aws_cognito_identity_pool.slick_idpool.id}"
+  identity_pool_id = aws_cognito_identity_pool.slick_idpool.id
 
   role_mapping {
-    identity_provider         = "${aws_iam_openid_connect_provider.openid.arn}"
+    identity_provider         = aws_iam_openid_connect_provider.openid.arn
     ambiguous_role_resolution = "AuthenticatedRole"
     type                      = "Rules"
 
     mapping_rule {
       claim      = "staff"
       match_type = "Equals"
-      role_arn   = "${aws_iam_role.authenticated.arn}"
+      role_arn   = aws_iam_role.authenticated.arn
       value      = "true"
     }
 
     mapping_rule {
       claim      = "aud"
       match_type = "Equals"
-      role_arn   = "${aws_iam_role.authenticated.arn}"
+      role_arn   = aws_iam_role.authenticated.arn
 
       // Need to add data source for apps to Okta provider, oauth app only created in stage so hardcoding for now
-      value = "${okta_app_oauth.app.id}"
+      value = okta_app_oauth.app.id
     }
   }
 
   roles {
-    "authenticated" = "${aws_iam_role.authenticated.arn}"
+    authenticated = aws_iam_role.authenticated.arn
   }
 }

--- a/examples/okta_app/datasource.tf
+++ b/examples/okta_app/datasource.tf
@@ -9,13 +9,13 @@ resource "okta_app_oauth" "test" {
 }
 
 data "okta_app" "test" {
-  label = "${okta_app_oauth.test.label}"
+  label = okta_app_oauth.test.label
 }
 
 data "okta_app" "test2" {
-  id = "${okta_app_oauth.test.id}"
+  id = okta_app_oauth.test.id
 }
 
 data "okta_app" "test3" {
-  label_prefix = "${okta_app_oauth.test.label}"
+  label_prefix = okta_app_oauth.test.label
 }

--- a/examples/okta_app_basic_auth/basic_updated.tf
+++ b/examples/okta_app_basic_auth/basic_updated.tf
@@ -16,9 +16,9 @@ resource "okta_app_basic_auth" "test" {
   auth_url = "https://example.com/auth.html"
 
   users {
-    id       = "${okta_user.user.id}"
-    username = "${okta_user.user.email}"
+    id       = okta_user.user.id
+    username = okta_user.user.email
   }
 
-  groups = ["${okta_group.group.id}"]
+  groups = [okta_group.group.id]
 }

--- a/examples/okta_app_bookmark/basic.tf
+++ b/examples/okta_app_bookmark/basic.tf
@@ -5,5 +5,5 @@ resource "okta_group" "group" {
 resource "okta_app_bookmark" "test" {
   label  = "testAcc_replace_with_uuid"
   url    = "https://test.com"
-  groups = ["${okta_group.group.id}"]
+  groups = [okta_group.group.id]
 }

--- a/examples/okta_app_bookmark/basic_updated.tf
+++ b/examples/okta_app_bookmark/basic_updated.tf
@@ -15,9 +15,9 @@ resource "okta_app_bookmark" "test" {
   url   = "https://test.com"
 
   users {
-    id       = "${okta_user.user.id}"
-    username = "${okta_user.user.email}"
+    id       = okta_user.user.id
+    username = okta_user.user.email
   }
 
-  groups = ["${okta_group.group.id}"]
+  groups = [okta_group.group.id]
 }

--- a/examples/okta_app_group_assignment/basic.tf
+++ b/examples/okta_app_group_assignment/basic.tf
@@ -16,6 +16,6 @@ resource okta_group test {
 }
 
 resource okta_app_group_assignment test {
-  app_id   = "${okta_app_oauth.test.id}"
-  group_id = "${okta_group.test.id}"
+  app_id   = okta_app_oauth.test.id
+  group_id = okta_group.test.id
 }

--- a/examples/okta_app_group_assignment/force_new_update.tf
+++ b/examples/okta_app_group_assignment/force_new_update.tf
@@ -16,7 +16,7 @@ resource okta_group test2 {
 }
 
 resource okta_app_group_assignment test {
-  app_id   = "${okta_app_oauth.test.id}"
-  group_id = "${okta_group.test2.id}"
+  app_id   = okta_app_oauth.test.id
+  group_id = okta_group.test2.id
   priority = 1
 }

--- a/examples/okta_app_group_assignment/updated.tf
+++ b/examples/okta_app_group_assignment/updated.tf
@@ -16,7 +16,7 @@ resource okta_group test {
 }
 
 resource okta_app_group_assignment test {
-  app_id   = "${okta_app_oauth.test.id}"
-  group_id = "${okta_group.test.id}"
+  app_id   = okta_app_oauth.test.id
+  group_id = okta_group.test.id
   priority = 1
 }

--- a/examples/okta_app_metadata_saml/datasource.tf
+++ b/examples/okta_app_metadata_saml/datasource.tf
@@ -14,6 +14,6 @@ resource okta_app_saml test {
 }
 
 data okta_app_metadata_saml test {
-  app_id = "${okta_app_saml.test.id}"
-  key_id = "${okta_app_saml.test.key_id}"
+  app_id = okta_app_saml.test.id
+  key_id = okta_app_saml.test.key_id
 }

--- a/examples/okta_app_oauth/groups_and_users.tf
+++ b/examples/okta_app_oauth/groups_and_users.tf
@@ -21,9 +21,9 @@ resource "okta_app_oauth" "test" {
   response_types            = ["code", "token", "id_token"]
 
   users {
-    id       = "${okta_user.user.id}"
-    username = "${okta_user.user.email}"
+    id       = okta_user.user.id
+    username = okta_user.user.email
   }
 
-  groups = ["${okta_group.group.id}"]
+  groups = [okta_group.group.id]
 }

--- a/examples/okta_app_oauth/service_with_jwks.tf
+++ b/examples/okta_app_oauth/service_with_jwks.tf
@@ -1,8 +1,8 @@
 resource "okta_app_oauth" "test" {
-  label          = "testAcc_replace_with_uuid"
-  type           = "service"
-  response_types = ["token"]
-  grant_types    = ["client_credentials"]
+  label                      = "testAcc_replace_with_uuid"
+  type                       = "service"
+  response_types             = ["token"]
+  grant_types                = ["client_credentials"]
   token_endpoint_auth_method = "private_key_jwt"
 
   jwks {

--- a/examples/okta_app_oauth_redirect_uri/basic.tf
+++ b/examples/okta_app_oauth_redirect_uri/basic.tf
@@ -15,6 +15,6 @@ resource "okta_app_oauth" "test" {
 }
 
 resource "okta_app_oauth_redirect_uri" "test" {
-  app_id = "${okta_app_oauth.test.id}"
+  app_id = okta_app_oauth.test.id
   uri    = "http://google.com"
 }

--- a/examples/okta_app_oauth_redirect_uri/basic_updated.tf
+++ b/examples/okta_app_oauth_redirect_uri/basic_updated.tf
@@ -15,6 +15,6 @@ resource "okta_app_oauth" "test" {
 }
 
 resource "okta_app_oauth_redirect_uri" "test" {
-  app_id = "${okta_app_oauth.test.id}"
+  app_id = okta_app_oauth.test.id
   uri    = "http://google-updated.com"
 }

--- a/examples/okta_app_saml/datasource.tf
+++ b/examples/okta_app_saml/datasource.tf
@@ -14,9 +14,9 @@ resource okta_app_saml test {
 }
 
 data okta_app_saml test {
-  id = "${okta_app_saml.test.id}"
+  id = okta_app_saml.test.id
 }
 
 data okta_app_saml test_label {
-  label = "${okta_app_saml.test.label}"
+  label = okta_app_saml.test.label
 }

--- a/examples/okta_app_saml/updated.tf
+++ b/examples/okta_app_saml/updated.tf
@@ -24,5 +24,5 @@ resource okta_app_saml test {
     name         = "Attr Two"
     filter_type  = "STARTS_WITH"
     filter_value = "test"
-}
+  }
 }

--- a/examples/okta_app_saml/user_groups.tf
+++ b/examples/okta_app_saml/user_groups.tf
@@ -32,19 +32,19 @@ resource "okta_app_saml" "test" {
   label             = "testAcc_replace_with_uuid"
 
   users {
-    id       = "${okta_user.user.id}"
-    username = "${okta_user.user.email}"
+    id       = okta_user.user.id
+    username = okta_user.user.email
   }
 
   users {
-    id       = "${okta_user.user1.id}"
-    username = "${okta_user.user1.email}"
+    id       = okta_user.user1.id
+    username = okta_user.user1.email
   }
 
-  groups = ["${okta_group.group.id}", "${okta_group.group1.id}", "${okta_group.group2.id}"]
+  groups = [okta_group.group.id, okta_group.group1.id, okta_group.group2.id]
 
   key_years_valid = 3
-  key_name = "hello"
+  key_name        = "hello"
 
   app_settings_json = <<EOT
 {

--- a/examples/okta_app_saml/user_groups_updated.tf
+++ b/examples/okta_app_saml/user_groups_updated.tf
@@ -34,10 +34,10 @@ resource "okta_user" "user1" {
 resource "okta_app_saml" "test" {
   preconfigured_app = "amazon_aws"
   label             = "testAcc_replace_with_uuid"
-  groups            = ["${data.okta_group.all.id}"]
+  groups            = [data.okta_group.all.id]
 
   users {
-    id       = "${okta_user.user1.id}"
-    username = "${okta_user.user1.email}"
+    id       = okta_user.user1.id
+    username = okta_user.user1.email
   }
 }

--- a/examples/okta_app_user/basic.tf
+++ b/examples/okta_app_user/basic.tf
@@ -19,7 +19,7 @@ resource okta_user test {
 }
 
 resource okta_app_user test {
-  app_id   = "${okta_app_oauth.test.id}"
-  user_id  = "${okta_user.test.id}"
-  username = "${okta_user.test.email}"
+  app_id   = okta_app_oauth.test.id
+  user_id  = okta_user.test.id
+  username = okta_user.test.email
 }

--- a/examples/okta_app_user/basic_profile.tf
+++ b/examples/okta_app_user/basic_profile.tf
@@ -22,7 +22,7 @@ resource okta_user test {
 }
 
 resource okta_app_user_schema test {
-  app_id      = "${okta_app_saml.test.id}"
+  app_id      = okta_app_saml.test.id
   index       = "testCustom"
   title       = "terraform acceptance test"
   type        = "string"
@@ -33,13 +33,13 @@ resource okta_app_user_schema test {
 }
 
 resource okta_app_user test {
-  app_id   = "${okta_app_saml.test.id}"
-  user_id  = "${okta_user.test.id}"
-  username = "${okta_user.test.email}"
+  app_id   = okta_app_saml.test.id
+  user_id  = okta_user.test.id
+  username = okta_user.test.email
 
   profile = <<JSON
 {"testCustom":"testing"}
 JSON
 
-  depends_on = ["okta_app_user_schema.test"]
+  depends_on = [okta_app_user_schema.test]
 }

--- a/examples/okta_app_user/update.tf
+++ b/examples/okta_app_user/update.tf
@@ -19,7 +19,7 @@ resource okta_user test {
 }
 
 resource okta_app_user test {
-  app_id   = "${okta_app_oauth.test.id}"
-  user_id  = "${okta_user.test.id}"
+  app_id   = okta_app_oauth.test.id
+  user_id  = okta_user.test.id
   username = "testAcc_replace_with_uuid"
 }

--- a/examples/okta_app_user_base_schema/basic.tf
+++ b/examples/okta_app_user_base_schema/basic.tf
@@ -4,7 +4,7 @@ resource okta_app_user_base_schema test {
   permissions = "READ_ONLY"
   title       = "Name"
   type        = "string"
-  app_id      = "${okta_app_oauth.test.id}"
+  app_id      = okta_app_oauth.test.id
   required    = true
 }
 

--- a/examples/okta_app_user_base_schema/updated.tf
+++ b/examples/okta_app_user_base_schema/updated.tf
@@ -4,7 +4,7 @@ resource okta_app_user_base_schema test {
   permissions = "READ_ONLY"
   title       = "Name"
   type        = "string"
-  app_id      = "${okta_app_oauth.test.id}"
+  app_id      = okta_app_oauth.test.id
   required    = false
 }
 

--- a/examples/okta_app_user_schema/basic.tf
+++ b/examples/okta_app_user_schema/basic.tf
@@ -7,7 +7,7 @@ resource okta_app_oauth test {
 }
 
 resource okta_app_user_schema test {
-  app_id      = "${okta_app_oauth.test.id}"
+  app_id      = okta_app_oauth.test.id
   index       = "testAcc_replace_with_uuid"
   title       = "terraform acceptance test"
   type        = "string"

--- a/examples/okta_app_user_schema/updated.tf
+++ b/examples/okta_app_user_schema/updated.tf
@@ -7,7 +7,7 @@ resource okta_app_oauth test {
 }
 
 resource okta_app_user_schema test {
-  app_id      = "${okta_app_oauth.test.id}"
+  app_id      = okta_app_oauth.test.id
   index       = "testAcc_replace_with_uuid"
   title       = "terraform acceptance test"
   type        = "string"

--- a/examples/okta_auth_server/datasource.tf
+++ b/examples/okta_auth_server/datasource.tf
@@ -5,5 +5,5 @@ resource "okta_auth_server" "test" {
 }
 
 data "okta_auth_server" "test" {
-  name = "${okta_auth_server.test.name}"
+  name = okta_auth_server.test.name
 }

--- a/examples/okta_auth_server/full_stack.tf
+++ b/examples/okta_auth_server/full_stack.tf
@@ -5,7 +5,7 @@ resource "okta_auth_server" "test" {
 }
 
 resource "okta_auth_server_claim" "test" {
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
   name           = "test"
   status         = "ACTIVE"
   claim_type     = "RESOURCE"
@@ -14,14 +14,14 @@ resource "okta_auth_server_claim" "test" {
 }
 
 resource "okta_auth_server_scope" "test" {
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
   consent        = "REQUIRED"
   description    = "This is a scope"
   name           = "test:something"
 }
 
 resource "okta_auth_server_policy" "test" {
-  auth_server_id   = "${okta_auth_server.test.id}"
+  auth_server_id   = okta_auth_server.test.id
   status           = "ACTIVE"
   name             = "test"
   description      = "Policy"
@@ -34,11 +34,11 @@ data "okta_group" "all" {
 }
 
 resource "okta_auth_server_policy_rule" "test" {
-  auth_server_id       = "${okta_auth_server.test.id}"
-  policy_id            = "${okta_auth_server_policy.test.id}"
+  auth_server_id       = okta_auth_server.test.id
+  policy_id            = okta_auth_server_policy.test.id
   status               = "ACTIVE"
   name                 = "test"
   priority             = 1
-  group_whitelist      = ["${data.okta_group.all.id}"]
+  group_whitelist      = [data.okta_group.all.id]
   grant_type_whitelist = ["password"]
 }

--- a/examples/okta_auth_server/full_stack_with_client.tf
+++ b/examples/okta_auth_server/full_stack_with_client.tf
@@ -5,7 +5,7 @@ resource "okta_auth_server" "test" {
 }
 
 resource "okta_auth_server_claim" "test" {
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
   name           = "test"
   status         = "ACTIVE"
   claim_type     = "RESOURCE"
@@ -14,19 +14,19 @@ resource "okta_auth_server_claim" "test" {
 }
 
 resource "okta_auth_server_scope" "test" {
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
   consent        = "REQUIRED"
   description    = "This is a scope"
   name           = "test:something"
 }
 
 resource "okta_auth_server_policy" "test" {
-  auth_server_id   = "${okta_auth_server.test.id}"
+  auth_server_id   = okta_auth_server.test.id
   status           = "ACTIVE"
   name             = "test"
   description      = "update"
   priority         = 1
-  client_whitelist = ["${okta_app_oauth.test.id}"]
+  client_whitelist = [okta_app_oauth.test.id]
 }
 
 data "okta_group" "all" {
@@ -34,12 +34,12 @@ data "okta_group" "all" {
 }
 
 resource "okta_auth_server_policy_rule" "test" {
-  auth_server_id       = "${okta_auth_server.test.id}"
-  policy_id            = "${okta_auth_server_policy.test.id}"
+  auth_server_id       = okta_auth_server.test.id
+  policy_id            = okta_auth_server_policy.test.id
   status               = "ACTIVE"
   name                 = "test"
   priority             = 1
-  group_whitelist      = ["${data.okta_group.all.id}"]
+  group_whitelist      = [data.okta_group.all.id]
   grant_type_whitelist = ["password", "implicit"]
 }
 

--- a/examples/okta_auth_server_claim/basic.tf
+++ b/examples/okta_auth_server_claim/basic.tf
@@ -4,7 +4,7 @@ resource "okta_auth_server_claim" "test" {
   claim_type     = "RESOURCE"
   value_type     = "EXPRESSION"
   value          = "cool"
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_claim/basic_group.tf
+++ b/examples/okta_auth_server_claim/basic_group.tf
@@ -5,7 +5,7 @@ resource "okta_auth_server_claim" "test" {
   value_type        = "GROUPS"
   group_filter_type = "EQUALS"
   value             = "Everyone"
-  auth_server_id    = "${okta_auth_server.test.id}"
+  auth_server_id    = okta_auth_server.test.id
 }
 
 resource "okta_auth_server_claim" "test_sw" {
@@ -15,7 +15,7 @@ resource "okta_auth_server_claim" "test_sw" {
   value_type        = "GROUPS"
   group_filter_type = "STARTS_WITH"
   value             = "Every"
-  auth_server_id    = "${okta_auth_server.test.id}"
+  auth_server_id    = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_claim/basic_updated.tf
+++ b/examples/okta_auth_server_claim/basic_updated.tf
@@ -4,7 +4,7 @@ resource "okta_auth_server_claim" "test" {
   claim_type     = "RESOURCE"
   value_type     = "EXPRESSION"
   value          = "cool_updated"
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_policy/basic.tf
+++ b/examples/okta_auth_server_policy/basic.tf
@@ -4,7 +4,7 @@ resource "okta_auth_server_policy" "test" {
   description      = "test"
   priority         = 1
   client_whitelist = ["ALL_CLIENTS"]
-  auth_server_id   = "${okta_auth_server.test.id}"
+  auth_server_id   = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_policy/basic_updated.tf
+++ b/examples/okta_auth_server_policy/basic_updated.tf
@@ -4,7 +4,7 @@ resource "okta_auth_server_policy" "test" {
   description      = "test updated"
   priority         = 1
   client_whitelist = ["ALL_CLIENTS"]
-  auth_server_id   = "${okta_auth_server.test.id}"
+  auth_server_id   = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_policy_rule/basic.tf
+++ b/examples/okta_auth_server_policy_rule/basic.tf
@@ -3,12 +3,12 @@ data "okta_group" "all" {
 }
 
 resource "okta_auth_server_policy_rule" "test" {
-  auth_server_id       = "${okta_auth_server.test.id}"
-  policy_id            = "${okta_auth_server_policy.test.id}"
+  auth_server_id       = okta_auth_server.test.id
+  policy_id            = okta_auth_server_policy.test.id
   status               = "ACTIVE"
   name                 = "test"
   priority             = 1
-  group_whitelist      = ["${data.okta_group.all.id}"]
+  group_whitelist      = [data.okta_group.all.id]
   grant_type_whitelist = ["implicit"]
 }
 
@@ -23,5 +23,5 @@ resource "okta_auth_server_policy" "test" {
   description      = "test"
   priority         = 1
   client_whitelist = ["ALL_CLIENTS"]
-  auth_server_id   = "${okta_auth_server.test.id}"
+  auth_server_id   = okta_auth_server.test.id
 }

--- a/examples/okta_auth_server_policy_rule/basic_updated.tf
+++ b/examples/okta_auth_server_policy_rule/basic_updated.tf
@@ -3,12 +3,12 @@ data "okta_group" "all" {
 }
 
 resource "okta_auth_server_policy_rule" "test" {
-  auth_server_id       = "${okta_auth_server.test.id}"
-  policy_id            = "${okta_auth_server_policy.test.id}"
+  auth_server_id       = okta_auth_server.test.id
+  policy_id            = okta_auth_server_policy.test.id
   status               = "ACTIVE"
   name                 = "test_updated"
   priority             = 1
-  group_whitelist      = ["${data.okta_group.all.id}"]
+  group_whitelist      = [data.okta_group.all.id]
   grant_type_whitelist = ["password"]
 }
 
@@ -23,5 +23,5 @@ resource "okta_auth_server_policy" "test" {
   description      = "test updated"
   priority         = 1
   client_whitelist = ["ALL_CLIENTS"]
-  auth_server_id   = "${okta_auth_server.test.id}"
+  auth_server_id   = okta_auth_server.test.id
 }

--- a/examples/okta_auth_server_scope/basic.tf
+++ b/examples/okta_auth_server_scope/basic.tf
@@ -2,7 +2,7 @@ resource "okta_auth_server_scope" "test" {
   consent        = "REQUIRED"
   description    = "test"
   name           = "test:something"
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_auth_server_scope/basic_updated.tf
+++ b/examples/okta_auth_server_scope/basic_updated.tf
@@ -2,7 +2,7 @@ resource "okta_auth_server_scope" "test" {
   consent        = "REQUIRED"
   description    = "test_updated"
   name           = "test:something"
-  auth_server_id = "${okta_auth_server.test.id}"
+  auth_server_id = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {

--- a/examples/okta_event_hook/basic.tf
+++ b/examples/okta_event_hook/basic.tf
@@ -1,6 +1,6 @@
 resource okta_event_hook test {
-  name    = "testAcc_replace_with_uuid"
-  events  = [
+  name = "testAcc_replace_with_uuid"
+  events = [
     "user.lifecycle.create",
     "user.lifecycle.delete.initiated",
   ]

--- a/examples/okta_event_hook/basic_activated.tf
+++ b/examples/okta_event_hook/basic_activated.tf
@@ -1,7 +1,7 @@
 resource okta_event_hook test {
-  name    = "testAcc_replace_with_uuid"
-  status  = "ACTIVE"
-  events  = [
+  name   = "testAcc_replace_with_uuid"
+  status = "ACTIVE"
+  events = [
     "user.lifecycle.create",
     "user.lifecycle.delete.initiated",
   ]

--- a/examples/okta_event_hook/basic_updated.tf
+++ b/examples/okta_event_hook/basic_updated.tf
@@ -1,7 +1,7 @@
 resource okta_event_hook test {
-  name    = "testAcc_replace_with_uuid"
-  status  = "INACTIVE"
-  events  = [
+  name   = "testAcc_replace_with_uuid"
+  status = "INACTIVE"
+  events = [
     "user.lifecycle.create",
     "user.lifecycle.delete.initiated",
     "user.account.update_profile",

--- a/examples/okta_group/datasource.tf
+++ b/examples/okta_group/datasource.tf
@@ -1,7 +1,7 @@
 resource okta_group test {
   name        = "testAcc_replace_with_uuid"
   description = "testing, testing"
-  users       = ["${okta_user.test.id}"]
+  users       = [okta_user.test.id]
 }
 
 resource okta_user test {
@@ -13,5 +13,5 @@ resource okta_user test {
 
 data okta_group test {
   include_users = true
-  name          = "${okta_group.test.name}"
+  name          = okta_group.test.name
 }

--- a/examples/okta_group/okta_group_with_users.tf
+++ b/examples/okta_group/okta_group_with_users.tf
@@ -7,10 +7,10 @@ resource "okta_group" "test" {
   description = "testing, testing"
 
   users = [
-    "${okta_user.test.id}",
-    "${okta_user.test1.id}",
-    "${okta_user.test2.id}",
-    "${okta_user.test3.id}",
+    okta_user.test.id,
+    okta_user.test1.id,
+    okta_user.test2.id,
+    okta_user.test3.id,
   ]
 }
 

--- a/examples/okta_group_roles/all_roles.tf
+++ b/examples/okta_group_roles/all_roles.tf
@@ -4,7 +4,7 @@ resource okta_group test {
 }
 
 resource okta_group_roles test {
-  group_id = "${okta_group.test.id}"
+  group_id = okta_group.test.id
 
   admin_roles = [
     "SUPER_ADMIN",
@@ -25,5 +25,5 @@ resource okta_user test {
   last_name         = "Smith"
   login             = "test-acc-replace_with_uuid@example.com"
   email             = "test-acc-replace_with_uuid@example.com"
-  group_memberships = ["${okta_group.test.id}"]
+  group_memberships = [okta_group.test.id]
 }

--- a/examples/okta_group_roles/basic.tf
+++ b/examples/okta_group_roles/basic.tf
@@ -4,7 +4,7 @@ resource okta_group test {
 }
 
 resource okta_group_roles test {
-  group_id    = "${okta_group.test.id}"
+  group_id    = okta_group.test.id
   admin_roles = ["SUPER_ADMIN"]
 }
 
@@ -13,5 +13,5 @@ resource okta_user test {
   last_name         = "Smith"
   login             = "test-acc-replace_with_uuid@example.com"
   email             = "test-acc-replace_with_uuid@example.com"
-  group_memberships = ["${okta_group.test.id}"]
+  group_memberships = [okta_group.test.id]
 }

--- a/examples/okta_group_rule/basic.tf
+++ b/examples/okta_group_rule/basic.tf
@@ -5,7 +5,7 @@ resource "okta_group" "test" {
 resource "okta_group_rule" "test" {
   name              = "testAcc_replace_with_uuid"
   status            = "ACTIVE"
-  group_assignments = ["${okta_group.test.id}"]
+  group_assignments = [okta_group.test.id]
   expression_type   = "urn:okta:expression:1.0"
   expression_value  = "String.startsWith(user.firstName,\"andy\")"
 }

--- a/examples/okta_group_rule/basic_deactivated.tf
+++ b/examples/okta_group_rule/basic_deactivated.tf
@@ -5,7 +5,7 @@ resource "okta_group" "test_other" {
 resource "okta_group_rule" "test" {
   name              = "testAcc_replace_with_uuid"
   status            = "INACTIVE"
-  group_assignments = ["${okta_group.test_other.id}"]
+  group_assignments = [okta_group.test_other.id]
   expression_type   = "urn:okta:expression:1.0"
   expression_value  = "String.startsWith(user.firstName,\"bob\")"
 }

--- a/examples/okta_group_rule/basic_group_update.tf
+++ b/examples/okta_group_rule/basic_group_update.tf
@@ -5,7 +5,7 @@ resource "okta_group" "test_other" {
 resource "okta_group_rule" "test" {
   name              = "testAcc_replace_with_uuid"
   status            = "ACTIVE"
-  group_assignments = ["${okta_group.test_other.id}"]
+  group_assignments = [okta_group.test_other.id]
   expression_type   = "urn:okta:expression:1.0"
   expression_value  = "String.startsWith(user.firstName,String.toLowerCase(\"bOb\"))"
 }

--- a/examples/okta_group_rule/basic_updated.tf
+++ b/examples/okta_group_rule/basic_updated.tf
@@ -5,7 +5,7 @@ resource "okta_group" "test" {
 resource "okta_group_rule" "test" {
   name              = "testAcc_replace_with_uuid"
   status            = "ACTIVE"
-  group_assignments = ["${okta_group.test.id}"]
+  group_assignments = [okta_group.test.id]
   expression_type   = "urn:okta:expression:1.0"
   expression_value  = "String.startsWith(user.firstName,String.toLowerCase(\"bob\"))"
 }

--- a/examples/okta_idp_metadata_saml/datasource.tf
+++ b/examples/okta_idp_metadata_saml/datasource.tf
@@ -14,7 +14,7 @@ resource okta_app_saml test {
 }
 
 resource okta_idp_saml_key test {
-  x5c = ["${okta_app_saml.test.certificate}"]
+  x5c = [okta_app_saml.test.certificate]
 }
 
 resource okta_idp_saml test {
@@ -25,12 +25,12 @@ resource okta_idp_saml test {
   sso_destination          = "https://idp.example.com"
   sso_binding              = "HTTP-POST"
   username_template        = "idpuser.email"
-  kid                      = "${okta_idp_saml_key.test.id}"
+  kid                      = okta_idp_saml_key.test.id
   issuer                   = "https://idp.example.com"
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"
 }
 
 data okta_idp_metadata_saml test {
-  idp_id = "${okta_idp_saml.test.id}"
+  idp_id = okta_idp_saml.test.id
 }

--- a/examples/okta_idp_saml/basic.tf
+++ b/examples/okta_idp_saml/basic.tf
@@ -14,7 +14,7 @@ resource okta_app_saml test {
 }
 
 resource okta_idp_saml_key test {
-  x5c = ["${okta_app_saml.test.certificate}"]
+  x5c = [okta_app_saml.test.certificate]
 }
 
 resource okta_idp_saml test {
@@ -25,7 +25,7 @@ resource okta_idp_saml test {
   sso_destination          = "https://idp.example.com"
   sso_binding              = "HTTP-POST"
   username_template        = "idpuser.email"
-  kid                      = "${okta_idp_saml_key.test.id}"
+  kid                      = okta_idp_saml_key.test.id
   issuer                   = "https://idp.example.com"
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"

--- a/examples/okta_idp_saml/basic_updated.tf
+++ b/examples/okta_idp_saml/basic_updated.tf
@@ -14,7 +14,7 @@ resource "okta_app_saml" "test" {
 }
 
 resource okta_idp_saml_key test {
-  x5c = ["${okta_app_saml.test.certificate}"]
+  x5c = [okta_app_saml.test.certificate]
 }
 
 resource okta_idp_saml test {
@@ -25,7 +25,7 @@ resource okta_idp_saml test {
   sso_destination          = "https://idp.example.com/test"
   sso_binding              = "HTTP-POST"
   username_template        = "idpuser.email"
-  kid                      = "${okta_idp_saml_key.test.id}"
+  kid                      = okta_idp_saml_key.test.id
   issuer                   = "https://idp.example.com/issuer"
   response_signature_scope = "RESPONSE"
   request_signature_scope  = "REQUEST"

--- a/examples/okta_idp_saml/datasource.tf
+++ b/examples/okta_idp_saml/datasource.tf
@@ -14,7 +14,7 @@ resource okta_app_saml test {
 }
 
 resource okta_idp_saml_key test {
-  x5c = ["${okta_app_saml.test.certificate}"]
+  x5c = [okta_app_saml.test.certificate]
 }
 
 resource okta_idp_saml test {
@@ -25,12 +25,12 @@ resource okta_idp_saml test {
   sso_destination          = "https://idp.example.com"
   sso_binding              = "HTTP-POST"
   username_template        = "idpuser.email"
-  kid                      = "${okta_idp_saml_key.test.id}"
+  kid                      = okta_idp_saml_key.test.id
   issuer                   = "https://idp.example.com"
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"
 }
 
 data okta_idp_saml test {
-  name = "${okta_idp_saml.test.name}"
+  name = okta_idp_saml.test.name
 }

--- a/examples/okta_idp_saml/datasource_id.tf
+++ b/examples/okta_idp_saml/datasource_id.tf
@@ -14,7 +14,7 @@ resource okta_app_saml test {
 }
 
 resource okta_idp_saml_key test {
-  x5c = ["${okta_app_saml.test.certificate}"]
+  x5c = [okta_app_saml.test.certificate]
 }
 
 resource okta_idp_saml test {
@@ -25,12 +25,12 @@ resource okta_idp_saml test {
   sso_destination          = "https://idp.example.com"
   sso_binding              = "HTTP-POST"
   username_template        = "idpuser.email"
-  kid                      = "${okta_idp_saml_key.test.id}"
+  kid                      = okta_idp_saml_key.test.id
   issuer                   = "https://idp.example.com"
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"
 }
 
 data okta_idp_saml test {
-  id = "${okta_idp_saml.test.id}"
+  id = okta_idp_saml.test.id
 }

--- a/examples/okta_idp_social/basic.tf
+++ b/examples/okta_idp_social/basic.tf
@@ -57,7 +57,7 @@ resource okta_idp_social microsoft {
   client_secret     = "abcd123"
   username_template = "idpuser.userPrincipalName"
   groups_action     = "ASSIGN"
-  groups_assignment = ["${okta_group.test.id}"]
+  groups_assignment = [okta_group.test.id]
 }
 
 resource "okta_group" "test" {

--- a/examples/okta_policy_mfa/basic.tf
+++ b/examples/okta_policy_mfa/basic.tf
@@ -11,8 +11,8 @@ resource okta_policy_mfa test {
     enroll = "REQUIRED"
   }
 
-  groups_included = ["${data.okta_group.all.id}"]
-  depends_on      = ["okta_factor.google_otp"]
+  groups_included = [data.okta_group.all.id]
+  depends_on      = [okta_factor.google_otp]
 }
 
 resource okta_factor google_otp {

--- a/examples/okta_policy_mfa/basic_updated.tf
+++ b/examples/okta_policy_mfa/basic_updated.tf
@@ -6,7 +6,7 @@ resource okta_policy_mfa test {
   name            = "testAcc_replace_with_uuid"
   status          = "INACTIVE"
   description     = "Terraform Acceptance Test MFA Policy Updated"
-  groups_included = ["${data.okta_group.all.id}"]
+  groups_included = [data.okta_group.all.id]
 
   google_otp = {
     enroll = "OPTIONAL"
@@ -16,10 +16,7 @@ resource okta_policy_mfa test {
     enroll = "OPTIONAL"
   }
 
-  depends_on = [
-    "okta_factor.google_otp",
-    "okta_factor.okta_sms",
-  ]
+  depends_on = [okta_factor.google_otp, okta_factor.okta_sms]
 }
 
 resource okta_factor google_otp {

--- a/examples/okta_policy_password/basic.tf
+++ b/examples/okta_policy_password/basic.tf
@@ -7,5 +7,5 @@ resource okta_policy_password test {
   status                 = "ACTIVE"
   description            = "Terraform Acceptance Test Password Policy"
   password_history_count = 4
-  groups_included        = ["${data.okta_group.all.id}"]
+  groups_included        = [data.okta_group.all.id]
 }

--- a/examples/okta_policy_password/basic_updated.tf
+++ b/examples/okta_policy_password/basic_updated.tf
@@ -26,5 +26,5 @@ resource okta_policy_password test {
   question_min_length                    = 10
   recovery_email_token                   = 20160
   sms_recovery                           = "ACTIVE"
-  groups_included                        = ["${data.okta_group.all.id}"]
+  groups_included                        = [data.okta_group.all.id]
 }

--- a/examples/okta_policy_rule_idp_discovery/app_exclude_platform.tf
+++ b/examples/okta_policy_rule_idp_discovery/app_exclude_platform.tf
@@ -1,12 +1,12 @@
 resource okta_policy_rule_idp_discovery test {
-  policyid = "${data.okta_policy.test.id}"
+  policyid = data.okta_policy.test.id
   priority = 1
   name     = "testAcc_replace_with_uuid"
   idp_type = "OKTA"
 
   app_exclude {
     type = "APP"
-    id   = "${okta_app_oauth.test.id}"
+    id   = okta_app_oauth.test.id
   }
 
   platform_include {

--- a/examples/okta_policy_rule_idp_discovery/app_include.tf
+++ b/examples/okta_policy_rule_idp_discovery/app_include.tf
@@ -1,12 +1,12 @@
 resource okta_policy_rule_idp_discovery test {
-  policyid = "${data.okta_policy.test.id}"
+  policyid = data.okta_policy.test.id
   priority = 1
   name     = "testAcc_replace_with_uuid"
   idp_type = "OKTA"
 
   app_include {
     type = "APP"
-    id   = "${okta_app_oauth.test.id}"
+    id   = okta_app_oauth.test.id
   }
 }
 

--- a/examples/okta_policy_rule_idp_discovery/basic.tf
+++ b/examples/okta_policy_rule_idp_discovery/basic.tf
@@ -4,11 +4,11 @@ data okta_policy test {
 }
 
 resource okta_policy_rule_idp_discovery test {
-  policyid             = "${data.okta_policy.test.id}"
+  policyid             = data.okta_policy.test.id
   priority             = 1
   name                 = "testAcc_replace_with_uuid"
   idp_type             = "SAML2"
-  idp_id               = "${okta_idp_saml.test.id}"
+  idp_id               = okta_idp_saml.test.id
   user_identifier_type = "ATTRIBUTE"
 
   // Don't have a company schema in this account, just chosing something always there
@@ -31,11 +31,11 @@ resource okta_idp_saml test {
   issuer                   = "https://idp.example.com"
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"
-  kid                      = "${okta_idp_saml_key.test.id}"
+  kid                      = okta_idp_saml_key.test.id
 }
 
 resource okta_idp_saml_key test {
-  x5c = ["${okta_app_saml.test.certificate}"]
+  x5c = [okta_app_saml.test.certificate]
 }
 
 resource okta_app_saml test {

--- a/examples/okta_policy_rule_idp_discovery/basic_deactivated.tf
+++ b/examples/okta_policy_rule_idp_discovery/basic_deactivated.tf
@@ -5,7 +5,7 @@ data okta_policy test {
 
 resource okta_policy_rule_idp_discovery test {
   status               = "INACTIVE"
-  policyid             = "${data.okta_policy.test.id}"
+  policyid             = data.okta_policy.test.id
   priority             = 1
   name                 = "testAcc_replace_with_uuid"
   user_identifier_type = "IDENTIFIER"

--- a/examples/okta_policy_rule_idp_discovery/basic_domain.tf
+++ b/examples/okta_policy_rule_idp_discovery/basic_domain.tf
@@ -4,7 +4,7 @@ data okta_policy test {
 }
 
 resource okta_policy_rule_idp_discovery test {
-  policyid             = "${data.okta_policy.test.id}"
+  policyid             = data.okta_policy.test.id
   priority             = 1
   name                 = "testAcc_replace_with_uuid"
   idp_type             = "OKTA"

--- a/examples/okta_policy_rule_signon/basic.tf
+++ b/examples/okta_policy_rule_signon/basic.tf
@@ -6,11 +6,11 @@ resource okta_policy_signon test {
   name            = "testAcc_replace_with_uuid"
   status          = "ACTIVE"
   description     = "Terraform Acceptance Test SignOn Policy"
-  groups_included = ["${data.okta_group.all.id}"]
+  groups_included = [data.okta_group.all.id]
 }
 
 resource okta_policy_rule_signon test {
-  policyid = "${okta_policy_signon.test.id}"
+  policyid = okta_policy_signon.test.id
   name     = "testAcc_replace_with_uuid"
   status   = "ACTIVE"
 }

--- a/examples/okta_policy_rule_signon/basic_updated.tf
+++ b/examples/okta_policy_rule_signon/basic_updated.tf
@@ -13,16 +13,16 @@ resource okta_policy_signon test {
   name            = "testAcc_replace_with_uuid"
   status          = "ACTIVE"
   description     = "Terraform Acceptance Test SignOn Policy"
-  groups_included = ["${data.okta_group.all.id}"]
+  groups_included = [data.okta_group.all.id]
 }
 
 resource okta_policy_rule_signon test {
-  policyid           = "${okta_policy_signon.test.id}"
+  policyid           = okta_policy_signon.test.id
   name               = "testAcc_replace_with_uuid"
   status             = "INACTIVE"
   access             = "DENY"
   session_idle       = 240
   session_lifetime   = 240
   session_persistent = false
-  users_excluded     = ["${okta_user.test.id}"]
+  users_excluded     = [okta_user.test.id]
 }

--- a/examples/okta_policy_rule_signon/excluded_network.tf
+++ b/examples/okta_policy_rule_signon/excluded_network.tf
@@ -6,16 +6,16 @@ resource okta_policy_signon test {
   name            = "testAcc_replace_with_uuid"
   status          = "ACTIVE"
   description     = "Terraform Acceptance Test SignOn Policy"
-  groups_included = ["${data.okta_group.all.id}"]
+  groups_included = [data.okta_group.all.id]
 }
 
 resource okta_policy_rule_signon test {
-  policyid           = "${okta_policy_signon.test.id}"
+  policyid           = okta_policy_signon.test.id
   name               = "testAcc_replace_with_uuid"
   access             = "DENY"
   status             = "ACTIVE"
   network_connection = "ZONE"
-  network_excludes   = ["${okta_network_zone.test.id}"]
+  network_excludes   = [okta_network_zone.test.id]
 }
 
 resource "okta_network_zone" "test" {

--- a/examples/okta_policy_signon/basic.tf
+++ b/examples/okta_policy_signon/basic.tf
@@ -13,12 +13,12 @@ resource okta_policy_signon test {
   name            = "testAcc_replace_with_uuid"
   status          = "ACTIVE"
   description     = "Terraform Acceptance Test SignOn Policy"
-  groups_included = ["${data.okta_group.all.id}"]
+  groups_included = [data.okta_group.all.id]
 }
 
 resource okta_policy_rule_signon test {
-  policyid       = "${okta_policy_signon.test.id}"
+  policyid       = okta_policy_signon.test.id
   name           = "testAcc_replace_with_uuid"
   status         = "ACTIVE"
-  users_excluded = ["${okta_user.test.id}"]
+  users_excluded = [okta_user.test.id]
 }

--- a/examples/okta_policy_signon/basic_inactive.tf
+++ b/examples/okta_policy_signon/basic_inactive.tf
@@ -6,5 +6,5 @@ resource okta_policy_signon test {
   name            = "testAcc_replace_with_uuid"
   status          = "INACTIVE"
   description     = "Terraform Acceptance Test SignOn Policy Updated"
-  groups_included = ["${okta_group.test.id}"]
+  groups_included = [okta_group.test.id]
 }

--- a/examples/okta_policy_signon/basic_renamed.tf
+++ b/examples/okta_policy_signon/basic_renamed.tf
@@ -6,7 +6,7 @@ resource okta_policy_signon test {
   name            = "testAccUpdated_replace_with_uuid"
   status          = "ACTIVE"
   description     = "Terraform Acceptance Test SignOn Policy"
-  groups_included = ["${okta_group.test.id}"]
+  groups_included = [okta_group.test.id]
 }
 
 resource okta_group test {

--- a/examples/okta_profile_mapping/basic.tf
+++ b/examples/okta_profile_mapping/basic.tf
@@ -1,6 +1,6 @@
 resource okta_profile_mapping test {
-  source_id          = "${okta_idp_social.google.id}"
-  target_id          = "${data.okta_user_profile_mapping_source.user.id}"
+  source_id          = okta_idp_social.google.id
+  target_id          = data.okta_user_profile_mapping_source.user.id
   delete_when_absent = true
 
   mappings {
@@ -41,7 +41,6 @@ resource okta_idp_social google {
 }
 
 data okta_user_profile_mapping_source user {
-  depends_on = [
-    okta_idp_social.google]
+  depends_on = [okta_idp_social.google]
 }
 

--- a/examples/okta_profile_mapping/prevent_delete.tf
+++ b/examples/okta_profile_mapping/prevent_delete.tf
@@ -1,6 +1,6 @@
 resource okta_profile_mapping test {
-  source_id          = "${okta_idp_social.google.id}"
-  target_id          = "${data.okta_user_profile_mapping_source.user.id}"
+  source_id          = okta_idp_social.google.id
+  target_id          = data.okta_user_profile_mapping_source.user.id
   delete_when_absent = false
 
   mappings {
@@ -66,7 +66,6 @@ resource okta_idp_social google {
 }
 
 data okta_user_profile_mapping_source user {
-  depends_on = [
-    okta_idp_social.google]
+  depends_on = [okta_idp_social.google]
 }
 

--- a/examples/okta_profile_mapping/updated.tf
+++ b/examples/okta_profile_mapping/updated.tf
@@ -1,6 +1,6 @@
 resource okta_profile_mapping test {
-  source_id          = "${okta_idp_social.google.id}"
-  target_id          = "${data.okta_user_profile_mapping_source.user.id}"
+  source_id          = okta_idp_social.google.id
+  target_id          = data.okta_user_profile_mapping_source.user.id
   delete_when_absent = true
 
   mappings {
@@ -46,6 +46,5 @@ resource okta_idp_social google {
 }
 
 data okta_user_profile_mapping_source user {
-  depends_on = [
-    okta_idp_social.google]
+  depends_on = [okta_idp_social.google]
 }

--- a/examples/okta_template_sms/basic.tf
+++ b/examples/okta_template_sms/basic.tf
@@ -1,6 +1,7 @@
 resource "okta_template_sms" test {
-  type = "SMS_VERIFY_CODE"
+  type     = "SMS_VERIFY_CODE"
   template = "Your $${org.name} code is: $${code}"
+
   translations {
     language = "en"
     template = "Your $${org.name} code is: $${code}"

--- a/examples/okta_template_sms/updated.tf
+++ b/examples/okta_template_sms/updated.tf
@@ -1,6 +1,7 @@
 resource "okta_template_sms" test {
-  type = "SMS_VERIFY_CODE"
+  type     = "SMS_VERIFY_CODE"
   template = "Your $${org.name} updated code is: $${code}"
+
   translations {
     language = "en"
     template = "Your $${org.name} updated code is: $${code}"

--- a/examples/okta_user/custom_attributes.tf
+++ b/examples/okta_user/custom_attributes.tf
@@ -11,7 +11,7 @@ resource "okta_user_schema" "test_array" {
   type       = "array"
   array_type = "string"
   master     = "PROFILE_MASTER"
-  depends_on = ["okta_user_schema.test_number", "okta_user_schema.test"]
+  depends_on = [okta_user_schema.test_number, okta_user_schema.test]
 }
 
 resource "okta_user_schema" "test_number" {
@@ -19,7 +19,7 @@ resource "okta_user_schema" "test_number" {
   title      = "terraform acceptance test"
   type       = "number"
   master     = "PROFILE_MASTER"
-  depends_on = ["okta_user_schema.test"]
+  depends_on = [okta_user_schema.test]
 }
 
 resource "okta_user" "test" {
@@ -35,5 +35,5 @@ resource "okta_user" "test" {
   }
 JSON
 
-  depends_on = ["okta_user_schema.test", "okta_user_schema.test_number"]
+  depends_on = [okta_user_schema.test, okta_user_schema.test_number]
 }

--- a/examples/okta_user/custom_attributes_array.tf
+++ b/examples/okta_user/custom_attributes_array.tf
@@ -11,7 +11,7 @@ resource "okta_user_schema" "test_array" {
   type       = "array"
   array_type = "string"
   master     = "PROFILE_MASTER"
-  depends_on = ["okta_user_schema.test_number", "okta_user_schema.test"]
+  depends_on = [okta_user_schema.test_number, okta_user_schema.test]
 }
 
 resource "okta_user_schema" "test_number" {
@@ -19,7 +19,7 @@ resource "okta_user_schema" "test_number" {
   title      = "terraform acceptance test"
   type       = "number"
   master     = "PROFILE_MASTER"
-  depends_on = ["okta_user_schema.test"]
+  depends_on = [okta_user_schema.test]
 }
 
 resource "okta_user" "test" {
@@ -36,5 +36,5 @@ resource "okta_user" "test" {
   }
 JSON
 
-  depends_on = ["okta_user_schema.test_array", "okta_user_schema.test_number"]
+  depends_on = [okta_user_schema.test_array, okta_user_schema.test_number]
 }

--- a/examples/okta_user/datasource.tf
+++ b/examples/okta_user/datasource.tf
@@ -11,7 +11,7 @@ resource okta_user_schema test_number {
   title      = "terraform acceptance test"
   type       = "number"
   master     = "PROFILE_MASTER"
-  depends_on = ["okta_user_schema.test_array"]
+  depends_on = [okta_user_schema.test_array]
 }
 
 resource okta_user test {
@@ -31,15 +31,15 @@ JSON
 data okta_user test {
   search {
     name  = "profile.firstName"
-    value = "${okta_user.test.first_name}"
+    value = okta_user.test.first_name
   }
 
   search {
     name  = "profile.lastName"
-    value = "${okta_user.test.last_name}"
+    value = okta_user.test.last_name
   }
 }
 
 data okta_user read_by_id {
-  user_id = "${okta_user.test.id}"
+  user_id = okta_user.test.id
 }

--- a/examples/okta_user/deprovisioned.tf
+++ b/examples/okta_user/deprovisioned.tf
@@ -1,7 +1,7 @@
 resource "okta_user" "test" {
-  first_name  = "TestAcc"
-  last_name   = "Smith"
-  login       = "test-acc-replace_with_uuid@example.com"
-  email       = "test-acc-replace_with_uuid@example.com"
-  status      = "DEPROVISIONED"
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "test-acc-replace_with_uuid@example.com"
+  email      = "test-acc-replace_with_uuid@example.com"
+  status     = "DEPROVISIONED"
 }

--- a/examples/okta_user/group_assigned.tf
+++ b/examples/okta_user/group_assigned.tf
@@ -9,5 +9,5 @@ resource "okta_user" "test" {
   login      = "test-acc-replace_with_uuid@example.com"
   email      = "test-acc-replace_with_uuid@example.com"
 
-  group_memberships = ["${okta_group.test.id}"]
+  group_memberships = [okta_group.test.id]
 }


### PR DESCRIPTION
- simple update to format terraform examples to pass `terraform fmt -recursive .`