### PR TITLE
New Resource: Okta Group Membership

### DIFF
--- a/examples/okta_group_membership/README.md
+++ b/examples/okta_group_membership/README.md
@@ -1,0 +1,7 @@
+# Okta Group Membership
+
+Represents an individual assignment of a user to a okta group.
+
+[See Okta documentation regarding group operations](https://developer.okta.com/docs/reference/api/groups/#group-member-operations)
+
+A simple example of usage of this resource can be [found here](./okta_group_membership.tf).

--- a/examples/okta_group_membership/okta_group_membership.tf
+++ b/examples/okta_group_membership/okta_group_membership.tf
@@ -1,16 +1,16 @@
 resource "okta_group" "test" {
-  name = "testAcc_replace_with_uuid"
+  name        = "testAcc_replace_with_uuid"
   description = "testing, testing"
 }
 
 resource "okta_user" "test" {
   first_name = "TestAcc"
-  last_name = "Jones"
-  login = "john_replace_with_uuid@ledzeppelin.com"
-  email = "john_replace_with_uuid@ledzeppelin.com"
+  last_name  = "Jones"
+  login      = "john_replace_with_uuid@ledzeppelin.com"
+  email      = "john_replace_with_uuid@ledzeppelin.com"
 }
 
 resource "okta_group_membership" "test" {
   group_id = okta_group.test.id
-  user_id = okta_user.test.id
+  user_id  = okta_user.test.id
 }

--- a/examples/okta_group_membership/okta_group_membership.tf
+++ b/examples/okta_group_membership/okta_group_membership.tf
@@ -1,0 +1,16 @@
+resource "okta_group" "test" {
+  name = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name = "Jones"
+  login = "john_replace_with_uuid@ledzeppelin.com"
+  email = "john_replace_with_uuid@ledzeppelin.com"
+}
+
+resource "okta_group_membership" "test" {
+  group_id = okta_group.test.id
+  user_id = okta_user.test.id
+}

--- a/examples/okta_group_membership/okta_group_membership.tf
+++ b/examples/okta_group_membership/okta_group_membership.tf
@@ -8,6 +8,10 @@ resource "okta_user" "test" {
   last_name  = "Jones"
   login      = "john_replace_with_uuid@ledzeppelin.com"
   email      = "john_replace_with_uuid@ledzeppelin.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
 }
 
 resource "okta_group_membership" "test" {

--- a/examples/okta_group_membership/okta_group_membership_updated.tf
+++ b/examples/okta_group_membership/okta_group_membership_updated.tf
@@ -1,0 +1,16 @@
+resource "okta_group" "test" {
+  name = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name = "Bould"
+  login = "steve_replace_with_uuid@ledzeppelin.com"
+  email = "steve_replace_with_uuid@ledzeppelin.com"
+}
+
+resource "okta_group_membership" "test" {
+  group_id = okta_group.test.id
+  user_id = okta_user.test.id
+}

--- a/examples/okta_group_membership/okta_group_membership_updated.tf
+++ b/examples/okta_group_membership/okta_group_membership_updated.tf
@@ -1,16 +1,16 @@
 resource "okta_group" "test" {
-  name = "testAcc_replace_with_uuid"
+  name        = "testAcc_replace_with_uuid"
   description = "testing, testing"
 }
 
 resource "okta_user" "test" {
   first_name = "TestAcc"
-  last_name = "Bould"
-  login = "steve_replace_with_uuid@ledzeppelin.com"
-  email = "steve_replace_with_uuid@ledzeppelin.com"
+  last_name  = "Bould"
+  login      = "steve_replace_with_uuid@ledzeppelin.com"
+  email      = "steve_replace_with_uuid@ledzeppelin.com"
 }
 
 resource "okta_group_membership" "test" {
   group_id = okta_group.test.id
-  user_id = okta_user.test.id
+  user_id  = okta_user.test.id
 }

--- a/examples/okta_group_membership/okta_group_membership_updated.tf
+++ b/examples/okta_group_membership/okta_group_membership_updated.tf
@@ -8,6 +8,10 @@ resource "okta_user" "test" {
   last_name  = "Bould"
   login      = "steve_replace_with_uuid@ledzeppelin.com"
   email      = "steve_replace_with_uuid@ledzeppelin.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
 }
 
 resource "okta_group_membership" "test" {

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -42,6 +42,7 @@ const (
 	inlineHook             = "okta_inline_hook"
 	networkZone            = "okta_network_zone"
 	oktaGroup              = "okta_group"
+	oktaGroupMembership    = "okta_group_membership"
 	oktaProfileMapping     = "okta_profile_mapping"
 	oktaUser               = "okta_user"
 	policyMfa              = "okta_policy_mfa"
@@ -155,6 +156,7 @@ func Provider() *schema.Provider {
 			inlineHook:             resourceInlineHook(),
 			networkZone:            resourceNetworkZone(),
 			oktaGroup:              resourceGroup(),
+			oktaGroupMembership:    resourceGroupMembership(),
 			oktaProfileMapping:     resourceOktaProfileMapping(),
 			oktaUser:               resourceUser(),
 			policyMfa:              resourcePolicyMfa(),

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -80,17 +80,21 @@ func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, 
 }
 
 func checkIfUserInGroup(ctx context.Context, client *okta.Client, groupId string, userId string) (bool, error) {
+	users, resp, err := client.Group.ListGroupUsers(ctx, groupId, &query.Params{})
+	if err != nil {
+		return false, err
+	}
 	for {
-		users, resp, err := client.Group.ListGroupUsers(ctx, groupId, &query.Params{})
-		if err != nil {
-			return false, err
-		}
 		for _, user := range users {
 			if userId == user.Id {
 				return true, nil
 			}
 		}
 		if resp.HasNextPage() {
+			resp, err = resp.Next(ctx, &users)
+			if err != nil {
+				return false, err
+			}
 			continue
 		} else {
 			break

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -1,0 +1,100 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func resourceGroupMembership() *schema.Resource {
+	return &schema.Resource{
+		CreateContext:      resourceGroupMembershipCreate,
+		ReadContext:        resourceGroupMembershipRead,
+		UpdateContext:      nil,
+		DeleteContext:      resourceGroupMembershipDelete,
+		Importer:           &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Description:        "",
+		Schema:             map[string]*schema.Schema{
+			"group_id": {
+				Type: schema.TypeString,
+				Required: true,
+				Description: "ID of a Okta Group",
+				ForceNew: true,
+			},
+			"user_id": {
+				Type: schema.TypeString,
+				Required: true,
+				Description: "ID of a Okta User",
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupId := d.Get("group_id").(string)
+	userId := d.Get("user_id").(string)
+	logger(m).Info("adding user to group", "group", groupId, "user", userId)
+	client := getOktaClientFromMetadata(m)
+	_, err := client.Group.AddUserToGroup(ctx, groupId, userId)
+	if err != nil {
+		return diag.Errorf("failed to add user to group: %v", err)
+	}
+	d.SetId(fmt.Sprintf("%s+%s", groupId, userId))
+	return resourceGroupRead(ctx, d, m)
+}
+
+func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupId := d.Get("group_id").(string)
+	userId := d.Get("user_id").(string)
+	logger(m).Info("checking for membership in group", "group", groupId, "user", userId)
+	client := getOktaClientFromMetadata(m)
+	inGroup, err := checkIfUserInGroup(ctx, client, groupId, userId)
+	if err != nil {
+		return diag.Errorf("unable to complete group check for user: %v", err)
+	}
+	if inGroup {
+		return nil
+	} else {
+		d.SetId("")
+		logger(m).Info("user is not in group", "group", groupId, "user", userId)
+		return nil
+	}
+}
+
+func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupId := d.Get("group_id").(string)
+	userId := d.Get("user_id").(string)
+	logger(m).Info("removing user to group", "group", groupId, "user", userId)
+	client := getOktaClientFromMetadata(m)
+	_, err := client.Group.RemoveUserFromGroup(ctx, groupId, userId)
+	if err != nil {
+		return diag.Errorf("failed to remove user to group: %v", err)
+	}
+	return nil
+}
+
+func checkIfUserInGroup(ctx context.Context, client *okta.Client, groupId string, userId string) (bool, error) {
+	for {
+		users, resp, err := client.Group.ListGroupUsers(ctx, groupId, &query.Params{})
+		if err != nil {
+			return false, err
+		}
+		for _, user := range users {
+			if userId == user.Id {
+				return true, nil
+			}
+		}
+		if resp.HasNextPage() {
+			continue
+		} else {
+			break
+		}
+	}
+	return false, nil
+}

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -70,7 +70,7 @@ func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m 
 func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	groupId := d.Get("group_id").(string)
 	userId := d.Get("user_id").(string)
-	logger(m).Info("removing user to group", "group", groupId, "user", userId)
+	logger(m).Info("removing user from group", "group", groupId, "user", userId)
 	client := getOktaClientFromMetadata(m)
 	_, err := client.Group.RemoveUserFromGroup(ctx, groupId, userId)
 	if err != nil {

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -46,7 +46,7 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("failed to add user to group: %v", err)
 	}
 	d.SetId(fmt.Sprintf("%s+%s", groupId, userId))
-	return resourceGroupRead(ctx, d, m)
+	return resourceGroupMembershipRead(ctx, d, m)
 }
 
 func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -11,26 +11,26 @@ import (
 
 func resourceGroupMembership() *schema.Resource {
 	return &schema.Resource{
-		CreateContext:      resourceGroupMembershipCreate,
-		ReadContext:        resourceGroupMembershipRead,
-		UpdateContext:      nil,
-		DeleteContext:      resourceGroupMembershipDelete,
-		Importer:           &schema.ResourceImporter{
+		CreateContext: resourceGroupMembershipCreate,
+		ReadContext:   resourceGroupMembershipRead,
+		UpdateContext: nil,
+		DeleteContext: resourceGroupMembershipDelete,
+		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description:        "",
-		Schema:             map[string]*schema.Schema{
+		Description: "",
+		Schema: map[string]*schema.Schema{
 			"group_id": {
-				Type: schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
 				Description: "ID of a Okta Group",
-				ForceNew: true,
+				ForceNew:    true,
 			},
 			"user_id": {
-				Type: schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
 				Description: "ID of a Okta User",
-				ForceNew: true,
+				ForceNew:    true,
 			},
 		},
 	}

--- a/okta/resource_okta_group_membership_test.go
+++ b/okta/resource_okta_group_membership_test.go
@@ -35,5 +35,11 @@ func checkMembershipState(id string) (bool, error) {
 	groupId := ids[0]
 	userId := ids[1]
 	client := getOktaClientFromMetadata(testAccProvider.Meta())
-	return checkIfUserInGroup(context.Background(), client, groupId, userId)
+	state, err := checkIfUserInGroup(context.Background(), client, groupId, userId)
+	if err != nil {
+		if strings.Contains(err.Error(), "Not Found") {
+			return state, nil
+		}
+	}
+	return state, err
 }

--- a/okta/resource_okta_group_membership_test.go
+++ b/okta/resource_okta_group_membership_test.go
@@ -1,8 +1,10 @@
 package okta
 
 import (
+	"context"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"strings"
 	"testing"
 )
 
@@ -16,6 +18,7 @@ func TestAccOktaGroupMembership_crud(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createCheckResourceDestroy(oktaGroupMembership, checkMembershipState),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -25,4 +28,12 @@ func TestAccOktaGroupMembership_crud(t *testing.T) {
 			},
 		},
 	})
+}
+
+func checkMembershipState(id string) (bool, error) {
+	ids := strings.Split(id, "+")
+	groupId := ids[0]
+	userId := ids[1]
+	client := getOktaClientFromMetadata(testAccProvider.Meta())
+	return checkIfUserInGroup(context.Background(), client, groupId, userId)
 }

--- a/okta/resource_okta_group_membership_test.go
+++ b/okta/resource_okta_group_membership_test.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"strings"
@@ -37,7 +38,7 @@ func checkMembershipState(id string) (bool, error) {
 	client := getOktaClientFromMetadata(testAccProvider.Meta())
 	state, err := checkIfUserInGroup(context.Background(), client, groupId, userId)
 	if err != nil {
-		if strings.Contains(err.Error(), "Not Found") {
+		if strings.Contains(err.Error(), fmt.Sprintf("Resource not found: %s (UserGroup)", groupId)) {
 			return state, nil
 		}
 	}

--- a/okta/resource_okta_group_membership_test.go
+++ b/okta/resource_okta_group_membership_test.go
@@ -1,0 +1,28 @@
+package okta
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccOktaGroupMembership_crud(t *testing.T) {
+	ri := acctest.RandInt()
+
+	mgr := newFixtureManager(oktaGroupMembership)
+	config := mgr.GetFixtures("okta_group_membership.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("okta_group_membership_updated.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				Config: updatedConfig,
+			},
+		},
+	})
+}

--- a/website/docs/r/group_membership.html.markdown
+++ b/website/docs/r/group_membership.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: 'okta' page_title: 'Okta: okta_group_membership' sidebar_current: 'docs-okta-resource-group-membership'
+description: |- Manage an individual instance of group membership.
+---
+
+# okta_group_membership
+
+Manage an individual instance of group membership.
+
+This resource allows you to manage group membership for a given user and group at an individual level. This allows you
+to manage group membership in terraform without overriding other automatic membership operations performed by group
+rules and other non-managed actions.
+
+## Example Usage
+
+```hcl
+resource "okta_group_membership" "example" {
+  group_id = "00g1mana0vCrxzQY84x7"
+  user_id  = "00u1manxvp7QBAGgk4x7"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `group_id` - (Required) The ID of the Okta Group.
+
+- `user_id` - (Required) The ID of the Okta User.
+
+## Attributes Reference
+
+N/A

--- a/website/docs/r/group_membership.html.markdown
+++ b/website/docs/r/group_membership.html.markdown
@@ -11,6 +11,9 @@ This resource allows you to manage group membership for a given user and group a
 to manage group membership in terraform without overriding other automatic membership operations performed by group
 rules and other non-managed actions.
 
+When using this with a `okta_user` resource, you should add a lifecycle ignore for group memberships to avoid conflicts
+in desired state.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
This is a new resource proposal to create a `okta_group_membership` resource.

The primary purpose of this resource would be to allow management of okta group memberships at a individual level, so when using this with a `okta_user` resource for example, you would be able to manage groups without potentially removing/killing membership of groups from rules or other desired automated group additions.

The secondary purpose would be to allow management of group memberships with mixed types of `data` and `resource` objects, and other variations of this.