### PR TITLE
New data source: `okta_app_user_assignments`

### DIFF
--- a/examples/okta_app_user_assignments/datasource.tf
+++ b/examples/okta_app_user_assignments/datasource.tf
@@ -1,0 +1,30 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+
+  lifecycle {
+    ignore_changes = ["users", "groups"]
+  }
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc_replace_with_uuid@example.com"
+  email      = "testAcc_replace_with_uuid@example.com"
+}
+
+resource "okta_app_user" "test" {
+  app_id   = okta_app_oauth.test.id
+  user_id  = okta_user.test.id
+  username = okta_user.test.email
+}
+
+data "okta_app_user_assignments" "test" {
+  depends_on = [okta_app_user.test]
+  id         = okta_app_oauth.test.id
+}

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	github.com/hashicorp/go-hclog v0.16.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
-	github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210519105407-20ace51aad26
+	github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210617075430-6c6c25f48f92
 )

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe h1:7++r96cEElvJoVHrZwT4643RpQ4R5dTEQChljJFjk54=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210423115517-16a380fed4fe/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef h1:yZ1fq+7or5hZIDVGQWbNW+P55um6QEUkCAN6giBw2Ts=
 github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210513125447-0c69158bf0ef/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210519105407-20ace51aad26 h1:GslfCBAaOiuJ04Vm/3SFptoLZm0nzdOO6DYuWGnteK4=
-github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210519105407-20ace51aad26/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
+github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210617075430-6c6c25f48f92 h1:7JVUl3X2qFDqqqkFS4p1zNtvOFf+1Ms0ONn6TTTXUuE=
+github.com/okta/okta-sdk-golang/v2 v2.3.1-0.20210617075430-6c6c25f48f92/go.mod h1:G4GCqqnZJCt91zMqYhDMLhg2INVbjiiFKkQ2mnia1J0=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/okta/data_source_okta_app_user_assignments.go
+++ b/okta/data_source_okta_app_user_assignments.go
@@ -1,0 +1,61 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func dataSourceAppUserAssignments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppUserAssignmentsRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the Okta App being queried for groups",
+				ForceNew:    true,
+			},
+			"users": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of user IDs assigned to the app",
+			},
+		},
+	}
+}
+
+func dataSourceAppUserAssignmentsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := getOktaClientFromMetadata(m)
+	id := d.Get("id").(string)
+
+	userAssignments, resp, err := client.Application.ListApplicationUsers(ctx, id, &query.Params{})
+	if err != nil {
+		return diag.Errorf("unable to query for users from app (%s): %s", id, err)
+	}
+
+	for {
+		var moreAssignments []*okta.AppUser
+		if resp.HasNextPage() {
+			resp, err = resp.Next(ctx, &moreAssignments)
+			if err != nil {
+				return diag.Errorf("unable to query for users from app (%s): %s", id, err)
+			}
+			userAssignments = append(userAssignments, moreAssignments...)
+		} else {
+			break
+		}
+	}
+
+	var users []string
+	for _, assignment := range userAssignments {
+		users = append(users, assignment.Id)
+	}
+	_ = d.Set("users", convertStringSetToInterface(users))
+	d.SetId(id)
+	return nil
+}

--- a/okta/data_source_okta_app_user_assignments_test.go
+++ b/okta/data_source_okta_app_user_assignments_test.go
@@ -1,0 +1,28 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaDataSourceAppUserAssignments_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager("okta_app_user_assignments")
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_app_user_assignments.test", "users.#"),
+				),
+			},
+		},
+	})
+
+}

--- a/okta/data_source_okta_app_user_assignments_test.go
+++ b/okta/data_source_okta_app_user_assignments_test.go
@@ -24,5 +24,4 @@ func TestAccOktaDataSourceAppUserAssignments_read(t *testing.T) {
 			},
 		},
 	})
-
 }

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -251,6 +251,7 @@ func Provider() *schema.Provider {
 			appSaml:                            dataSourceAppSaml(),
 			appOAuth:                           dataSourceAppOauth(),
 			"okta_app_metadata_saml":           dataSourceAppMetadataSaml(),
+			"okta_app_user_assignments":        dataSourceAppUserAssignments(),
 			"okta_default_policies":            deprecatedPolicies,
 			"okta_default_policy":              dataSourceDefaultPolicies(),
 			"okta_everyone_group":              dataSourceEveryoneGroup(),

--- a/website/docs/d/app_user_assignments.html.markdown
+++ b/website/docs/d/app_user_assignments.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_app_user_assignments'
+sidebar_current: 'docs-okta-datasource-app-user-assignments'
+description: |-
+Get a set of users assigned to an Okta application.
+---
+
+
+# okta_app_user_assignments
+
+Use this data source to retrieve the list of users assigned to the given Okta application (by ID).
+
+## Example Usage
+
+```hcl
+data "okta_app_user_assignments" "test" {
+  id         = okta_app_oauth.test.id
+}
+```
+
+## Argument Reference
+
+- `id` - (Required) The ID of the Okta application you want to retrieve the groups for.
+
+## Attribute Reference
+
+- `id` - ID of application.
+
+- `users` - List of user IDs assigned to the application.


### PR DESCRIPTION
Creates a new data source, intended to replace the `users` data on the okta_app_* data sources.

Initial implementation only provides the list of `users` IDs, which is the same thing being provided directly in the data sources now.