### PR TITLE
Timeout Increase

### DIFF
--- a/okta/provider.go
+++ b/okta/provider.go
@@ -164,8 +164,8 @@ func Provider() *schema.Provider {
 				Type:             schema.TypeInt,
 				Optional:         true,
 				Default:          0,
-				ValidateDiagFunc: intBetween(0, 100),
-				Description:      "Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `100`.",
+				ValidateDiagFunc: intBetween(0, 300),
+				Description:      "Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `300`.",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -100,4 +100,4 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 - `max_retries` - (Optional) Maximum number of retries to attempt before returning an error, the default is `5`.
 
-- `request_timeout` - (Optional) Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `100`.
+- `request_timeout` - (Optional) Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `300`.


### PR DESCRIPTION
I've found that when actually setting a `request_timeout` value, there are many API calls (particularly the `/apps` endpoint) which take longer than the given maximum to return from Okta, especially under API load. 

This is to bump up the maximum timeout time to 5 minutes, which seems like a good balance between what the API actually performs like and a sane "it's probably broken past this" time.