### PR TITLE
Mark App Users & Groups Schema as Deprecated

### DIFF
--- a/okta/app.go
+++ b/okta/app.go
@@ -58,12 +58,14 @@ var baseAppSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Elem:        appUserResource,
 		Description: "Users associated with the application",
+		Deprecated:  "The direct configuration of users in this app resource is deprecated, please ensure you are the resource `okta_app_user` for this functionality.",
 	},
 	"groups": {
 		Type:        schema.TypeSet,
 		Optional:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Description: "Groups associated with the application",
+		Deprecated:  "The direct configuration of users in this app resource is deprecated, please ensure you are the resource `okta_app_group_assignments` for this functionality.",
 	},
 	"status": {
 		Type:             schema.TypeString,

--- a/okta/app.go
+++ b/okta/app.go
@@ -58,14 +58,14 @@ var baseAppSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Elem:        appUserResource,
 		Description: "Users associated with the application",
-		Deprecated:  "The direct configuration of users in this app resource is deprecated, please ensure you are the resource `okta_app_user` for this functionality.",
+		Deprecated:  "The direct configuration of users in this app resource is deprecated, please ensure you use the resource `okta_app_user` for this functionality.",
 	},
 	"groups": {
 		Type:        schema.TypeSet,
 		Optional:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Description: "Groups associated with the application",
-		Deprecated:  "The direct configuration of groups in this app resource is deprecated, please ensure you are the resource `okta_app_group_assignments` for this functionality.",
+		Deprecated:  "The direct configuration of groups in this app resource is deprecated, please ensure you use the resource `okta_app_group_assignments` for this functionality.",
 	},
 	"status": {
 		Type:             schema.TypeString,

--- a/okta/app.go
+++ b/okta/app.go
@@ -65,7 +65,7 @@ var baseAppSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Description: "Groups associated with the application",
-		Deprecated:  "The direct configuration of users in this app resource is deprecated, please ensure you are the resource `okta_app_group_assignments` for this functionality.",
+		Deprecated:  "The direct configuration of groups in this app resource is deprecated, please ensure you are the resource `okta_app_group_assignments` for this functionality.",
 	},
 	"status": {
 		Type:             schema.TypeString,

--- a/website/docs/r/app_auto_login.html.markdown
+++ b/website/docs/r/app_auto_login.html.markdown
@@ -60,6 +60,12 @@ The following arguments are supported:
 
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
+- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
+
+- `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
+
 - `logo` (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 ## Attributes Reference

--- a/website/docs/r/app_basic_auth.html.markdown
+++ b/website/docs/r/app_basic_auth.html.markdown
@@ -33,8 +33,10 @@ The following arguments are supported:
 - `auth_url` - (Required) The URL of the authenticating site for this app.
 
 - `users` - (Optional) Users associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 - `groups` - (Optional) Groups associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `status` - (Optional) Status of application. (`"ACTIVE"` or `"INACTIVE"`).
 

--- a/website/docs/r/app_bookmark.html.markdown
+++ b/website/docs/r/app_bookmark.html.markdown
@@ -32,8 +32,10 @@ The following arguments are supported:
 - `request_integration` - (Optional) Would you like Okta to add an integration for this app?
 
 - `users` - (Optional) Users associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 - `groups` - (Optional) Groups associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `status` - (Optional) Status of application. (`"ACTIVE"` or `"INACTIVE"`).
 

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -52,8 +52,10 @@ The following arguments are supported:
 - `type` - (Required) The type of OAuth application. Valid values: `"web"`, `"native"`, `"browser"`, `"service"`.
 
 - `users` - (Optional) The users assigned to the application. It is recommended not to use this and instead use `okta_app_user`.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 - `groups` - (Optional) The groups assigned to the application. It is recommended not to use this and instead use `okta_app_group_assignment`.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `client_id` - (Optional) OAuth client ID. If set during creation, app is created with this id.
 

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -105,8 +105,10 @@ The following arguments are supported:
 - `acs_endpoints` - An array of ACS endpoints. You can configure a maximum of 100 endpoints.
 
 - `users` - (Optional) Users associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 - `groups` - (Optional) Groups associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `attribute_statements` - (Optional) List of SAML Attribute statements.
   - `name` - (Required) The name of the attribute statement.

--- a/website/docs/r/app_secure_password_store.html.markdown
+++ b/website/docs/r/app_secure_password_store.html.markdown
@@ -57,8 +57,10 @@ The following arguments are supported:
 - `shared_password` - (Optional) Shared password, required for certain schemes.
 
 - `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 - `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `status` - (Optional) Status of application. By default, it is `"ACTIVE"`.
 

--- a/website/docs/r/app_swa.html.markdown
+++ b/website/docs/r/app_swa.html.markdown
@@ -43,8 +43,10 @@ The following arguments are supported:
 - `url_regex` - (Optional) A regex that further restricts URL to the specified regex.
 
 - `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 - `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `status` - (Optional) Status of application. By default, it is `"ACTIVE"`.
 

--- a/website/docs/r/app_three_field.html.markdown
+++ b/website/docs/r/app_three_field.html.markdown
@@ -45,8 +45,10 @@ The following arguments are supported:
 - `url_regex` - (Optional) A regex that further restricts URL to the specified regex.
 
 - `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 - `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `status` - (Optional) Status of application. By default, it is `"ACTIVE"`.
 


### PR DESCRIPTION
These should be fully replaced by using:
Users: `okta_app_user`
Groups: `okta_app_group_assignments` 

In a future breaking change, the intent would be to remove the handling of users/groups from here since it's redundant with the usage of the resources mentioned above. Would save on API calls.