### PR TITLE
New Resource: okta_group_memberships

### DIFF
--- a/examples/okta_group_memberships/README.md
+++ b/examples/okta_group_memberships/README.md
@@ -1,0 +1,7 @@
+# Okta Group Memberships
+
+Resource to manage a set of memberships for a specific group.
+
+[See Okta documentation regarding group operations](https://developer.okta.com/docs/reference/api/groups/#group-member-operations)
+
+A simple example of usage of this resource can be [found here](./basic.tf).

--- a/examples/okta_group_memberships/basic.tf
+++ b/examples/okta_group_memberships/basic.tf
@@ -1,0 +1,57 @@
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user" "test1" {
+  first_name = "TestAcc1"
+  last_name  = "Smith"
+  login      = "testAcc1-replace_with_uuid@example.com"
+  email      = "testAcc1-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test2" {
+  first_name = "TestAcc2"
+  last_name  = "Brando"
+  login      = "testAcc2-replace_with_uuid@example.com"
+  email      = "testAcc2-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test3" {
+  first_name = "TestAcc3"
+  last_name  = "Python"
+  login      = "testAcc3-replace_with_uuid@example.com"
+  email      = "testAcc3-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test4" {
+  first_name = "TestAcc4"
+  last_name  = "Jenkins"
+  login      = "testAcc4-replace_with_uuid@example.com"
+  email      = "testAcc4-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+
+resource "okta_group_memberships" "test" {
+  group_id = okta_group.test.id
+  users = [
+    okta_user.test1.id,
+    okta_user.test2.id,
+  ]
+}

--- a/examples/okta_group_memberships/basic_removal.tf
+++ b/examples/okta_group_memberships/basic_removal.tf
@@ -1,0 +1,56 @@
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user" "test1" {
+  first_name = "TestAcc1"
+  last_name  = "Smith"
+  login      = "testAcc1-replace_with_uuid@example.com"
+  email      = "testAcc1-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test2" {
+  first_name = "TestAcc2"
+  last_name  = "Brando"
+  login      = "testAcc2-replace_with_uuid@example.com"
+  email      = "testAcc2-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test3" {
+  first_name = "TestAcc3"
+  last_name  = "Python"
+  login      = "testAcc3-replace_with_uuid@example.com"
+  email      = "testAcc3-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test4" {
+  first_name = "TestAcc4"
+  last_name  = "Jenkins"
+  login      = "testAcc4-replace_with_uuid@example.com"
+  email      = "testAcc4-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+
+resource "okta_group_memberships" "test" {
+  group_id = okta_group.test.id
+  users = [
+    okta_user.test1.id,
+  ]
+}

--- a/examples/okta_group_memberships/basic_update.tf
+++ b/examples/okta_group_memberships/basic_update.tf
@@ -1,0 +1,58 @@
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_user" "test1" {
+  first_name = "TestAcc1"
+  last_name  = "Smith"
+  login      = "testAcc1-replace_with_uuid@example.com"
+  email      = "testAcc1-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test2" {
+  first_name = "TestAcc2"
+  last_name  = "Brando"
+  login      = "testAcc2-replace_with_uuid@example.com"
+  email      = "testAcc2-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test3" {
+  first_name = "TestAcc3"
+  last_name  = "Python"
+  login      = "testAcc3-replace_with_uuid@example.com"
+  email      = "testAcc3-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+resource "okta_user" "test4" {
+  first_name = "TestAcc4"
+  last_name  = "Jenkins"
+  login      = "testAcc4-replace_with_uuid@example.com"
+  email      = "testAcc4-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+
+
+resource "okta_group_memberships" "test" {
+  group_id = okta_group.test.id
+  users = [
+    okta_user.test1.id,
+    okta_user.test3.id,
+    okta_user.test4.id,
+  ]
+}

--- a/okta/group.go
+++ b/okta/group.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
@@ -49,4 +50,56 @@ func listGroups(ctx context.Context, client *okta.Client, qp *query.Params) ([]*
 		}
 	}
 	return resGroups, nil
+}
+
+// Group Primary Key Operations
+func addGroupMembers(ctx context.Context, client *okta.Client, groupId string, users []string) error {
+	for _, user := range users {
+		resp, err := client.Group.AddUserToGroup(ctx, groupId, user)
+		exists, err := doesResourceExist(resp, err)
+		if err != nil {
+			return fmt.Errorf("failed to add user (%s) to group (%s): %v", user, groupId, err)
+		}
+		if !exists {
+			return fmt.Errorf("targeted object does not exist: %s", err)
+		}
+	}
+	return nil
+}
+
+func removeGroupMembers(ctx context.Context, client *okta.Client, groupId string, users []string) error {
+	for _, user := range users {
+		resp, err := client.Group.RemoveUserFromGroup(ctx, groupId, user)
+		err = suppressErrorOn404(resp, err)
+		if err != nil {
+			return fmt.Errorf("failed to remove user (%s) from group (%s): %v", user, groupId, err)
+		}
+	}
+	return nil
+}
+
+//User Primary Key Operatios
+func addUserToGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
+	for _, group := range groups {
+		resp, err := client.Group.AddUserToGroup(ctx, group, userId)
+		exists, err := doesResourceExist(resp, err)
+		if err != nil {
+			return fmt.Errorf("failed to add user (%s) to group (%s): %v", userId, group, err)
+		}
+		if !exists {
+			return fmt.Errorf("targeted object does not exist: %s", err)
+		}
+	}
+	return nil
+}
+
+func removeUserFromGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
+	for _, group := range groups {
+		resp, err := client.Group.RemoveUserFromGroup(ctx, group, userId)
+		err = suppressErrorOn404(resp, err)
+		if err != nil {
+			return fmt.Errorf("failed to remove user (%s) from group (%s): %v", userId, group, err)
+		}
+	}
+	return nil
 }

--- a/okta/group.go
+++ b/okta/group.go
@@ -52,7 +52,7 @@ func listGroups(ctx context.Context, client *okta.Client, qp *query.Params) ([]*
 	return resGroups, nil
 }
 
-// Group Primary Key Operations
+// Group Primary Key Operations (Use when # groups < # users in operations)
 func addGroupMembers(ctx context.Context, client *okta.Client, groupId string, users []string) error {
 	for _, user := range users {
 		resp, err := client.Group.AddUserToGroup(ctx, groupId, user)
@@ -78,7 +78,7 @@ func removeGroupMembers(ctx context.Context, client *okta.Client, groupId string
 	return nil
 }
 
-//User Primary Key Operatios
+// User Primary Key Operations (use when # users < # groups in operations)
 func addUserToGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
 	for _, group := range groups {
 		resp, err := client.Group.AddUserToGroup(ctx, group, userId)

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -52,6 +52,7 @@ const (
 	oktaGroup              = "okta_group"
 	oktaGroups             = "okta_groups"
 	oktaGroupMembership    = "okta_group_membership"
+	oktaGroupMemberships   = "okta_group_memberships"
 	oktaProfileMapping     = "okta_profile_mapping"
 	oktaUser               = "okta_user"
 	policyMfa              = "okta_policy_mfa"
@@ -203,6 +204,7 @@ func Provider() *schema.Provider {
 			networkZone:            resourceNetworkZone(),
 			oktaGroup:              resourceGroup(),
 			oktaGroupMembership:    resourceGroupMembership(),
+			oktaGroupMemberships:   resourceGroupMemberships(),
 			oktaProfileMapping:     resourceOktaProfileMapping(),
 			oktaUser:               resourceUser(),
 			policyMfa:              resourcePolicyMfa(),

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -36,6 +36,7 @@ func resourceGroupMembership() *schema.Resource {
 				ForceNew:    true,
 			},
 		},
+		DeprecationMessage: "resource `okta_group_membersip` is now deprecated, please use `okta_group_memberships` or `okta_user_group_memberships` based applicable needs",
 	}
 }
 

--- a/okta/resource_okta_group_membership.go
+++ b/okta/resource_okta_group_membership.go
@@ -36,7 +36,7 @@ func resourceGroupMembership() *schema.Resource {
 				ForceNew:    true,
 			},
 		},
-		DeprecationMessage: "resource `okta_group_membersip` is now deprecated, please use `okta_group_memberships` or `okta_user_group_memberships` based applicable needs",
+		DeprecationMessage: "resource `okta_group_membersip` is now deprecated, please use `okta_group_memberships` or `okta_user_group_memberships` based on applicable needs",
 	}
 }
 

--- a/okta/resource_okta_group_memberships.go
+++ b/okta/resource_okta_group_memberships.go
@@ -1,0 +1,178 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func resourceGroupMemberships() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUserGroupMembershipCreate,
+		ReadContext:   resourceUserGroupMembershipRead,
+		UpdateContext: resourceUserGroupMembershipUpdate,
+		DeleteContext: resourceUserGroupMembershipDelete,
+		Importer:      nil,
+		Description:   "Resource to manage a set of group memberships for a specific user.",
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of a Okta User",
+				ForceNew:    true,
+			},
+			"groups": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "The list of Okta group IDs which the user should have membership managed for.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
+	client := getOktaClientFromMetadata(m)
+	err := addUserToGroups(ctx, client, userId, groups)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	bOff := backoff.NewExponentialBackOff()
+	bOff.MaxElapsedTime = time.Second * 10
+	bOff.InitialInterval = time.Second
+	err = backoff.Retry(func() error {
+		ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		if ok {
+			return nil
+		}
+		return fmt.Errorf("user (%s) did not have expected group memberships after multiple checks", userId)
+	}, bOff)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(userId)
+	return nil
+}
+
+func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
+	client := getOktaClientFromMetadata(m)
+	ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
+	if err != nil {
+		return diag.Errorf("unable to complete group check for user: %v", err)
+	}
+	if ok {
+		return nil
+	} else {
+		d.SetId("")
+		logger(m).Info("user (%s) did not have expected group memberships or did not exist", userId)
+		return nil
+	}
+}
+
+func resourceUserGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
+	client := getOktaClientFromMetadata(m)
+	err := removeUserFromGroups(ctx, client, userId, groups)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	client := getOktaClientFromMetadata(m)
+
+	old, new := d.GetChange("groups")
+
+	oldSet := old.(*schema.Set)
+	newSet := new.(*schema.Set)
+
+	groupsToAdd := convertInterfaceArrToStringArr(newSet.Difference(oldSet).List())
+	groupsToRemove := convertInterfaceArrToStringArr(oldSet.Difference(newSet).List())
+
+	err := addUserToGroups(ctx, client, userId, groupsToAdd)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	err = removeUserFromGroups(ctx, client, userId, groupsToRemove)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func checkIfGroupHasUsers(ctx context.Context, client *okta.Client, userId string, groups []string) (bool, error) {
+	userGroups, resp, err := client.User.ListUserGroups(ctx, userId)
+	exists, err := doesResourceExist(resp, err)
+	if err != nil {
+		return false, fmt.Errorf("unable to return groups for user (%s) from API", userId)
+	}
+
+	if !exists {
+		return false, nil
+	}
+
+	// Create set of groups
+	expectedGroupSet := make(map[string]bool)
+
+	for _, group := range groups {
+		expectedGroupSet[group] = false
+	}
+
+	// Use groups pulled from user and mark set if found
+	for _, group := range userGroups {
+		if _, ok := expectedGroupSet[group.Id]; ok {
+			expectedGroupSet[group.Id] = true
+		}
+	}
+
+	// Check set for any missing values
+	for _, state := range expectedGroupSet {
+		if !state {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func addUserToGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
+	for _, group := range groups {
+		resp, err := client.Group.AddUserToGroup(ctx, group, userId)
+		exists, err := doesResourceExist(resp, err)
+		if err != nil {
+			return fmt.Errorf("failed to add user (%s) to group (%s): %v", userId, group, err)
+		}
+		if !exists {
+			return fmt.Errorf("targeted object does not exist: %s", err)
+		}
+	}
+	return nil
+}
+
+func removeUserFromGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
+	for _, group := range groups {
+		resp, err := client.Group.RemoveUserFromGroup(ctx, group, userId)
+		err = suppressErrorOn404(resp, err)
+		if err != nil {
+			return fmt.Errorf("failed to remove user (%s) from group (%s): %v", userId, group, err)
+		}
+	}
+	return nil
+}

--- a/okta/resource_okta_group_memberships.go
+++ b/okta/resource_okta_group_memberships.go
@@ -165,28 +165,3 @@ func checkIfGroupHasUsers(ctx context.Context, client *okta.Client, groupId stri
 
 	return true, nil
 }
-
-func addGroupMembers(ctx context.Context, client *okta.Client, groupId string, users []string) error {
-	for _, user := range users {
-		resp, err := client.Group.AddUserToGroup(ctx, groupId, user)
-		exists, err := doesResourceExist(resp, err)
-		if err != nil {
-			return fmt.Errorf("failed to add user (%s) to group (%s): %v", user, groupId, err)
-		}
-		if !exists {
-			return fmt.Errorf("targeted object does not exist: %s", err)
-		}
-	}
-	return nil
-}
-
-func removeGroupMembers(ctx context.Context, client *okta.Client, groupId string, users []string) error {
-	for _, user := range users {
-		resp, err := client.Group.RemoveUserFromGroup(ctx, groupId, user)
-		err = suppressErrorOn404(resp, err)
-		if err != nil {
-			return fmt.Errorf("failed to remove user (%s) from group (%s): %v", user, groupId, err)
-		}
-	}
-	return nil
-}

--- a/okta/resource_okta_group_memberships.go
+++ b/okta/resource_okta_group_memberships.go
@@ -13,30 +13,30 @@ import (
 
 func resourceGroupMemberships() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceUserGroupMembershipCreate,
-		ReadContext:   resourceUserGroupMembershipRead,
-		UpdateContext: resourceUserGroupMembershipUpdate,
-		DeleteContext: resourceUserGroupMembershipDelete,
+		CreateContext: resourceGroupMembershipsCreate,
+		ReadContext:   resourceGroupMembershipsRead,
+		UpdateContext: resourceGroupMembershipsUpdate,
+		DeleteContext: resourceGroupMembershipsDelete,
 		Importer:      nil,
 		Description:   "Resource to manage a set of group memberships for a specific user.",
 		Schema: map[string]*schema.Schema{
-			"user_id": {
+			"group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "ID of a Okta User",
+				Description: "ID of a Okta group",
 				ForceNew:    true,
 			},
-			"groups": {
+			"users": {
 				Type:        schema.TypeSet,
 				Required:    true,
-				Description: "The list of Okta group IDs which the user should have membership managed for.",
+				Description: "The list of Okta user IDs which the group should have membership managed for.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
 }
 
-func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupMembershipsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	userId := d.Get("user_id").(string)
 	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
 	client := getOktaClientFromMetadata(m)
@@ -64,7 +64,7 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupMembershipsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	userId := d.Get("user_id").(string)
 	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
 	client := getOktaClientFromMetadata(m)
@@ -81,7 +81,7 @@ func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, m 
 	}
 }
 
-func resourceUserGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupMembershipsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	userId := d.Get("user_id").(string)
 	groups := convertInterfaceToStringSetNullable(d.Get("groups"))
 	client := getOktaClientFromMetadata(m)
@@ -92,7 +92,7 @@ func resourceUserGroupMembershipDelete(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourceGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupMembershipsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	userId := d.Get("user_id").(string)
 	client := getOktaClientFromMetadata(m)
 

--- a/okta/resource_okta_group_memberships.go
+++ b/okta/resource_okta_group_memberships.go
@@ -24,7 +24,7 @@ func resourceGroupMemberships() *schema.Resource {
 			"group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "ID of a Okta group",
+				Description: "ID of a Okta group.",
 				ForceNew:    true,
 			},
 			"users": {

--- a/okta/resource_okta_group_memberships_test.go
+++ b/okta/resource_okta_group_memberships_test.go
@@ -1,0 +1,34 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaGroupMemberships_crud(t *testing.T) {
+	ri := acctest.RandInt()
+
+	mgr := newFixtureManager(oktaGroupMemberships)
+	start := mgr.GetFixtures("basic.tf", ri, t)
+	update := mgr.GetFixtures("basic_update.tf", ri, t)
+	remove := mgr.GetFixtures("basic_removal.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: start,
+			},
+			{
+				Config: update,
+			},
+			{
+				Config: remove,
+			},
+		},
+	})
+}

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -148,28 +148,3 @@ func checkIfUserHasGroups(ctx context.Context, client *okta.Client, userId strin
 
 	return true, nil
 }
-
-func addUserToGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
-	for _, group := range groups {
-		resp, err := client.Group.AddUserToGroup(ctx, group, userId)
-		exists, err := doesResourceExist(resp, err)
-		if err != nil {
-			return fmt.Errorf("failed to add user (%s) to group (%s): %v", userId, group, err)
-		}
-		if !exists {
-			return fmt.Errorf("targeted object does not exist: %s", err)
-		}
-	}
-	return nil
-}
-
-func removeUserFromGroups(ctx context.Context, client *okta.Client, userId string, groups []string) error {
-	for _, group := range groups {
-		resp, err := client.Group.RemoveUserFromGroup(ctx, group, userId)
-		err = suppressErrorOn404(resp, err)
-		if err != nil {
-			return fmt.Errorf("failed to remove user (%s) from group (%s): %v", userId, group, err)
-		}
-	}
-	return nil
-}

--- a/website/docs/r/group_memberships.html.markdown
+++ b/website/docs/r/group_memberships.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "okta"
+page_title: "Okta: okta_group_memberships"
+sidebar_current: "docs-okta-resource-group-memberships"
+description: |-
+  Resource to manage a set of memberships for a specific group.
+---
+
+# okta_group_memberships
+
+Resource to manage a set of memberships for a specific group.
+
+This resource will allow you to bulk manage group membership in Okta for a given group. This offers an interface to pass multiple users into a single resource call, for better API resource usage. Effectively this is the same as using the `okta_group_membership` resource several times with a single group and many different users. If you need a relationship of a single user to many groups, please use the `okta_user_group_memberships` resource.
+
+When using this with a `okta_user` resource, you should add a lifecycle ignore for group memberships to avoid conflicts in desired state.
+
+## Example Usage
+
+```hcl
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+}
+
+resource "okta_group_memberships" "test" {
+  group_id = okta_group.test.id
+  users = [
+    okta_user.test1.id,
+    okta_user.test2.id,
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `group_id` - (Required) ID of a Okta group.
+- `users` - (Required) The list of Okta user IDs which the group should have membership managed for.
+
+## Attributes Reference
+
+N/A


### PR DESCRIPTION
The compliment to #416, except with the opposite relationship pattern.

* Creates `okta_group_memberships`, using the group listing endpoints for validation membership (instead of the user listing endpoints used in #416).
* Deprecates `okta_group_membership` in favor of using this or `okta_user_group_memberships`