### PR TITLE
New data source: `okta_app_group_assignments`

### DIFF
--- a/examples/okta_app_group_assignments/datasource.tf
+++ b/examples/okta_app_group_assignments/datasource.tf
@@ -40,7 +40,7 @@ resource "okta_app_group_assignments" "test" {
   }
 }
 
-data "okta_app_group_assingments" "test" {
+data "okta_app_group_assignments" "test" {
   depends_on = [okta_app_group_assignments.test]
-  id         = okta_app_oauth.id
+  id         = okta_app_oauth.test.id
 }

--- a/examples/okta_app_group_assignments/datasource.tf
+++ b/examples/okta_app_group_assignments/datasource.tf
@@ -41,5 +41,6 @@ resource "okta_app_group_assignments" "test" {
 }
 
 data "okta_app_group_assingments" "test" {
+  depends_on = [okta_app_group_assignments.test]
   id = okta_app_oauth.id
 }

--- a/examples/okta_app_group_assignments/datasource.tf
+++ b/examples/okta_app_group_assignments/datasource.tf
@@ -42,5 +42,5 @@ resource "okta_app_group_assignments" "test" {
 
 data "okta_app_group_assingments" "test" {
   depends_on = [okta_app_group_assignments.test]
-  id = okta_app_oauth.id
+  id         = okta_app_oauth.id
 }

--- a/examples/okta_app_group_assignments/datasource.tf
+++ b/examples/okta_app_group_assignments/datasource.tf
@@ -1,0 +1,45 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+
+  lifecycle {
+    ignore_changes = ["users", "groups"]
+  }
+}
+
+resource "okta_group" "test1" {
+  name = "testAcc_replace_with_uuid"
+}
+
+resource "okta_group" "test2" {
+  name = "testAcc_replace_with_uuid_2"
+}
+
+resource "okta_group" "test3" {
+  name = "testAcc_replace_with_uuid_3"
+}
+
+resource "okta_app_group_assignments" "test" {
+  app_id = okta_app_oauth.test.id
+
+  group {
+    id       = okta_group.test1.id
+    priority = 1
+  }
+  group {
+    id       = okta_group.test2.id
+    priority = 2
+  }
+  group {
+    id       = okta_group.test3.id
+    priority = 3
+  }
+}
+
+data "okta_app_group_assingments" "test" {
+  id = okta_app_oauth.id
+}

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe h1:7++r96cEElvJoVHrZwT4643RpQ4R5dTEQChljJFjk54=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef h1:yZ1fq+7or5hZIDVGQWbNW+P55um6QEUkCAN6giBw2Ts=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=

--- a/okta/data_source_okta_app_group_assignments.go
+++ b/okta/data_source_okta_app_group_assignments.go
@@ -8,9 +8,9 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
 
-func dataSourceOktaAppGroupAssignments() *schema.Resource {
+func dataSourceAppGroupAssignments() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: nil,
+		ReadContext: dataSourceAppGroupAssignmentsRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,
@@ -28,7 +28,7 @@ func dataSourceOktaAppGroupAssignments() *schema.Resource {
 	}
 }
 
-func dataSourceOktaAppGroupAssignmentsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func dataSourceAppGroupAssignmentsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := getOktaClientFromMetadata(m)
 	id := d.Get("id").(string)
 

--- a/okta/data_source_okta_app_group_assignments.go
+++ b/okta/data_source_okta_app_group_assignments.go
@@ -42,5 +42,6 @@ func dataSourceAppGroupAssignmentsRead(ctx context.Context, d *schema.ResourceDa
 		groups = append(groups, assignment.Id)
 	}
 	_ = d.Set("groups", convertStringSetToInterface(groups))
+	d.SetId(id)
 	return nil
 }

--- a/okta/data_source_okta_app_group_assignments.go
+++ b/okta/data_source_okta_app_group_assignments.go
@@ -21,7 +21,7 @@ func dataSourceAppGroupAssignments() *schema.Resource {
 			"groups": {
 				Type:        schema.TypeSet,
 				Computed:    true,
-				Elem:        schema.TypeString,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "List of groups IDs assigned to the app",
 			},
 		},

--- a/okta/data_source_okta_app_group_assignments.go
+++ b/okta/data_source_okta_app_group_assignments.go
@@ -1,0 +1,46 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func dataSourceOktaAppGroupAssignments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: nil,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the Okta App being queried for groups",
+				ForceNew:    true,
+			},
+			"groups": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        schema.TypeString,
+				Description: "List of groups IDs assigned to the app",
+			},
+		},
+	}
+}
+
+func dataSourceOktaAppGroupAssignmentsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := getOktaClientFromMetadata(m)
+	id := d.Get("id").(string)
+
+	groupAssignments, _, err := client.Application.ListApplicationGroupAssignments(ctx, id, &query.Params{})
+	if err != nil {
+		return diag.Errorf("Unable to query for groups from app (%s): %s", id, err)
+	}
+
+	var groups []string
+	for _, assignment := range groupAssignments {
+		groups = append(groups, assignment.Id)
+	}
+	_ = d.Set("groups", convertStringSetToInterface(groups))
+	return nil
+}

--- a/okta/data_source_okta_app_group_assignments_test.go
+++ b/okta/data_source_okta_app_group_assignments_test.go
@@ -1,0 +1,25 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaDataSourceAppGroupAssignments_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appGroupAssignments)
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+
+}

--- a/okta/data_source_okta_app_group_assignments_test.go
+++ b/okta/data_source_okta_app_group_assignments_test.go
@@ -18,6 +18,9 @@ func TestAccOktaDataSourceAppGroupAssignments_read(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_app_group_assignments.test", "groups.#"),
+				),
 			},
 		},
 	})

--- a/okta/data_source_okta_app_group_assignments_test.go
+++ b/okta/data_source_okta_app_group_assignments_test.go
@@ -24,5 +24,4 @@ func TestAccOktaDataSourceAppGroupAssignments_read(t *testing.T) {
 			},
 		},
 	})
-
 }

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -248,6 +248,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"okta_app":                         dataSourceApp(),
+			appGroupAssignments:                dataSourceAppGroupAssignments(),
 			appSaml:                            dataSourceAppSaml(),
 			appOAuth:                           dataSourceAppOauth(),
 			"okta_app_metadata_saml":           dataSourceAppMetadataSaml(),

--- a/website/docs/d/app_group_assignments.html.markdown
+++ b/website/docs/d/app_group_assignments.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_app_group_assignments'
+sidebar_current: 'docs-okta-datasource-app-group-assignments'
+description: |-
+Get a set of groups assigned to an Okta application.
+---
+
+
+# okta_app_group_assignments
+
+Use this data source to retrieve the list of groups assigned to the given Okta application (by ID).
+
+## Example Usage
+
+```hcl
+data "okta_app_group_assignments" "test" {
+  id         = okta_app_oauth.test.id
+}
+```
+
+## Argument Reference
+
+- `id` - (Required) The ID of the Okta application you want to retrieve the groups for.
+
+## Attribute Reference
+
+- `id` - ID of application.
+
+- `groups` - List of groups IDs assigned to the application.


### PR DESCRIPTION
Creates a new data source, intended to replace the `groups` data on the `okta_app_*` resources.

Initial implementation only provides the list of groups IDs, much like the `groups` interface does.