### PR TITLE
Added `dynamic_proxy_type` for `okta_network_zone` resources

### DIFF
--- a/examples/okta_network_zone/basic.tf
+++ b/examples/okta_network_zone/basic.tf
@@ -10,3 +10,10 @@ resource "okta_network_zone" "dynamic_network_zone_example" {
   type              = "DYNAMIC"
   dynamic_locations = ["US", "AF-BGL"]
 }
+
+resource "okta_network_zone" "dynamic_proxy_example" {
+  name               = "testAcc_replace_with_uuid Dynamic Proxy"
+  type               = "DYNAMIC"
+  usage              = "BLOCKLIST"
+  dynamic_proxy_type = "TorAnonymizer"
+}

--- a/examples/okta_network_zone/basic_updated.tf
+++ b/examples/okta_network_zone/basic_updated.tf
@@ -10,3 +10,10 @@ resource "okta_network_zone" "dynamic_network_zone_example" {
   type              = "DYNAMIC"
   dynamic_locations = ["US", "AF-BGL", "UA-26"]
 }
+
+resource "okta_network_zone" "dynamic_proxy_example" {
+  name               = "testAcc_replace_with_uuid Dynamic Proxy Updated"
+  type               = "DYNAMIC"
+  usage              = "POLICY"
+  dynamic_proxy_type = "NotTorAnonymizer"
+}

--- a/okta/resource_okta_network_zone.go
+++ b/okta/resource_okta_network_zone.go
@@ -26,6 +26,12 @@ func resourceNetworkZone() *schema.Resource {
 				Description: "Array of locations ISO-3166-1(2). Format code: countryCode OR countryCode-regionCode",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"dynamic_proxy_type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: stringInSlice([]string{"Any", "TorAnonymizer", "NotTorAnonymizer"}),
+				Description:      "Type of proxy being controlled by this network zone",
+			},
 			"gateways": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -86,6 +92,7 @@ func resourceNetworkZoneRead(ctx context.Context, d *schema.ResourceData, m inte
 	_ = d.Set("name", zone.Name)
 	_ = d.Set("type", zone.Type)
 	_ = d.Set("usage", zone.Usage)
+	_ = d.Set("dynamic_proxy_type", zone.ProxyType)
 	err = setNonPrimitives(d, map[string]interface{}{
 		"gateways":          flattenAddresses(zone.Gateways),
 		"proxies":           flattenAddresses(zone.Proxies),
@@ -123,6 +130,7 @@ func buildNetworkZone(d *schema.ResourceData) *sdk.NetworkZone {
 	var proxiesList []*sdk.AddressObj
 	var locationsList []*sdk.Location
 	zoneType := d.Get("type").(string)
+	proxyType := d.Get("dynamic_proxy_type").(string)
 
 	if zoneType == "IP" {
 		if values, ok := d.GetOk("gateways"); ok {
@@ -147,6 +155,7 @@ func buildNetworkZone(d *schema.ResourceData) *sdk.NetworkZone {
 		Gateways:  gatewaysList,
 		Locations: locationsList,
 		Proxies:   proxiesList,
+		ProxyType: proxyType,
 		Usage:     d.Get("usage").(string),
 	}
 }

--- a/sdk/network_zone.go
+++ b/sdk/network_zone.go
@@ -25,6 +25,7 @@ type (
 		Locations []*Location   `json:"locations,omitempty"`
 		Name      string        `json:"name,omitempty"`
 		Proxies   []*AddressObj `json:"proxies,omitempty"`
+		ProxyType string        `json:"proxyType,omitempty"`
 		System    bool          `json:"system,omitempty"`
 		Type      string        `json:"type,omitempty"`
 		Usage     string        `json:"usage,omitempty"`

--- a/website/docs/r/network_zone.html.markdown
+++ b/website/docs/r/network_zone.html.markdown
@@ -23,6 +23,17 @@ resource "okta_network_zone" "example" {
 }
 ```
 
+## Example Usage - Dynamic Tor Blocker
+
+```hcl
+resource "okta_network_zone" "example" {
+  name               = "TOR Blocker"
+  type               = "DYNAMIC"
+  usage              = "BLOCKLIST"
+  dynamic_proxy_type = "TorAnonymizer"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -33,6 +44,8 @@ The following arguments are supported:
 
 - `dynamic_locations` - (Optional) Array of locations [ISO-3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
   and [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2). Format code: countryCode OR countryCode-regionCode.
+
+- `dynamic_proxy_type` - (Optional) Type of proxy being controlled by this dynamic network zone - can be one of `Any`, `TorAnonymizer` or `NotTorAnonymizer`.
 
 - `gateways` - (Optional) Array of values in CIDR/range form.
 


### PR DESCRIPTION
Added missing `proxy_type` to the `okta_network_zone` resource, to allow configuring of the Any/Tor/NotTor proxy types allowed by the API. Updated docs & added examples.