### PR TITLE
Okta Group Membership - Wait after create

### DIFF
--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -3,6 +3,7 @@ package okta
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -47,6 +48,7 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("failed to add user to group: %v", err)
 	}
 	d.SetId(fmt.Sprintf("%s+%s", groupId, userId))
+	time.Sleep(5 * time.Second)
 	return resourceGroupMembershipRead(ctx, d, m)
 }
 

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -48,7 +48,6 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.Errorf("failed to add user to group: %v", err)
 	}
-	d.SetId(fmt.Sprintf("%s+%s", groupId, userId))
 	bOff := backoff.NewExponentialBackOff()
 	bOff.MaxElapsedTime = time.Second * 10
 	bOff.InitialInterval = time.Second
@@ -63,9 +62,9 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 		return fmt.Errorf("failed to find user (%s) in group (%s) after multiple tries", userId, groupId)
 	}, bOff)
 	if err != nil {
-		d.SetId("")
 		return diag.FromErr(err)
 	}
+	d.SetId(fmt.Sprintf("%s+%s", groupId, userId))
 	return nil
 }
 

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -55,12 +55,12 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 	err = backoff.Retry(func() error {
 		inGroup, err := checkIfUserInGroup(ctx, client, groupId, userId)
 		if err != nil {
-			return backoff.Permanent(fmt.Errorf("failed to find user in group after addition with error: %v", err))
+			return backoff.Permanent(fmt.Errorf("failed to find user (%s) in group (%s) after addition with error: %v", userId, groupId, err))
 		}
 		if inGroup {
 			return nil
 		}
-		return fmt.Errorf("failed to find user in group after multiple tries")
+		return fmt.Errorf("failed to find user (%s) in group (%s) after multiple tries", userId, groupId)
 	}, bOff)
 	if err != nil {
 		d.SetId("")


### PR DESCRIPTION
This is a primitive bug fix for the issue I've encountered, documented below.

There can be a lag upon group membership addition operation, which does not mesh well with the ability to perform the read function after create. Therefore, my simple fix is to set a wait/delay between the addition operation and the read operation (only for creates); since there is no ID or "404-like" error we can reliably use as a "re-try" trigger.

```
    apply.go:71: 

        	Error Trace:	apply.go:71

        	            				module_test.go:22

        	Error:      	Received unexpected error:

        	            	FatalError{Underlying: error while running command: exit status 1; 

        	            	Error: Provider produced inconsistent result after apply

        	            	

        	            	When applying changes to

        	            	module.test_machine_user_okta_admin.okta_group_membership.group_membership["Test_Dummy_Group"],

        	            	provider "registry.terraform.io/oktadeveloper/okta" produced an unexpected new

        	            	value: Root resource was present, but now absent.

        	            	

        	            	This is a bug in the provider, which should be reported in the provider's own

        	            	issue tracker.

        	            	}

        	Test:       	TestMachineUserOktaAdminV2

```

