### PR TITLE
New Resource: okta_group_role

### DIFF
--- a/examples/okta_group_role/README.md
+++ b/examples/okta_group_role/README.md
@@ -1,0 +1,6 @@
+# okta_group_role
+
+Represents an assignment of an Admin role to an Okta
+Group. [See Okta documentation for more details](https://developer.okta.com/docs/reference/api/roles/#list-roles-assigned-to-group)
+
+- Example of a group assigned as a `READ_ONLY_ADMIN` [can be found here](./basic.tf)

--- a/examples/okta_group_role/basic.tf
+++ b/examples/okta_group_role/basic.tf
@@ -1,0 +1,20 @@
+// Test group & user assigned to group
+resource "okta_group" "test" {
+  name = "testAcc_replace_with_uuid"
+  description = "testing"
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name = "Smith"
+  login = "testAcc-replace_with_uuid@example.com"
+  email = "testAcc-replace_with_uuid@example.com"
+  group_memberships = [
+    okta_group.test.id]
+}
+
+//Usage of role
+resource "okta_group_role" "test" {
+  group_id = okta_group.test.id
+  role_type = "READ_ONLY_ADMIN"
+}

--- a/examples/okta_group_role/basic.tf
+++ b/examples/okta_group_role/basic.tf
@@ -1,20 +1,20 @@
 // Test group & user assigned to group
 resource "okta_group" "test" {
-  name = "testAcc_replace_with_uuid"
+  name        = "testAcc_replace_with_uuid"
   description = "testing"
 }
 
 resource "okta_user" "test" {
   first_name = "TestAcc"
-  last_name = "Smith"
-  login = "testAcc-replace_with_uuid@example.com"
-  email = "testAcc-replace_with_uuid@example.com"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
   group_memberships = [
-    okta_group.test.id]
+  okta_group.test.id]
 }
 
 //Usage of role
 resource "okta_group_role" "test" {
-  group_id = okta_group.test.id
+  group_id  = okta_group.test.id
   role_type = "READ_ONLY_ADMIN"
 }

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -33,6 +33,7 @@ const (
 	authServerScope        = "okta_auth_server_scope"
 	eventHook              = "okta_event_hook"
 	factor                 = "okta_factor"
+	groupRole              = "okta_group_role"
 	groupRoles             = "okta_group_roles"
 	groupRule              = "okta_group_rule"
 	idpResource            = "okta_idp_oidc"
@@ -146,6 +147,7 @@ func Provider() *schema.Provider {
 			authServerScope:        resourceAuthServerScope(),
 			eventHook:              resourceEventHook(),
 			factor:                 resourceFactor(),
+			groupRole:              resourceGroupRole(),
 			groupRoles:             resourceGroupRoles(),
 			groupRule:              resourceGroupRule(),
 			idpResource:            resourceIdpOidc(),

--- a/okta/resource_okta_group_role.go
+++ b/okta/resource_okta_group_role.go
@@ -1,0 +1,86 @@
+package okta
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func resourceGroupRole() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGroupRoleCreate,
+		ReadContext:   resourceGroupRoleRead,
+		UpdateContext: nil,
+		DeleteContext: resourceGroupRoleDelete,
+		Importer:      nil,
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of group to attach admin roles to",
+				ForceNew:    true,
+			},
+			"role_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Type of Role to assign",
+				ForceNew:    true,
+				ValidateDiagFunc: stringInSlice([]string{
+					"API_ACCESS_MANAGEMENT_ADMIN",
+					"APP_ADMIN",
+					"GROUP_MEMBERSHIP_ADMIN",
+					"HELP_DESK_ADMIN",
+					"MOBILE_ADMIN",
+					"ORG_ADMIN",
+					"READ_ONLY_ADMIN",
+					"REPORT_ADMIN",
+					"SUPER_ADMIN",
+					"USER_ADMIN",
+				}),
+			},
+		},
+	}
+}
+
+func resourceGroupRoleCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupID := d.Get("group_id").(string)
+	roleType := d.Get("role_type").(string)
+	logger(m).Info("assigning role to group", "group_id", groupID, "role_type", roleType)
+	role, _, err := getOktaClientFromMetadata(m).Group.AssignRoleToGroup(ctx, groupID, okta.AssignRoleRequest{
+		Type: roleType,
+	}, nil)
+	if err != nil {
+		return diag.Errorf("failed to assign role %s to group %s: %v", roleType, groupID, err)
+	}
+	d.SetId(role.Id)
+	return resourceGroupRoleRead(ctx, d, m)
+}
+
+func resourceGroupRoleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupID := d.Get("group_id").(string)
+	rolesAssigned, _, err := getOktaClientFromMetadata(m).Group.ListGroupAssignedRoles(ctx, groupID, nil)
+	if err != nil {
+		return diag.Errorf("failed to list roles assigned to group %s: %v", groupID, err)
+	}
+	for _, role := range rolesAssigned {
+		if role.Id == d.Id() {
+			_ = d.Set("role_type", role.Type)
+			return nil
+		}
+	}
+	logger(m).Info("no roles found assigned to group", "group_id", groupID)
+	d.SetId("")
+	return nil
+}
+
+func resourceGroupRoleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupID := d.Get("group_id").(string)
+	roleType := d.Get("role_type").(string)
+	logger(m).Info("deleting assigned role from group", "group_id", groupID, "role_type", roleType)
+	_, err := getOktaClientFromMetadata(m).Group.RemoveRoleFromGroup(ctx, groupID, d.Id())
+	if err != nil {
+		return diag.Errorf("failed to remove role %s assigned to group %s: %v", roleType, groupID, err)
+	}
+	return nil
+}

--- a/okta/resource_okta_group_role_test.go
+++ b/okta/resource_okta_group_role_test.go
@@ -1,0 +1,30 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaGroupAdminRole_crud(t *testing.T) {
+	ri := acctest.RandInt()
+	resourceName := fmt.Sprintf("%s.test", groupRole)
+	mgr := newFixtureManager(groupRole)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createCheckResourceDestroy(oktaGroup, doesGroupExist),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "role_type", "READ_ONLY_ADMIN"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_group_roles.go
+++ b/okta/resource_okta_group_roles.go
@@ -11,6 +11,7 @@ import (
 
 func resourceGroupRoles() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "This resource will be removed in favor of using \"okta_group_role\", please migrate away from this resource as soon as you are able.",
 		// No point in having an exist function, since only the group has to exist
 		CreateContext: resourceGroupRolesCreate,
 		ReadContext:   resourceGroupRolesRead,

--- a/website/docs/r/group_role.html.markdown
+++ b/website/docs/r/group_role.html.markdown
@@ -36,7 +36,3 @@ The following arguments are supported:
 ## Import
 
 TBD
-
-```
-$ terraform import okta_group_roles.example <group id>
-```

--- a/website/docs/r/group_role.html.markdown
+++ b/website/docs/r/group_role.html.markdown
@@ -3,7 +3,7 @@ layout: 'okta' page_title: 'Okta: okta_group_role' sidebar_current: 'docs-okta-r
 Assigns Admin roles to Okta Groups.
 ---
 
-# okta_group_roles
+# okta_group_role
 
 Assigns Admin roles to Okta Groups.
 

--- a/website/docs/r/group_role.html.markdown
+++ b/website/docs/r/group_role.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: 'okta' page_title: 'Okta: okta_group_role' sidebar_current: 'docs-okta-resource-group-role' description: |-
+Assigns Admin roles to Okta Groups.
+---
+
+# okta_group_roles
+
+Assigns Admin roles to Okta Groups.
+
+This resource allows you to assign Okta administrator roles to Okta Groups. This resource provides a one-to-one
+interface between the Okta group and the admin role.
+
+## Example Usage
+
+```hcl
+resource "okta_group_role" "example" {
+  group_id  = "<group id>"
+  role_type = "READ_ONLY_ADMIN"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `group_id` - (Required) The ID of group to attach admin roles to.
+
+- `role_type` - (Required) Admin role assigned to the group. It can be any one of the following values `"SUPER_ADMIN"`
+  , `"ORG_ADMIN"`, `"APP_ADMIN"`, `"USER_ADMIN"`, `"HELP_DESK_ADMIN"`, `"READ_ONLY_ADMIN"`
+  , `"MOBILE_ADMIN"`, `"API_ACCESS_MANAGEMENT_ADMIN"`, `"REPORT_ADMIN"`, `"GROUP_MEMBERSHIP_ADMIN"`.
+
+## Attributes Reference
+
+- `id` - The ID of the Group Role Assignment.
+
+## Import
+
+TBD
+
+```
+$ terraform import okta_group_roles.example <group id>
+```

--- a/website/docs/r/group_role.html.markdown
+++ b/website/docs/r/group_role.html.markdown
@@ -35,4 +35,8 @@ The following arguments are supported:
 
 ## Import
 
-TBD
+Individual admin role assignment can be imported by passing the group and role assignment IDs as follows:
+
+```
+$ terraform import okta_group_role.example <group id>/<role id>
+```


### PR DESCRIPTION
This PR creates a new resource: `okta_group_role`

This resource is designed to replace `okta_group_roles` such that:

- Manages the admin role assignments at an individual level, instead of the list of roles that `okta_group_roles` manages with.
- This allows the ID for the resource to be exactly the `roleID` defined in the API docs

This PR is part 1 of a few PRs for resources I will release, the others being:

1. Group target list for admin roles
2. App instance target list for admin roles
3. App catalog/name target list for admin roles

This resource will provide the "base" that I will use to work on the others (although technically it's not required). In this case having the individual role assignment ID is a requirement for using the API endpoints for the target lists, so this would be immensely more helpful than how `roles` works.

This is intended to replace #154  with the additional caveats of:

- Not modifying the `okta_group_roles` resource, only adding a deprecation message. This should allow us to avoid a breaking change and ease people into the new pattern. (Follows best practice per the hashicorp docs)
- Appending the various admin role scoping functionality into this resource (or standalone resources where possible).