### PR TITLE
Remove Okta User `login` ForceNew

### DIFF
--- a/examples/okta_user/login_changed.tf
+++ b/examples/okta_user/login_changed.tf
@@ -1,0 +1,6 @@
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAccUpdated-replace_with_uuid@example.com"
+  email      = "testAccUpdated-replace_with_uuid@example.com"
+}

--- a/okta/resource_okta_user.go
+++ b/okta/resource_okta_user.go
@@ -162,7 +162,6 @@ func resourceUser() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "User Okta login",
-				ForceNew:    true,
 			},
 			"manager": {
 				Type:        schema.TypeString,

--- a/okta/resource_okta_user_test.go
+++ b/okta/resource_okta_user_test.go
@@ -344,6 +344,33 @@ func TestAccOktaUser_validRole(t *testing.T) {
 	})
 }
 
+func TestAccOktaUser_loginUpdates(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(oktaUser)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updatedLogin := mgr.GetFixtures("login_changed.tf", ri, t)
+
+	resourceName := fmt.Sprintf("%s.test", oktaUser)
+	email := fmt.Sprintf("testAcc-%d@example.com", ri)
+	updatedEmail := fmt.Sprintf("testAccUpdated-%d@example.com", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.TestCheckResourceAttr(resourceName, "email", email),
+			},
+			{
+				Config: updatedLogin,
+				Check:  resource.TestCheckResourceAttr(resourceName, "email", updatedEmail),
+			},
+		},
+	})
+}
+
 func testAccCheckUserDestroy(s *terraform.State) error {
 	client := getOktaClientFromMetadata(testAccProvider.Meta())
 	for _, r := range s.RootModule().Resources {


### PR DESCRIPTION
This PR:

- Removes the `ForceNew` from the `login` field in Okta, since it's unnecessary for update (does this count as a breaking change since it alters the resource management behavior?)
- Adds a explicit test where we alter the `login` and `email` fields after user creation.