### PR TITLE
Fix: `listGroups` paging logic

### DIFF
--- a/okta/group.go
+++ b/okta/group.go
@@ -44,7 +44,6 @@ func listGroups(ctx context.Context, client *okta.Client, qp *query.Params) ([]*
 				return nil, err
 			}
 			groups = append(groups, nextGroups...)
-
 		} else {
 			break
 		}

--- a/okta/group.go
+++ b/okta/group.go
@@ -32,24 +32,24 @@ func listGroupUserIDs(ctx context.Context, m interface{}, id string) ([]string, 
 }
 
 func listGroups(ctx context.Context, client *okta.Client, qp *query.Params) ([]*okta.Group, error) {
-	var resGroups []*okta.Group
 	groups, resp, err := client.Group.ListGroups(ctx, qp)
 	if err != nil {
 		return nil, err
 	}
 	for {
-		resGroups = append(resGroups, groups...)
+		var nextGroups []*okta.Group
 		if resp.HasNextPage() {
-			resp, err = resp.Next(ctx, &groups)
+			resp, err = resp.Next(ctx, &nextGroups)
 			if err != nil {
 				return nil, err
 			}
-			continue
+			groups = append(groups, nextGroups...)
+
 		} else {
 			break
 		}
 	}
-	return resGroups, nil
+	return groups, nil
 }
 
 // Group Primary Key Operations (Use when # groups < # users in operations)

--- a/okta/group.go
+++ b/okta/group.go
@@ -37,8 +37,8 @@ func listGroups(ctx context.Context, client *okta.Client, qp *query.Params) ([]*
 		return nil, err
 	}
 	for {
-		var nextGroups []*okta.Group
 		if resp.HasNextPage() {
+			var nextGroups []*okta.Group
 			resp, err = resp.Next(ctx, &nextGroups)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
The paging logic was not working properly for this function. This update corrects this.

I did a couple demos of the code block since this is only really noticeable normally in terraform when you're querying over the 200 group / page limit.

The demo of the original (bad) logic is at: https://gist.github.com/ymylei/12df37c170296433ff76fde76c68eac6

The demo of the updated (good) logic is at: https://gist.github.com/ymylei/408519c7881d9bf8693bca6727d039d7

If possible @bogdanprodan-okta would you be able to merge and do a patch release of the provider with this? I'm very keen on using the `okta_groups` data source.