### PR TITLE
Fix: Add group existence check to group_membership resource

### DIFF
--- a/examples/okta_group_membership/okta_group_membership_removed.tf
+++ b/examples/okta_group_membership/okta_group_membership_removed.tf
@@ -10,12 +10,12 @@ resource "okta_user" "test" {
 }
 
 ## Test Case
-resource "okta_group" "test" {
-  name        = "testAcc_replace_with_uuid"
+resource "okta_group" "test_2" {
+  name        = "testAcc_2_replace_with_uuid"
   description = "testing, testing"
 }
 
-resource "okta_group_membership" "test" {
-  group_id = okta_group.test.id
+resource "okta_group_membership" "test_2" {
+  group_id = okta_group.test_2.id
   user_id  = okta_user.test.id
 }

--- a/examples/okta_group_membership/okta_group_membership_updated.tf
+++ b/examples/okta_group_membership/okta_group_membership_updated.tf
@@ -1,20 +1,31 @@
-resource "okta_group" "test" {
-  name        = "testAcc_replace_with_uuid"
-  description = "testing, testing"
-}
-
 resource "okta_user" "test" {
   first_name = "TestAcc"
-  last_name  = "Bould"
-  login      = "steve_replace_with_uuid@ledzeppelin.com"
-  email      = "steve_replace_with_uuid@ledzeppelin.com"
+  last_name  = "Jones"
+  login      = "john_replace_with_uuid@ledzeppelin.com"
+  email      = "john_replace_with_uuid@ledzeppelin.com"
 
   lifecycle {
     ignore_changes = [group_memberships]
   }
 }
 
+## Test Case
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+}
+
 resource "okta_group_membership" "test" {
   group_id = okta_group.test.id
+  user_id  = okta_user.test.id
+}
+
+resource "okta_group" "test_2" {
+  name        = "testAcc_2_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group_membership" "test_2" {
+  group_id = okta_group.test_2.id
   user_id  = okta_user.test.id
 }

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -100,8 +100,11 @@ func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, 
 
 func checkIfUserInGroup(ctx context.Context, client *okta.Client, groupId, userId string) (bool, error) {
 	users, resp, err := client.Group.ListGroupUsers(ctx, groupId, &query.Params{Limit: defaultPaginationLimit})
+	groupExists, err := doesResourceExist(resp, err)
 	if err != nil {
 		return false, err
+	} else if !groupExists {
+		return false, nil
 	}
 	for {
 		for _, user := range users {

--- a/okta/resource_okta_group_membership_test.go
+++ b/okta/resource_okta_group_membership_test.go
@@ -16,6 +16,7 @@ func TestAccOktaGroupMembership_crud(t *testing.T) {
 	mgr := newFixtureManager(oktaGroupMembership)
 	config := mgr.GetFixtures("okta_group_membership.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("okta_group_membership_updated.tf", ri, t)
+	removedConfig := mgr.GetFixtures("okta_group_membership_removed.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -27,6 +28,9 @@ func TestAccOktaGroupMembership_crud(t *testing.T) {
 			},
 			{
 				Config: updatedConfig,
+			},
+			{
+				Config: removedConfig,
 			},
 		},
 	})


### PR DESCRIPTION
The `checkIfUserInGroup` function has a flaw where it doesn't take into account what to do if the group is deleted while the resource is in use. This adds a check so if the group resource doesn't exist we just return false which the rest of the logic the resource should handle appropriately. 