### PR TITLE
(WIP) Resource: okta_app_user_assignments

### DIFF
--- a/examples/okta_app_basic_auth/basic_updated.tf
+++ b/examples/okta_app_basic_auth/basic_updated.tf
@@ -1,11 +1,11 @@
 resource "okta_user" "user" {
   admin_roles = [
     "APP_ADMIN",
-    "USER_ADMIN"]
-  first_name  = "TestAcc"
-  last_name   = "blah"
-  login       = "testAcc-replace_with_uuid@example.com"
-  email       = "testAcc-replace_with_uuid@example.com"
+  "USER_ADMIN"]
+  first_name = "TestAcc"
+  last_name  = "blah"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
 }
 
 resource "okta_group" "group" {

--- a/examples/okta_app_group_assignment/basic.tf
+++ b/examples/okta_app_group_assignment/basic.tf
@@ -24,7 +24,7 @@ resource "okta_group" "test3" {
 }
 
 locals {
-  group_ids = tolist([okta_group.test.id,okta_group.test2.id,okta_group.test3.id])
+  group_ids = tolist([okta_group.test.id, okta_group.test2.id, okta_group.test3.id])
 }
 
 resource "okta_app_group_assignment" "test" {

--- a/examples/okta_app_group_assignment/updated.tf
+++ b/examples/okta_app_group_assignment/updated.tf
@@ -24,7 +24,7 @@ resource "okta_group" "test3" {
 }
 
 locals {
-  group_ids = tolist([okta_group.test.id,okta_group.test2.id,okta_group.test3.id])
+  group_ids = tolist([okta_group.test.id, okta_group.test2.id, okta_group.test3.id])
 }
 
 resource "okta_app_group_assignment" "test" {

--- a/examples/okta_app_group_assignments/basic.tf
+++ b/examples/okta_app_group_assignments/basic.tf
@@ -24,18 +24,18 @@ resource "okta_group" "test3" {
 }
 
 resource "okta_app_group_assignments" "test" {
-  app_id   = okta_app_oauth.test.id
+  app_id = okta_app_oauth.test.id
 
   group {
-    id = okta_group.test1.id
+    id       = okta_group.test1.id
     priority = 1
   }
   group {
-    id = okta_group.test2.id
+    id       = okta_group.test2.id
     priority = 2
   }
   group {
-    id = okta_group.test3.id
+    id       = okta_group.test3.id
     priority = 3
   }
 }

--- a/examples/okta_app_group_assignments/updated.tf
+++ b/examples/okta_app_group_assignments/updated.tf
@@ -24,14 +24,14 @@ resource "okta_group" "test3" {
 }
 
 resource "okta_app_group_assignments" "test" {
-  app_id   = okta_app_oauth.test.id
+  app_id = okta_app_oauth.test.id
 
   group {
-    id = okta_group.test1.id
+    id       = okta_group.test1.id
     priority = 2
   }
   group {
-    id = okta_group.test2.id
+    id       = okta_group.test2.id
     priority = 1
   }
 }

--- a/examples/okta_app_user_assignments/basic.tf
+++ b/examples/okta_app_user_assignments/basic.tf
@@ -1,0 +1,52 @@
+resource "okta_app_oauth" "test" {
+  label = "testAcc_replace_with_uuid"
+  type = "browser"
+  grant_types = ["authorization_code"]
+  token_endpoint_auth_method = "none"
+  redirect_uris = ["https://testing.com"]
+  response_types = ["code"]
+
+    lifecycle {
+        ignore_changes = ["users", "groups"]
+    }
+}
+
+resource "okta_user" "test1" {
+  first_name = "Test"
+  last_name = "Broker"
+  login = "testAcc_broker_replace_with_uuid@example.com"
+  email = "testAcc_broker_replace_with_uuid@example.com"
+}
+
+resource "okta_user" "test2" {
+  first_name = "Test"
+  last_name = "Python"
+  login = "testAcc_python_replace_with_uuid@example.com"
+  email = "testAcc_python_replace_with_uuid@example.com"
+}
+
+resource "okta_user" "test3" {
+  first_name = "Test"
+  last_name = "Jaeger"
+  login = "testAcc_jaeger_replace_with_uuid@example.com"
+  email = "testAcc_jaeger_replace_with_uuid@example.com"
+}
+
+resource "okta_app_user_assignments" "test" {
+  app_id = okta_app_oauth.test.id
+
+  users {
+      id = okta_user.test1.id
+      username = okta_user.test1.login
+  }
+
+  users {
+      id = okta_user.test2.id
+      username = okta_user.test2.login
+  }
+
+  users {
+      id = okta_user.test2.id
+      username = okta_user.test2.login
+  }
+}

--- a/examples/okta_app_user_assignments/updated.tf
+++ b/examples/okta_app_user_assignments/updated.tf
@@ -44,9 +44,4 @@ resource "okta_app_user_assignments" "test" {
     id       = okta_user.test2.id
     username = okta_user.test2.login
   }
-
-  users {
-    id       = okta_user.test3.id
-    username = okta_user.test3.login
-  }
 }

--- a/examples/okta_auth_server_policy/datasource.tf
+++ b/examples/okta_auth_server_policy/datasource.tf
@@ -1,18 +1,18 @@
 resource "okta_auth_server_policy" "test" {
-  status           = "ACTIVE"
-  name             = "test"
-  description      = "test"
-  priority         = 1
+  status      = "ACTIVE"
+  name        = "test"
+  description = "test"
+  priority    = 1
   client_whitelist = [
-    "ALL_CLIENTS"]
-  auth_server_id   = okta_auth_server.test.id
+  "ALL_CLIENTS"]
+  auth_server_id = okta_auth_server.test.id
 }
 
 resource "okta_auth_server" "test" {
   name        = "testAcc_replace_with_uuid"
   description = "test"
-  audiences   = [
-    "whatever.rise.zone"]
+  audiences = [
+  "whatever.rise.zone"]
 }
 
 data "okta_auth_server_policy" "test" {

--- a/examples/okta_idp_social/datasource.tf
+++ b/examples/okta_idp_social/datasource.tf
@@ -58,7 +58,7 @@ resource "okta_idp_social" "microsoft" {
   username_template = "idpuser.userPrincipalName"
   groups_action     = "ASSIGN"
   groups_assignment = [
-    okta_group.test.id]
+  okta_group.test.id]
 }
 
 resource "okta_group" "test" {

--- a/examples/okta_policy_mfa_default/basic_updated.tf
+++ b/examples/okta_policy_mfa_default/basic_updated.tf
@@ -2,7 +2,7 @@ resource "okta_policy_mfa_default" "test" {
   google_otp = {
     enroll = "OPTIONAL"
   }
-  depends_on      = [okta_factor.google_otp]
+  depends_on = [okta_factor.google_otp]
 }
 
 resource "okta_factor" "google_otp" {

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe h1:7++r96cEElvJoVHrZwT4643RpQ4R5dTEQChljJFjk54=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef h1:yZ1fq+7or5hZIDVGQWbNW+P55um6QEUkCAN6giBw2Ts=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -30,6 +30,7 @@ const (
 	appSwa                 = "okta_app_swa"
 	appSharedCredentials   = "okta_app_shared_credentials"
 	appThreeField          = "okta_app_three_field"
+	appUserAssignments     = "okta_app_user_assignments"
 	appUserSchema          = "okta_app_user_schema"
 	appUserBaseSchema      = "okta_app_user_base_schema"
 	authServer             = "okta_auth_server"
@@ -184,6 +185,7 @@ func Provider() *schema.Provider {
 			appSwa:                 resourceAppSwa(),
 			appSharedCredentials:   resourceAppSharedCredentials(),
 			appThreeField:          resourceAppThreeField(),
+			appUserAssignments:     resourceAppUserAssignments(),
 			appUserSchema:          resourceAppUserSchema(),
 			appUserBaseSchema:      resourceAppUserBaseSchema(),
 			authServer:             resourceAuthServer(),

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -121,6 +121,20 @@ func resourceOktaAppUserAssignmentsRead(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
+func resourceOktaAppUserAssignmentsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := getOktaClientFromMetadata(m)
+	appID := d.Get("app_id").(string)
+	users := d.Get("users").(*schema.Set).List()
+
+	assignments := tfUsersToUserAssignments(users...)
+
+	err := removeUserAssignments(ctx, client, appID, assignments)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
 func tfUsersToUserAssignments(users ...interface{}) map[string]okta.AppUser {
 	assignments := map[string]okta.AppUser{}
 

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -61,6 +61,7 @@ func resourceAppUserAssignments() *schema.Resource {
 							ValidateDiagFunc: stringIsJSON,
 							StateFunc:        normalizeDataJSON,
 							Optional:         true,
+							Computed:         true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								return new == ""
 							},

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -14,10 +14,10 @@ import (
 
 func resourceOktaAppUserAssignments() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: nil,
-		ReadContext:   nil,
-		UpdateContext: nil,
-		DeleteContext: nil,
+		CreateContext: resourceOktaAppUserAssignmentsCreate,
+		ReadContext:   resourceOktaAppUserAssignmentsRead,
+		UpdateContext: resourceOktaAppUserAssignmentsUpdate,
+		DeleteContext: resourceOktaAppUserAssignmentsDelete,
 		Importer:      nil,
 		Schema: map[string]*schema.Schema{
 			"app_id": {

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -61,9 +61,6 @@ func resourceAppUserAssignments() *schema.Resource {
 							ValidateDiagFunc: stringIsJSON,
 							StateFunc:        normalizeDataJSON,
 							Optional:         true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return new == ""
-							},
 						},
 						"retain_assignment": {
 							Type:        schema.TypeBool,

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -12,12 +12,12 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
 
-func resourceOktaAppUserAssignments() *schema.Resource {
+func resourceAppUserAssignments() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceOktaAppUserAssignmentsCreate,
-		ReadContext:   resourceOktaAppUserAssignmentsRead,
-		UpdateContext: resourceOktaAppUserAssignmentsUpdate,
-		DeleteContext: resourceOktaAppUserAssignmentsDelete,
+		CreateContext: resourceAppUserAssignmentsCreate,
+		ReadContext:   resourceAppUserAssignmentsRead,
+		UpdateContext: resourceAppUserAssignmentsUpdate,
+		DeleteContext: resourceAppUserAssignmentsDelete,
 		Importer:      nil,
 		Schema: map[string]*schema.Schema{
 			"app_id": {
@@ -78,7 +78,7 @@ func resourceOktaAppUserAssignments() *schema.Resource {
 	}
 }
 
-func resourceOktaAppUserAssignmentsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppUserAssignmentsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	users := d.Get("users").(*schema.Set).List()
 	client := getOktaClientFromMetadata(m)
 	appID := d.Get("app_id").(string)
@@ -92,10 +92,10 @@ func resourceOktaAppUserAssignmentsCreate(ctx context.Context, d *schema.Resourc
 
 	//okta_app_user_assignments completely controls all assignments for an application
 	d.SetId(appID)
-	return resourceOktaAppUserAssignmentsRead(ctx, d, m)
+	return resourceAppUserAssignmentsRead(ctx, d, m)
 }
 
-func resourceOktaAppUserAssignmentsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppUserAssignmentsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := getOktaClientFromMetadata(m)
 	appID := d.Get("app_id").(string)
 
@@ -121,7 +121,7 @@ func resourceOktaAppUserAssignmentsRead(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceOktaAppUserAssignmentsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppUserAssignmentsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := getOktaClientFromMetadata(m)
 	appID := d.Get("app_id").(string)
 	users := d.Get("users").(*schema.Set).List()
@@ -135,7 +135,7 @@ func resourceOktaAppUserAssignmentsDelete(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceOktaAppUserAssignmentsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppUserAssignmentsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := getOktaClientFromMetadata(m)
 	appID := d.Get("app_id").(string)
 
@@ -159,7 +159,7 @@ func resourceOktaAppUserAssignmentsUpdate(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	return resourceOktaAppUserAssignmentsRead(ctx, d, m)
+	return resourceAppUserAssignmentsRead(ctx, d, m)
 }
 
 func tfUsersToUserAssignments(users ...interface{}) map[string]okta.AppUser {

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -1,0 +1,58 @@
+package okta
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func resourceOktaAppUserAssignments() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: nil,
+		ReadContext:   nil,
+		UpdateContext: nil,
+		DeleteContext: nil,
+		Importer:      nil,
+		Schema: map[string]*schema.Schema{
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "App to associate user with",
+			},
+			"users": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "Set of users to associate with the app",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "User associated with the application",
+						},
+						"username": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"password": {
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Optional:  true,
+						},
+						"profile": {
+							Type:             schema.TypeString,
+							ValidateDiagFunc: stringIsJSON,
+							StateFunc:        normalizeDataJSON,
+							Optional:         true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return new == ""
+							},
+						},
+						"retain_assignment": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Retain the user assignment on destroy. If set to true, the resource will be removed from state but not from the Okta app.",
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -1,6 +1,11 @@
 package okta
 
-import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 func resourceOktaAppUserAssignments() *schema.Resource {
 	return &schema.Resource{
@@ -55,4 +60,8 @@ func resourceOktaAppUserAssignments() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceOktaAppUserAssignmentsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return diag.Errorf("not implemented")
 }

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -226,7 +226,7 @@ func addUserAssignments(ctx context.Context, client *okta.Client, appID string, 
 }
 
 func removeUserAssignments(ctx context.Context, client *okta.Client, appID string, assignments map[string]okta.AppUser) error {
-	for userID, _ := range assignments {
+	for userID := range assignments {
 		_, err := client.Application.DeleteApplicationUser(ctx, appID, userID, &query.Params{})
 		if err != nil {
 			return fmt.Errorf("failed to unassign user (%s) from app (%s): %s", userID, appID, err)

--- a/okta/resource_okta_app_user_assignments.go
+++ b/okta/resource_okta_app_user_assignments.go
@@ -1,10 +1,15 @@
 package okta
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
 
 func resourceOktaAppUserAssignments() *schema.Resource {
@@ -24,9 +29,20 @@ func resourceOktaAppUserAssignments() *schema.Resource {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "Set of users to associate with the app",
+				MinItems:    1,
+				Set: func(v interface{}) int {
+					buf := bytes.NewBuffer(nil)
+					user := v.(map[string]interface{})
+
+					buf.WriteString(fmt.Sprintf("%s-", user["id"].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", user["username"].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", normalizeDataJSON(user["profile"])))
+
+					return schema.HashString(buf.String())
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"user_id": {
+						"id": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "User associated with the application",
@@ -63,5 +79,71 @@ func resourceOktaAppUserAssignments() *schema.Resource {
 }
 
 func resourceOktaAppUserAssignmentsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	return diag.Errorf("not implemented")
+	users := d.Get("users").(*schema.Set).List()
+	client := getOktaClientFromMetadata(m)
+	appID := d.Get("app_id").(string)
+
+	assignments := tfUsersToUserAssignments(users...)
+
+	err := addUserAssignments(ctx, client, appID, assignments)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	//okta_app_user_assignments completely controls all assignments for an application
+	d.SetId(appID)
+	return nil //TODO: Use read function here
+}
+
+func tfUsersToUserAssignments(users ...interface{}) map[string]okta.AppUser {
+	assignments := map[string]okta.AppUser{}
+
+	for _, rawUser := range users {
+		user := rawUser.(map[string]interface{})
+
+		id := user["id"].(string)
+		if id == "" {
+			continue
+		}
+
+		username := user["username"].(string)
+
+		password := user["password"].(string)
+
+		rawProfile := user["profile"]
+		var profile interface{}
+		_ = json.Unmarshal([]byte(rawProfile.(string)), &profile)
+
+		assignments[id] = okta.AppUser{
+			Id:      id,
+			Profile: profile,
+			Credentials: &okta.AppUserCredentials{
+				UserName: username,
+				Password: &okta.AppUserPasswordCredential{
+					Value: password,
+				},
+			},
+		}
+	}
+	return assignments
+}
+
+func addUserAssignments(ctx context.Context, client *okta.Client, appID string, assignments map[string]okta.AppUser) error {
+	for userID, assignment := range assignments {
+		_, _, err := client.Application.AssignUserToApplication(ctx, appID, assignment)
+		if err != nil {
+			return fmt.Errorf("failed to assign user (%s) to app (%s): %s", userID, appID, err)
+		}
+	}
+	return nil
+}
+
+func removeUserAssignments(ctx context.Context, client *okta.Client, appID string, assignments map[string]okta.AppUser) error {
+	for userID, _ := range assignments {
+		_, err := client.Application.DeleteApplicationUser(ctx, appID, userID, &query.Params{})
+		if err != nil {
+			return fmt.Errorf("failed to unassign user (%s) from app (%s): %s", userID, appID, err)
+		}
+	}
+	return nil
 }

--- a/okta/resource_okta_app_user_assignments_test.go
+++ b/okta/resource_okta_app_user_assignments_test.go
@@ -1,0 +1,38 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAppUserAssignments_crud(t *testing.T) {
+	ri := acctest.RandInt()
+	resourceName := fmt.Sprintf("%s.test", appUserAssignments)
+	mgr := newFixtureManager(appUserAssignments)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("updated.tf", ri, t)
+
+	user1 := fmt.Sprintf("%s.test1", oktaUser)
+	user2 := fmt.Sprintf("%s.test2", oktaUser)
+	user3 := fmt.Sprintf("%s.test3", oktaUser)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				Config: updatedConfig,
+			},
+			{
+				Config: config,
+			},
+		},
+	})
+}

--- a/okta/resource_okta_app_user_assignments_test.go
+++ b/okta/resource_okta_app_user_assignments_test.go
@@ -15,9 +15,9 @@ func TestAccAppUserAssignments_crud(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("updated.tf", ri, t)
 
-	user1 := fmt.Sprintf("%s.test1", oktaUser)
-	user2 := fmt.Sprintf("%s.test2", oktaUser)
-	user3 := fmt.Sprintf("%s.test3", oktaUser)
+	// user1 := fmt.Sprintf("%s.test1", oktaUser)
+	// user2 := fmt.Sprintf("%s.test2", oktaUser)
+	// user3 := fmt.Sprintf("%s.test3", oktaUser)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -26,12 +26,21 @@ func TestAccAppUserAssignments_crud(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
+				),
 			},
 			{
 				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
+				),
 			},
 			{
 				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Creates a new resource `okta_app_user_assignments` for bulk assignment management for app users.

Details to come

TODO:
1. Need to figure out how to properly suppress the diffs on the embedded `profile` attribute when it's not being set by us.
2. Merge in changes from #477 
3. Look into handling of the `userScope` to ensure we're only reading/controlling "user" assignment.
4. Add docs
5. Add complex tests of the other major app types, particularly those which actually handle the `credentials` passed.