### PR TITLE
Retain user group app assignments

### DIFF
--- a/examples/okta_app_group_assignment/retain_assignment.tf
+++ b/examples/okta_app_group_assignment/retain_assignment.tf
@@ -1,0 +1,22 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+
+  lifecycle {
+    ignore_changes = ["users", "groups"]
+  }
+}
+
+resource "okta_group" "test" {
+  name = "testAcc_replace_with_uuid"
+}
+
+resource "okta_app_group_assignment" "test" {
+  app_id            = okta_app_oauth.test.id
+  group_id          = okta_group.test.id
+  retain_assignment = true
+}

--- a/examples/okta_app_group_assignment/retain_assignment_destroy.tf
+++ b/examples/okta_app_group_assignment/retain_assignment_destroy.tf
@@ -1,0 +1,16 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+
+  lifecycle {
+    ignore_changes = ["users", "groups"]
+  }
+}
+
+resource "okta_group" "test" {
+  name = "testAcc_replace_with_uuid"
+}

--- a/examples/okta_app_user/retain.tf
+++ b/examples/okta_app_user/retain.tf
@@ -1,0 +1,26 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+
+  lifecycle {
+    ignore_changes = ["users", "groups"]
+  }
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc_replace_with_uuid@example.com"
+  email      = "testAcc_replace_with_uuid@example.com"
+}
+
+resource "okta_app_user" "test" {
+  app_id            = okta_app_oauth.test.id
+  user_id           = okta_user.test.id
+  username          = okta_user.test.email
+  retain_assignment = true
+}

--- a/examples/okta_app_user/retain_destroy.tf
+++ b/examples/okta_app_user/retain_destroy.tf
@@ -1,0 +1,19 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+
+  lifecycle {
+    ignore_changes = ["users", "groups"]
+  }
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc_replace_with_uuid@example.com"
+  email      = "testAcc_replace_with_uuid@example.com"
+}

--- a/okta/resource_okta_app_group_assignment.go
+++ b/okta/resource_okta_app_group_assignment.go
@@ -26,6 +26,7 @@ func resourceAppGroupAssignment() *schema.Resource {
 
 				_ = d.Set("app_id", parts[0])
 				_ = d.Set("group_id", parts[1])
+				_ = d.Set("retain_assignment", false)
 
 				assignment, _, err := getOktaClientFromMetadata(m).Application.
 					GetApplicationGroupAssignment(ctx, parts[0], parts[1], nil)
@@ -65,6 +66,12 @@ func resourceAppGroupAssignment() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return new == ""
 				},
+			},
+			"retain_assignment": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Retain the group assignment on destroy. If set to true, the resource will be removed from state but not from the Okta app.",
 			},
 		},
 	}
@@ -122,6 +129,12 @@ func resourceAppGroupAssignmentRead(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceAppGroupAssignmentDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	retain := d.Get("retain_assignment").(bool)
+	if retain {
+		// The assignment should be retained, bail before DeleteApplicationGroupAssignment is called
+		return nil
+	}
+
 	_, err := getOktaClientFromMetadata(m).Application.DeleteApplicationGroupAssignment(
 		ctx,
 		d.Get("app_id").(string),

--- a/okta/resource_okta_app_user.go
+++ b/okta/resource_okta_app_user.go
@@ -26,6 +26,7 @@ func resourceAppUser() *schema.Resource {
 
 				_ = d.Set("app_id", parts[0])
 				_ = d.Set("user_id", parts[1])
+				_ = d.Set("retain_assignment", false)
 
 				assignment, _, err := getOktaClientFromMetadata(m).Application.
 					GetApplicationUser(ctx, parts[0], parts[1], nil)
@@ -68,6 +69,12 @@ func resourceAppUser() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return new == ""
 				},
+			},
+			"retain_assignment": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Retain the user assignment on destroy. If set to true, the resource will be removed from state but not from the Okta app.",
 			},
 		},
 	}
@@ -124,6 +131,12 @@ func resourceAppUserRead(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func resourceAppUserDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	retain := d.Get("retain_assignment").(bool)
+	if retain {
+		// The assignment should be retained, bail before DeleteApplicationUser is called
+		return nil
+	}
+
 	_, err := getOktaClientFromMetadata(m).Application.DeleteApplicationUser(
 		ctx,
 		d.Get("app_id").(string),

--- a/okta/test_utils.go
+++ b/okta/test_utils.go
@@ -45,3 +45,13 @@ func createCheckResourceDestroy(typeName string, checkUpstream checkUpstream) re
 		return nil
 	}
 }
+
+func ensureResourceNotExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return nil
+		}
+		return fmt.Errorf("Resource found: %s", name)
+	}
+}

--- a/website/docs/r/app_group_assignment.html.markdown
+++ b/website/docs/r/app_group_assignment.html.markdown
@@ -38,6 +38,8 @@ resource "okta_app_oauth" "app" {
 }
 ```
 
+~> **Important:** When the `app_group_assignment` is retained, by setting `retain_assignment` to `true`, it is no longer managed by Terraform after it is destroyed. To truly delete the assignment, you will need to remove it either through the Okta Console or API. This argument exists for the use case where the same group is assigned in multiple places in order to prevent a single destruction removing all of them.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -47,6 +49,8 @@ The following arguments are supported:
 - `group_id` - (Required) The ID of the group to assign the app to.
 
 - `profile` - (Optional) JSON document containing [application profile](https://developer.okta.com/docs/reference/api/apps/#profile-object)
+
+- `retain_assignment` - (Optional) Retain the group assignment on destroy. If set to true, the resource will be removed from state but not from the Okta app.
 
 ## Attributes Reference
 

--- a/website/docs/r/app_user.html.markdown
+++ b/website/docs/r/app_user.html.markdown
@@ -20,6 +20,8 @@ lifecycle {
 }
 ```
 
+~> **Important:** When the `okta_app_user` is retained, by setting `retain_assignment` to `true`, it is no longer managed by Terraform after it is destroyed. To truly delete the assignment, you will need to remove it either through the Okta Console or API. This argument exists for the use case where the same user is assigned in multiple places in order to prevent a single destruction removing all of them.
+
 ## Example Usage
 
 ```hcl
@@ -43,6 +45,8 @@ The following arguments are supported:
 - `password` - (Optional) The password to use.
 
 - `profile` - (Optional) The JSON profile of the App User.
+
+- `retain_assignment` - (Optional) Retain the user association on destroy. If set to true, the resource will be removed from state but not from the Okta app.
 
 ## Attributes Reference
 


### PR DESCRIPTION
We have a very distributed terraform setup where we use Okta with AWS SSO for user and permissions management. The same User and Group assignments can be made in different modules for different AWS Permission Sets by different developers. Okta user and group assignments are idempotent, meaning you can assign the same user multiple times in multiple places which only results in a single assignment in the Okta app. The flip side is that a single destroy of `okta_app_user` or `okta_app_group_assignment` completely removes the user/group from the app, even though it may still exist in multiple other terraform modules.

This adds `retain_assignment` arguments to both the `okta_app_user` and `okta_app_group_assignment` resources. This optional attribute allows terraform to remove the resource from state when it is destroyed, but to retain the user/group assignments on the associated Okta app. Documentation changes have been added warning that using this feature will result in the need to possibly manually remove user/group assignments in the future.

Tests have been updated and run and are passing against our instance of oktapreview.

Let me know what you think and if you'd like any changes. 