### PR TITLE
Deprecate `users` and `groups` field in the `okta_app_*` data sources

### DIFF
--- a/okta/data_source_okta_app.go
+++ b/okta/data_source_okta_app.go
@@ -52,12 +52,14 @@ func dataSourceApp() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Groups associated with the application",
+				Deprecated:  "The `groups` field is now deprecated for the data source `okta_app`, please replace all uses of this with: <TBD>",
 			},
 			"users": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Users associated with the application",
+				Deprecated:  "The `users` field is now deprecated for the data source `okta_app`, please replace all uses of this with: <TBD>",
 			},
 		},
 	}

--- a/okta/data_source_okta_app.go
+++ b/okta/data_source_okta_app.go
@@ -52,14 +52,14 @@ func dataSourceApp() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Groups associated with the application",
-				Deprecated:  "The `groups` field is now deprecated for the data source `okta_app`, please replace all uses of this with: <TBD>",
+				Deprecated:  "The `groups` field is now deprecated for the data source `okta_app`, please replace all uses of this with: `okta_app_group_assignments`",
 			},
 			"users": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Users associated with the application",
-				Deprecated:  "The `users` field is now deprecated for the data source `okta_app`, please replace all uses of this with: <TBD>",
+				Deprecated:  "The `users` field is now deprecated for the data source `okta_app`, please replace all uses of this with: `okta_app_user_assignments`",
 			},
 		},
 	}

--- a/okta/data_source_okta_app_oauth.go
+++ b/okta/data_source_okta_app_oauth.go
@@ -133,12 +133,14 @@ func dataSourceAppOauth() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Groups associated with the application",
+				Deprecated:  "The `groups` field is now deprecated for the data source `okta_app_oauth`, please replace all uses of this with: `okta_app_group_assignments`",
 			},
 			"users": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Users associated with the application",
+				Deprecated:  "The `users` field is now deprecated for the data source `okta_app_oauth`, please replace all uses of this with: `okta_app_user_assignments`",
 			},
 		},
 	}

--- a/okta/data_source_okta_app_saml.go
+++ b/okta/data_source_okta_app_saml.go
@@ -283,12 +283,14 @@ func dataSourceAppSaml() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Groups associated with the application",
+				Deprecated:  "The `groups` field is now deprecated for the data source `okta_app_saml`, please replace all uses of this with: `okta_app_group_assignments`",
 			},
 			"users": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Users associated with the application",
+				Deprecated:  "The `users` field is now deprecated for the data source `okta_app_saml`, please replace all uses of this with: `okta_app_user_assignments`",
 			},
 		},
 	}

--- a/website/docs/d/app.html.markdown
+++ b/website/docs/d/app.html.markdown
@@ -41,5 +41,7 @@ data "okta_app" "example" {
 - `links` - Generic JSON containing discoverable resources related to the app
 
 - `users` - List of users IDs assigned to the application.
+  - `DEPRECATED`: Please replace all usage of this field with the data source `okta_app_user_assignments`.
 
 - `groups` - List of groups IDs assigned to the application.
+  - `DEPRECATED`: Please replace all usage of this field with the data source `okta_app_group_assignments`.

--- a/website/docs/d/app_oauth.html.markdown
+++ b/website/docs/d/app_oauth.html.markdown
@@ -74,5 +74,7 @@ data "okta_app_oauth" "test" {
 - `links` - generic JSON containing discoverable resources related to the app
 
 - `users` - List of users IDs assigned to the application.
+  - `DEPRECATED`: Please replace all usage of this field with the data source `okta_app_user_assignments`.
 
 - `groups` - List of groups IDs assigned to the application.
+  - `DEPRECATED`: Please replace all usage of this field with the data source `okta_app_group_assignments`.

--- a/website/docs/d/app_saml.html.markdown
+++ b/website/docs/d/app_saml.html.markdown
@@ -117,5 +117,7 @@ data "okta_app_saml" "example" {
 - `links` - Generic JSON containing discoverable resources related to the app
 
 - `users` - List of users IDs assigned to the application.
+  - `DEPRECATED`: Please replace all usage of this field with the data source `okta_app_user_assignments`.
 
 - `groups` - List of groups IDs assigned to the application.
+  - `DEPRECATED`: Please replace all usage of this field with the data source `okta_app_group_assignments`.


### PR DESCRIPTION
Adds deprecations to these fields ahead of their removal. Requires the replacement data sources below (if deprecation messages are not going to be altered or functionality not replaced).

Replacement data sources:
- `groups`: #498 
- `users`: #501