### PR TITLE
Added issuer_mode for default auth server

### DIFF
--- a/website/docs/r/auth_server_default.html.markdown
+++ b/website/docs/r/auth_server_default.html.markdown
@@ -34,6 +34,8 @@ The following arguments are supported:
 
 - `description` - (Optional) The description of the authorization server.
 
+- `issuer_mode` - (Optional) Allows you to use a custom issuer URL. It can be set to `"CUSTOM_URL"` or `"ORG_URL"`
+
 ## Attributes Reference
 
 - `id` - ID of the authorization server.


### PR DESCRIPTION
Added missing `issuer_mode` for the default auth server resource. Copied from `resource_okta_auth_server`.