### PR TITLE
Added okta_user_admin_roles resources

### DIFF
--- a/examples/okta_user_admin_roles/README.md
+++ b/examples/okta_user_admin_roles/README.md
@@ -1,0 +1,7 @@
+# Okta User Group Memberships
+
+Resource to manage a set of group memberships for a specific user.
+
+[See Okta documentation regarding group operations](https://developer.okta.com/docs/reference/api/groups/#group-member-operations)
+
+A simple example of usage of this resource can be [found here](./basic.tf).

--- a/examples/okta_user_admin_roles/basic.tf
+++ b/examples/okta_user_admin_roles/basic.tf
@@ -1,0 +1,18 @@
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [admin_roles]
+  }
+}
+
+resource "okta_user_admin_roles" "test" {
+  user_id     = okta_user.test.id
+  admin_roles = [
+    "APP_ADMIN",
+    "USER_ADMIN",
+  ]
+}

--- a/examples/okta_user_admin_roles/basic_removal.tf
+++ b/examples/okta_user_admin_roles/basic_removal.tf
@@ -1,0 +1,17 @@
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [admin_roles]
+  }
+}
+
+resource "okta_user_admin_roles" "test" {
+  user_id     = okta_user.test.id
+  admin_roles = [
+    "APP_ADMIN",
+  ]
+}

--- a/examples/okta_user_admin_roles/basic_update.tf
+++ b/examples/okta_user_admin_roles/basic_update.tf
@@ -1,0 +1,19 @@
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [admin_roles]
+  }
+}
+
+resource "okta_user_admin_roles" "test" {
+  user_id     = okta_user.test.id
+  admin_roles = [
+    "APP_ADMIN",
+    "USER_ADMIN",
+    "HELP_DESK_ADMIN",
+  ]
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -73,6 +73,7 @@ const (
 	userSchema             = "okta_user_schema"
 	userType               = "okta_user_type"
 	userGroupMemberships   = "okta_user_group_memberships"
+	userAdminRoles         = "okta_user_admin_roles"
 )
 
 // Provider establishes a client connection to an okta site
@@ -227,6 +228,7 @@ func Provider() *schema.Provider {
 			userBaseSchema:         resourceUserBaseSchema(),
 			userType:               resourceUserType(),
 			userGroupMemberships:   resourceUserGroupMemberships(),
+			userAdminRoles:         resourceUserAdminRoles(),
 
 			// The day I realized I was naming stuff wrong :'-(
 			"okta_idp":                       deprecateIncorrectNaming(resourceIdpOidc(), idpOidc),

--- a/okta/resource_okta_user_admin_roles.go
+++ b/okta/resource_okta_user_admin_roles.go
@@ -1,0 +1,74 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceUserAdminRoles() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUserAdminRolesCreate,
+		ReadContext:   resourceUserAdminRolesRead,
+		UpdateContext: resourceUserAdminRolesUpdate,
+		DeleteContext: resourceUserAdminRolesDelete,
+		Importer:      nil,
+		Description:   "Resource to manage a set of administrator roles for a specific user.",
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of a Okta User",
+				ForceNew:    true,
+			},
+			"admin_roles": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "User Okta admin roles - ie. ['APP_ADMIN', 'USER_ADMIN']",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceUserAdminRolesCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	roles := convertInterfaceToStringSetNullable(d.Get("admin_roles"))
+	client := getOktaClientFromMetadata(m)
+	err := assignAdminRolesToUser(ctx, userId, roles, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(userId)
+	return nil
+}
+
+func resourceUserAdminRolesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	err := setAdminRoles(ctx, d, m)
+	if err != nil {
+		return diag.Errorf("failed to set read user's roles: %v", err)
+	}
+	return nil
+}
+
+func resourceUserAdminRolesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	client := getOktaClientFromMetadata(m)
+	err := updateAdminRolesOnUser(ctx, userId, nil, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceUserAdminRolesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	userId := d.Get("user_id").(string)
+	client := getOktaClientFromMetadata(m)
+
+	roles := convertInterfaceToStringSet(d.Get("admin_roles"))
+	if err := updateAdminRolesOnUser(ctx, userId, roles, client); err != nil {
+		return diag.Errorf("failed to update user admin roles: %v", err)
+	}
+	return nil
+}

--- a/okta/resource_okta_user_admin_roles.go
+++ b/okta/resource_okta_user_admin_roles.go
@@ -13,8 +13,14 @@ func resourceUserAdminRoles() *schema.Resource {
 		ReadContext:   resourceUserAdminRolesRead,
 		UpdateContext: resourceUserAdminRolesUpdate,
 		DeleteContext: resourceUserAdminRolesDelete,
-		Importer:      nil,
-		Description:   "Resource to manage a set of administrator roles for a specific user.",
+		Importer: &schema.ResourceImporter{
+			StateContext: func(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				_ = d.Set("user_id", d.Id())
+				d.SetId(d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+		Description: "Resource to manage a set of administrator roles for a specific user.",
 		Schema: map[string]*schema.Schema{
 			"user_id": {
 				Type:        schema.TypeString,

--- a/okta/resource_okta_user_admin_roles.go
+++ b/okta/resource_okta_user_admin_roles.go
@@ -32,7 +32,10 @@ func resourceUserAdminRoles() *schema.Resource {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "User Okta admin roles - ie. ['APP_ADMIN', 'USER_ADMIN']",
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: elemInSlice(validAdminRoles),
+				},
 			},
 		},
 	}

--- a/okta/resource_okta_user_admin_roles_test.go
+++ b/okta/resource_okta_user_admin_roles_test.go
@@ -1,0 +1,34 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaUserAdminRoles_crud(t *testing.T) {
+	ri := acctest.RandInt()
+
+	mgr := newFixtureManager(userAdminRoles)
+	start := mgr.GetFixtures("basic.tf", ri, t)
+	update := mgr.GetFixtures("basic_update.tf", ri, t)
+	remove := mgr.GetFixtures("basic_removal.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: start,
+			},
+			{
+				Config: update,
+			},
+			{
+				Config: remove,
+			},
+		},
+	})
+}

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -65,6 +65,7 @@ The following arguments are supported:
 - `custom_profile_attributes` - (Optional) raw JSON containing all custom profile attributes.
 
 - `admin_roles` - (Optional) Administrator roles assigned to User.
+  - `DEPRECATED`: Please replace usage with the `okta_user_admin_roles` resource.
 
 - `city` - (Optional) User profile property.
 

--- a/website/docs/r/user_admin_roles.html.markdown
+++ b/website/docs/r/user_admin_roles.html.markdown
@@ -3,7 +3,7 @@ layout: "okta"
 page_title: "Okta: okta_user_admin_roles"
 sidebar_current: "docs-okta-resource-user-admin-roles"
 description: |-
-  Resource to manage a set of admin rolesfor a specific user.
+  Resource to manage a set of admin roles for a specific user.
 ---
 
 # okta_user_admin_roles
@@ -47,3 +47,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 N/A
+
+## Import
+
+Existing user admin roles can be imported via the Okta User ID.
+
+```
+$ terraform import okta_user_admin_roles.example <user id>
+```

--- a/website/docs/r/user_admin_roles.html.markdown
+++ b/website/docs/r/user_admin_roles.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "okta"
+page_title: "Okta: okta_user_admin_roles"
+sidebar_current: "docs-okta-resource-user-admin-roles"
+description: |-
+  Resource to manage a set of admin rolesfor a specific user.
+---
+
+# okta_user_admin_roles
+
+Resource to manage a set of admin roles for a specific user.
+
+This resource allows you to manage admin roles for a single user, independent of the user schema itself.
+
+When using this with a `okta_user` resource, you should add a lifecycle ignore for admin roles to avoid conflicts
+in desired state.
+
+## Example Usage
+
+```hcl
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  lifecycle {
+    ignore_changes = [admin_roles]
+  }
+}
+
+resource "okta_user_admin_roles" "test" {
+  user_id     = okta_user.test.id
+  admin_roles = [
+    "APP_ADMIN",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `user_id` - (Required) ID of a Okta User.
+- `admin_roles` - (Required) The list of Okta user admin roles, e.g. `["APP_ADMIN", "USER_ADMIN"]`
+
+## Attributes Reference
+
+N/A


### PR DESCRIPTION
Allow for user admin roles to be managed outside the user schema.

Needed to allow directory based users to not have to have an explicit user schema created, and rather just manage the `admin_roles` in Terraform.

### Validation

Tested via acceptance tests