### PR TITLE
New Resource: User Group Memberships

### DIFF
--- a/examples/okta_user_group_memberships/README.md
+++ b/examples/okta_user_group_memberships/README.md
@@ -1,0 +1,7 @@
+# Okta User Group Memberships
+
+Resource to manage a set of group memberships for a specific user.
+
+[See Okta documentation regarding group operations](https://developer.okta.com/docs/reference/api/groups/#group-member-operations)
+
+A simple example of usage of this resource can be [found here](./basic.tf).

--- a/examples/okta_user_group_memberships/basic.tf
+++ b/examples/okta_user_group_memberships/basic.tf
@@ -1,0 +1,38 @@
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_group" "test_1" {
+  name        = "testAcc_1_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_2" {
+  name        = "testAcc_2_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_3" {
+  name        = "testAcc_3_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_4" {
+  name        = "testAcc_4_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user_group_memberships" "test" {
+  user_id = okta_user.test.id
+  groups = [
+    okta_group.test_1.id,
+    okta_group.test_2.id,
+  ]
+}

--- a/examples/okta_user_group_memberships/basic_removal.tf
+++ b/examples/okta_user_group_memberships/basic_removal.tf
@@ -1,0 +1,37 @@
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_group" "test_1" {
+  name        = "testAcc_1_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_2" {
+  name        = "testAcc_2_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_3" {
+  name        = "testAcc_3_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_4" {
+  name        = "testAcc_4_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user_group_memberships" "test" {
+  user_id = okta_user.test.id
+  groups = [
+    okta_group.test_1.id,
+  ]
+}

--- a/examples/okta_user_group_memberships/basic_update.tf
+++ b/examples/okta_user_group_memberships/basic_update.tf
@@ -1,0 +1,39 @@
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_group" "test_1" {
+  name        = "testAcc_1_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_2" {
+  name        = "testAcc_2_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_3" {
+  name        = "testAcc_3_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group" "test_4" {
+  name        = "testAcc_4_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user_group_memberships" "test" {
+  user_id = okta_user.test.id
+  groups = [
+    okta_group.test_1.id,
+    okta_group.test_3.id,
+    okta_group.test_4.id,
+  ]
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -69,6 +69,7 @@ const (
 	userBaseSchema         = "okta_user_base_schema"
 	userSchema             = "okta_user_schema"
 	userType               = "okta_user_type"
+	userGroupMemberships   = "okta_user_group_memberships"
 )
 
 // Provider establishes a client connection to an okta site
@@ -219,6 +220,7 @@ func Provider() *schema.Provider {
 			userSchema:             resourceUserSchema(),
 			userBaseSchema:         resourceUserBaseSchema(),
 			userType:               resourceUserType(),
+			userGroupMemberships:   resourceUserGroupMemberships(),
 
 			// The day I realized I was naming stuff wrong :'-(
 			"okta_idp":                       deprecateIncorrectNaming(resourceIdpOidc(), idpOidc),

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -17,10 +17,8 @@ func resourceUserGroupMemberships() *schema.Resource {
 		ReadContext:   resourceUserGroupMembershipRead,
 		UpdateContext: resourceUserGroupMembershipUpdate,
 		DeleteContext: resourceUserGroupMembershipDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Description: "Resource to manage a set of group memberships for a specific user.",
+		Importer:      nil,
+		Description:   "Resource to manage a set of group memberships for a specific user.",
 		Schema: map[string]*schema.Schema{
 			"user_id": {
 				Type:        schema.TypeString,

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -118,8 +118,8 @@ func resourceUserGroupMembershipUpdate(ctx context.Context, d *schema.ResourceDa
 	oldSet := old.(*schema.Set)
 	newSet := new.(*schema.Set)
 
-	groupsToAdd := convertInterfaceToStringSetNullable(newSet.Difference(oldSet).List())
-	groupsToRemove := convertInterfaceToStringSetNullable(oldSet.Difference(newSet).List())
+	groupsToAdd := convertInterfaceArrToStringArr(newSet.Difference(oldSet).List())
+	groupsToRemove := convertInterfaceArrToStringArr(oldSet.Difference(newSet).List())
 
 	err := addUserToGroups(ctx, client, userId, groupsToAdd)
 	if err != nil {

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -49,7 +49,6 @@ func resourceUserGroupMembershipCreate(ctx context.Context, d *schema.ResourceDa
 	bOff.InitialInterval = time.Second
 	err = backoff.Retry(func() error {
 		ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
-		//TODO: Fix error messages
 		if err != nil {
 			return backoff.Permanent(err)
 		}

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -1,0 +1,99 @@
+ackage okta
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func resourceGroupMembership() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGroupMembershipCreate,
+		ReadContext:   resourceGroupMembershipRead,
+		UpdateContext: nil,
+		DeleteContext: resourceGroupMembershipDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Description: "",
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of a Okta User",
+				ForceNew:    true,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of a Okta Group",
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupId := d.Get("group_id").(string)
+	userId := d.Get("user_id").(string)
+	logger(m).Info("adding user to group", "group", groupId, "user", userId)
+	client := getOktaClientFromMetadata(m)
+	_, err := client.Group.AddUserToGroup(ctx, groupId, userId)
+	if err != nil {
+		return diag.Errorf("failed to add user to group: %v", err)
+	}
+	bOff := backoff.NewExponentialBackOff()
+	bOff.MaxElapsedTime = time.Second * 10
+	bOff.InitialInterval = time.Second
+	err = backoff.Retry(func() error {
+		inGroup, err := checkIfUserInGroup(ctx, client, groupId, userId)
+		if err != nil {
+			return backoff.Permanent(fmt.Errorf("failed to find user (%s) in group (%s) after addition with error: %v", userId, groupId, err))
+		}
+		if inGroup {
+			return nil
+		}
+		return fmt.Errorf("failed to find user (%s) in group (%s) after multiple tries", userId, groupId)
+	}, bOff)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(fmt.Sprintf("%s+%s", groupId, userId))
+	return nil
+}
+
+func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupId := d.Get("group_id").(string)
+	userId := d.Get("user_id").(string)
+	logger(m).Info("checking for membership in group", "group", groupId, "user", userId)
+	client := getOktaClientFromMetadata(m)
+	inGroup, err := checkIfUserInGroup(ctx, client, groupId, userId)
+	if err != nil {
+		return diag.Errorf("unable to complete group check for user: %v", err)
+	}
+	if inGroup {
+		return nil
+	} else {
+		d.SetId("")
+		logger(m).Info("user is not in group", "group", groupId, "user", userId)
+		return nil
+	}
+}
+
+func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	groupId := d.Get("group_id").(string)
+	userId := d.Get("user_id").(string)
+	logger(m).Info("removing user from group", "group", groupId, "user", userId)
+	client := getOktaClientFromMetadata(m)
+	_, err := client.Group.RemoveUserFromGroup(ctx, groupId, userId)
+	if err != nil {
+		return diag.Errorf("failed to remove user to group: %v", err)
+	}
+	return nil
+}

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -174,7 +174,8 @@ func addUserToGroups(ctx context.Context, client *okta.Client, userId string, gr
 
 func removeUserFromGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
 	for _, group := range groups {
-		_, err := client.Group.RemoveUserFromGroup(ctx, group, userId)
+		resp, err := client.Group.RemoveUserFromGroup(ctx, group, userId)
+		err = suppressErrorOn404(resp, err)
 		if err != nil {
 			return fmt.Errorf("failed to remove user (%s) from group (%s): %v", userId, group, err)
 		}

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -48,7 +48,7 @@ func resourceUserGroupMembershipCreate(ctx context.Context, d *schema.ResourceDa
 	} else if !exists {
 		return diag.Errorf("user (%s) does not exist in this Okta instance", userId)
 	}
-	err := addUserToGroups(ctx, client, userId, groups)
+	err = addUserToGroups(ctx, client, userId, groups)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -1,4 +1,4 @@
-ackage okta
+package okta
 
 import (
 	"context"
@@ -9,19 +9,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
 
-func resourceGroupMembership() *schema.Resource {
+func resourceUserGroupMemberships() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceGroupMembershipCreate,
-		ReadContext:   resourceGroupMembershipRead,
-		UpdateContext: nil,
-		DeleteContext: resourceGroupMembershipDelete,
+		CreateContext: resourceUserGroupMembershipCreate,
+		ReadContext:   resourceUserGroupMembershipRead,
+		UpdateContext: resourceUserGroupMembershipUpdate,
+		DeleteContext: resourceUserGroupMembershipDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "",
+		Description: "Resource to manage a set of group memberships for a specific user.",
 		Schema: map[string]*schema.Schema{
 			"user_id": {
 				Type:        schema.TypeString,
@@ -29,71 +28,144 @@ func resourceGroupMembership() *schema.Resource {
 				Description: "ID of a Okta User",
 				ForceNew:    true,
 			},
-			"group_id": {
-				Type:        schema.TypeString,
+			"groups": {
+				Type:        schema.TypeSet,
 				Required:    true,
-				Description: "ID of a Okta Group",
-				ForceNew:    true,
+				Description: "The list of Okta group IDs which the user should have membership managed for.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
 }
 
-func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	groupId := d.Get("group_id").(string)
+func resourceUserGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	userId := d.Get("user_id").(string)
-	logger(m).Info("adding user to group", "group", groupId, "user", userId)
+	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
 	client := getOktaClientFromMetadata(m)
-	_, err := client.Group.AddUserToGroup(ctx, groupId, userId)
+	err := addUserToGroups(ctx, client, userId, groups)
 	if err != nil {
-		return diag.Errorf("failed to add user to group: %v", err)
+		return diag.FromErr(err)
 	}
 	bOff := backoff.NewExponentialBackOff()
 	bOff.MaxElapsedTime = time.Second * 10
 	bOff.InitialInterval = time.Second
 	err = backoff.Retry(func() error {
-		inGroup, err := checkIfUserInGroup(ctx, client, groupId, userId)
+		ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
+		//TODO: Fix error messages
 		if err != nil {
-			return backoff.Permanent(fmt.Errorf("failed to find user (%s) in group (%s) after addition with error: %v", userId, groupId, err))
+			return backoff.Permanent(err)
 		}
-		if inGroup {
+		if ok {
 			return nil
 		}
-		return fmt.Errorf("failed to find user (%s) in group (%s) after multiple tries", userId, groupId)
+		return fmt.Errorf("user (%s) did not have expected group memberships after multiple checks", userId)
 	}, bOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(fmt.Sprintf("%s+%s", groupId, userId))
+	d.SetId(userId)
 	return nil
 }
 
-func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	groupId := d.Get("group_id").(string)
+func resourceUserGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	userId := d.Get("user_id").(string)
-	logger(m).Info("checking for membership in group", "group", groupId, "user", userId)
+	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
 	client := getOktaClientFromMetadata(m)
-	inGroup, err := checkIfUserInGroup(ctx, client, groupId, userId)
+	ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
 	if err != nil {
 		return diag.Errorf("unable to complete group check for user: %v", err)
 	}
-	if inGroup {
+	if ok {
 		return nil
 	} else {
 		d.SetId("")
-		logger(m).Info("user is not in group", "group", groupId, "user", userId)
+		logger(m).Info("user (%s) did not have expected group memberships", userId)
 		return nil
 	}
 }
 
-func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	groupId := d.Get("group_id").(string)
+func resourceUserGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	userId := d.Get("user_id").(string)
-	logger(m).Info("removing user from group", "group", groupId, "user", userId)
+	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
 	client := getOktaClientFromMetadata(m)
-	_, err := client.Group.RemoveUserFromGroup(ctx, groupId, userId)
+	err := removeUserFromGroups(ctx, client, userId, groups)
 	if err != nil {
-		return diag.Errorf("failed to remove user to group: %v", err)
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceUserGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	client := getOktaClientFromMetadata(m)
+
+	old, new := d.GetChange("groups")
+
+	oldSet := old.(*schema.Set)
+	newSet := new.(*schema.Set)
+
+	groupsToAdd := convertInterfaceToStringSetNullable(newSet.Difference(oldSet).List())
+	groupsToRemove := convertInterfaceToStringSetNullable(oldSet.Difference(newSet).List())
+
+	err := addUserToGroups(ctx, client, userId, groupsToAdd)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	err = removeUserFromGroups(ctx, client, userId, groupsToRemove)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func checkIfUserHasGroups(ctx context.Context, client *okta.Client, userId string, groups []string) (bool, error) {
+	userGroups, _, err := client.User.ListUserGroups(ctx, userId)
+	if err != nil {
+		return false, fmt.Errorf("unable to return groups for user (%s) from API", userId)
+	}
+
+	// Create set of groups
+	expectedGroupSet := make(map[string]bool)
+
+	for _, group := range groups {
+		expectedGroupSet[group] = false
+	}
+
+	// Use groups pulled from user and mark set if found
+	for _, group := range userGroups {
+		if _, ok := expectedGroupSet[group.Id]; ok {
+			expectedGroupSet[group.Id] = true
+		}
+	}
+
+	// Check set for any missing values
+	for _, state := range expectedGroupSet {
+		if !state {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func addUserToGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
+	for _, group := range groups {
+		_, err := client.Group.AddUserToGroup(ctx, group, userId)
+		if err != nil {
+			return fmt.Errorf("failed to add user (%s) to group (%s): %v", userId, group, err)
+		}
+	}
+	return nil
+}
+
+func removeUserFromGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
+	for _, group := range groups {
+		_, err := client.Group.RemoveUserFromGroup(ctx, group, userId)
+		if err != nil {
+			return fmt.Errorf("failed to remove user (%s) from group (%s): %v", userId, group, err)
+		}
 	}
 	return nil
 }

--- a/okta/resource_okta_user_group_memberships_test.go
+++ b/okta/resource_okta_user_group_memberships_test.go
@@ -1,0 +1,34 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaUserGroupMemberships_crud(t *testing.T) {
+	ri := acctest.RandInt()
+
+	mgr := newFixtureManager(userGroupMemberships)
+	start := mgr.GetFixtures("basic.tf", ri, t)
+	update := mgr.GetFixtures("basic_update.tf", ri, t)
+	remove := mgr.GetFixtures("basic_removal.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: start,
+			},
+			{
+				Config: update,
+			},
+			{
+				Config: remove,
+			},
+		},
+	})
+}

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -151,12 +151,17 @@ func convertInterfaceToStringArr(purportedList interface{}) []string {
 	rawArr, ok := purportedList.([]interface{})
 
 	if ok {
-		arr = make([]string, len(rawArr))
-		for i, thing := range rawArr {
-			arr[i] = thing.(string)
-		}
+		arr = convertInterfaceArrToStringArr(rawArr)
 	}
 
+	return arr
+}
+
+func convertInterfaceArrToStringArr(rawArr []interface{}) []string {
+	arr := make([]string, len(rawArr))
+	for i, thing := range rawArr {
+		arr[i] = thing.(string)
+	}
 	return arr
 }
 

--- a/website/docs/r/user_group_memberships.html.markdown
+++ b/website/docs/r/user_group_memberships.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "okta"
+page_title: "Okta: okta_user_group_membership"
+sidebar_current: "docs-okta-resource-user-group-memberships"
+description: |-
+  Resource to manage a set of group memberships for a specific user.
+---
+
+# okta_user_group_memberships
+
+Resource to manage a set of group memberships for a specific user.
+
+This resource allows you to bulk manage groups for a single user, independent of the user schema itself. This allows you
+to manage group membership in terraform without overriding other automatic membership operations performed by group
+rules and other non-managed actions.
+
+When using this with a `okta_user` resource, you should add a lifecycle ignore for group memberships to avoid conflicts
+in desired state.
+
+## Example Usage
+
+```hcl
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user_group_memberships" "test" {
+  user_id = okta_user.test.id
+  groups = [
+    okta_group.test_1.id,
+    okta_group.test_2.id,
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `user_id` - (Required) ID of a Okta User.
+- `groups` - (Required) The list of Okta group IDs which the user should have membership managed for.
+
+## Attributes Reference
+
+N/A


### PR DESCRIPTION
In an effort to correct some of the mistakes posed by the use of the resource `okta_group_membership` (https://github.com/okta/terraform-provider-okta/pull/252), I'm creating/proposing this new `okta_user_group_memberships` resource.

This is basically a clone of `okta_group_membership`, however the read functionality and handling is modified so the groups are handled in bulk on a per user basis. This allows for significant reduction in API calls during the `READ` phase (and create phase) when doing the validation of memberships of groups. This is because the standard API endpoints for users will allow you to get all groups, so it's better due to the API limits imposed to compute as much as we can IMO.