### PR TITLE
Index attribute should actually be id in okta_user

### DIFF
--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -132,7 +132,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-- `index` - (Optional) ID of the User schema property.
+- `id` - (Optional) ID of the User schema property.
 
 ## Import
 


### PR DESCRIPTION
The id attribute is mistakenly called index in the documents