### PR TITLE
Ignore 'username' field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	github.com/hashicorp/go-hclog v0.16.0
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
-	github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef
+	github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210519105407-20ace51aad26
 )

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe h1:7++r9
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef h1:yZ1fq+7or5hZIDVGQWbNW+P55um6QEUkCAN6giBw2Ts=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
+github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210519105407-20ace51aad26 h1:GslfCBAaOiuJ04Vm/3SFptoLZm0nzdOO6DYuWGnteK4=
+github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210519105407-20ace51aad26/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/okta/resource_okta_app_auto_login.go
+++ b/okta/resource_okta_app_auto_login.go
@@ -79,10 +79,6 @@ func resourceAppAutoLoginCreate(ctx context.Context, d *schema.ResourceData, m i
 		return diag.Errorf("failed to create auto login application: %v", err)
 	}
 	d.SetId(app.Id)
-	err = handleAppGroupsAndUsers(ctx, app.Id, d, m)
-	if err != nil {
-		return diag.Errorf("failed to handle groups and users for auto login application: %v", err)
-	}
 	err = handleAppLogo(ctx, d, m, app.Id, app.Links)
 	if err != nil {
 		return diag.Errorf("failed to upload logo for auto login application: %v", err)
@@ -112,10 +108,6 @@ func resourceAppAutoLoginRead(ctx context.Context, d *schema.ResourceData, m int
 	_ = d.Set("user_name_template_suffix", app.Credentials.UserNameTemplate.Suffix)
 	_ = d.Set("logo_url", linksValue(app.Links, "logo", "href"))
 	appRead(d, app.Name, app.Status, app.SignOnMode, app.Label, app.Accessibility, app.Visibility)
-	err = syncGroupsAndUsers(ctx, app.Id, d, m)
-	if err != nil {
-		return diag.Errorf("failed to sync groups and users for auto login application: %v", err)
-	}
 	if d.HasChange("logo") {
 		err = handleAppLogo(ctx, d, m, app.Id, app.Links)
 		if err != nil {
@@ -137,10 +129,6 @@ func resourceAppAutoLoginUpdate(ctx context.Context, d *schema.ResourceData, m i
 	err = setAppStatus(ctx, d, client, app.Status)
 	if err != nil {
 		return diag.Errorf("failed to set auto login application status: %v", err)
-	}
-	err = handleAppGroupsAndUsers(ctx, app.Id, d, m)
-	if err != nil {
-		return diag.Errorf("failed to handle groups and users for auto login application: %v", err)
 	}
 	return resourceAppAutoLoginRead(ctx, d, m)
 }

--- a/website/docs/r/app_auto_login.html.markdown
+++ b/website/docs/r/app_auto_login.html.markdown
@@ -60,10 +60,6 @@ The following arguments are supported:
 
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
-- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
-
-- `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
-
 - `logo` (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 ## Attributes Reference

--- a/website/docs/r/app_user.html.markdown
+++ b/website/docs/r/app_user.html.markdown
@@ -40,7 +40,8 @@ The following arguments are supported:
 
 - `user_id` - (Required) User to associate the application with.
 
-- `username` - (Required) The username to use for the app user.
+- `username` - (Optional) The username to use for the app user. In case the user is assigned to the app with 
+  'SHARED_USERNAME_AND_PASSWORD' credentials scheme, this field will be computed and should not be set.
 
 - `password` - (Optional) The password to use.
 


### PR DESCRIPTION
Ignore 'username' field when the assigned app has 'SHARED_USERNAME_AND_PASSWORD' credentials scheme
Fix #447 