### PR TITLE
Ensure logo updated when source file changes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ signs:
 release:
   # Explicit set the repo to release from. Default is origin.
   github:
-    owner: okta
+    owner: gavinbunney
     name: terraform-provider-okta
   # Visit your project's GitHub Releases page to publish this release.
   draft: true

--- a/okta/app.go
+++ b/okta/app.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/okta/terraform-provider-okta/sdk"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
@@ -79,6 +81,14 @@ var baseAppSchema = map[string]*schema.Schema{
 		Description:      "Logo of the application.",
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			return new == ""
+		},
+		StateFunc: func(val interface{}) string {
+			logoPath := val.(string)
+			if logoPath == "" {
+				return logoPath
+			}
+
+			return fmt.Sprintf("%s (%s)", logoPath, sdk.GetAppLogoHash(logoPath))
 		},
 	},
 	"logo_url": {

--- a/sdk/app_logo.go
+++ b/sdk/app_logo.go
@@ -3,8 +3,11 @@ package sdk
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"log"
 	"mime/multipart"
 	"os"
 
@@ -34,4 +37,21 @@ func (m *ApiSupplement) UploadAppLogo(ctx context.Context, appID, filename strin
 		return nil, err
 	}
 	return m.RequestExecutor.Do(ctx, req, nil)
+}
+
+func GetAppLogoHash(filename string) string {
+	file, err := os.Open(filename)
+	if err != nil {
+		return ""
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		log.Fatal(err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
Compute and store the hash of the logo alongside the path to ensure any changes to the source file are reflected on Okta. Without this change, the logo is not updated as the path attribute hasn't changed.

Fixes: #512 

Validated:
1. New logo set
2. Change logo path
3. Change logo image

### Example output

```
  ~ resource "okta_app_bookmark" "confluence" {
        id                  = "XXXXXXXXXXX"
      ~ logo                = "./../../assets/app-confluence.png (320385e0df8be4557e73dfdb2e58ca53da25ecdf8a9b85f0be4d7f61e9281681)" -> "./../../assets/app-confluence.png (6904d1f02905f4365311ec9d9e161eda995001dc122150f466922ef41f9022da)"
        name                = "bookmark"
        # (10 unchanged attributes hidden)
    }
```