### PR TITLE
Added case for idp_discovery since default name is different than other types

### DIFF
--- a/okta/data_source_okta_default_policy.go
+++ b/okta/data_source_okta_default_policy.go
@@ -32,5 +32,9 @@ func dataSourceDefaultPolicies() *schema.Resource {
 }
 
 func dataSourceDefaultPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	policyType := d.Get("type").(string)
+	if policyType == sdk.IdpDiscoveryType {
+		return setPolicyByName(ctx, d, m, "Idp Discovery Policy")
+	}
 	return setPolicyByName(ctx, d, m, "Default Policy")
 }

--- a/okta/data_source_okta_default_policy_test.go
+++ b/okta/data_source_okta_default_policy_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/oktadeveloper/terraform-provider-okta/sdk"
 )
 
-func TestAccOktaDataSourceDefaultPolicy_read(t *testing.T) {
+func TestAccOktaDataSourceDefaultPolicy_readPasswordPolicy(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccDataSourceDefaultPolicyConfig(ri)
+	config := testAccDataSourceDefaultPolicy(ri, sdk.PasswordPolicyType)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -30,10 +30,30 @@ func TestAccOktaDataSourceDefaultPolicy_read(t *testing.T) {
 	})
 }
 
-func testAccDataSourceDefaultPolicyConfig(rInt int) string {
+func TestAccOktaDataSourceDefaultPolicy_readIdpPolicy(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccDataSourceDefaultPolicy(ri, sdk.IdpDiscoveryType)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_default_policy.default-"+strconv.Itoa(ri), "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDefaultPolicy(rInt int, policy string) string {
 	return fmt.Sprintf(`
 data "okta_default_policy" "default-%d" {
   type = "%s"
 }
-`, rInt, sdk.PasswordPolicyType)
+`, rInt, policy)
 }


### PR DESCRIPTION
```[{"type":"IDP_DISCOVERY","id":"00p1d71a9Ckq59Snm5d6","status":"ACTIVE","name":"Idp Discovery Policy","description":"The default IdP Discovery Policy","priority":1,"system":true,"conditions":null,"created":"2020-11-25T18:53:28.000Z","lastUpdated":"2020-11-25T18:53:28.000Z","_links":{"self":{"href":"https://<tenant_redacted>/api/v1/policies/00p1d71a9Ckq59Snm5d6","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://<tenant_redacted>/api/v1/policies/00p1d71a9Ckq59Snm5d6/rules","hints":{"allow":["GET","POST"]}}}}] ```

This is a result of a curl for `/api/v1/policies?type=IDP_DISCOVERY`.  The default policy name is not `Default Policy` like the other policy types.  I would have expected a system policy to have a consistent name, but it seems `IDP_DISCOVERY` is different, so the existing code fails for that type.

Okta Terraform Version: `3.7.1`
Terraform Version: `0.14.2`
Resource: `okta_default_policy`

https://github.com/oktadeveloper/terraform-provider-okta/issues/232