### PR TITLE
Fix handling of null credentials signing

### DIFF
--- a/okta/data_source_okta_auth_server.go
+++ b/okta/data_source_okta_auth_server.go
@@ -71,10 +71,16 @@ func dataSourceAuthServerRead(ctx context.Context, d *schema.ResourceData, m int
 	_ = d.Set("name", authServer.Name)
 	_ = d.Set("description", authServer.Description)
 	_ = d.Set("audiences", convertStringSetToInterface(authServer.Audiences))
-	_ = d.Set("credentials_rotation_mode", authServer.Credentials.Signing.RotationMode)
-	_ = d.Set("kid", authServer.Credentials.Signing.Kid)
-	_ = d.Set("credentials_next_rotation", authServer.Credentials.Signing.NextRotation.String())
-	_ = d.Set("credentials_last_rotated", authServer.Credentials.Signing.LastRotated.String())
+	if authServer.Credentials != nil && authServer.Credentials.Signing != nil {
+		_ = d.Set("kid", authServer.Credentials.Signing.Kid)
+		_ = d.Set("credentials_rotation_mode", authServer.Credentials.Signing.RotationMode)
+		if authServer.Credentials.Signing.NextRotation != nil {
+			_ = d.Set("credentials_next_rotation", authServer.Credentials.Signing.NextRotation.String())
+		}
+		if authServer.Credentials.Signing.LastRotated != nil {
+			_ = d.Set("credentials_last_rotated", authServer.Credentials.Signing.LastRotated.String())
+		}
+	}
 	_ = d.Set("status", authServer.Status)
 	_ = d.Set("issuer", authServer.Issuer)
 	// Do not sync these unless the issuer mode is specified since it is an EA feature


### PR DESCRIPTION
Credentials signing can be empty for the default auth server. This change adds explicit handling for that scenario.

Fixes ported from same changes done in `resource_okta_default_auth_server.go`.

Currently fetching an auth server without these results in a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a88d1d]

goroutine 53 [running]:
github.com/okta/terraform-provider-okta/okta.dataSourceAuthServerRead(0x1f9a118, 0xc00010d9e0, 0xc000292780, 0x1c31980, 0xc0002b0540, 0xc00026bc00, 0xc00014f948, 0x100df38)
	github.com/okta/terraform-provider-okta/okta/data_source_okta_auth_server.go:76 +0x37d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc00021ec40, 0x1f9a0a8, 0xc00073d2c0, 0xc000292780, 0x1c31980, 0xc0002b0540, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:347 +0x17f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc00021ec40, 0x1f9a0a8, 0xc00073d2c0, 0xc000a22d40, 0x1c31980, 0xc0002b0540, 0xc0002b0540, 0xc000a22d40, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:558 +0xfd
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc000284f30, 0x1f9a0a8, 0xc00073d2c0, 0xc000a22ba0, 0xc00073d2c0, 0x100b665, 0x1d001a0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/grpc_provider.go:1105 +0x4d6
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadDataSource(0xc00055ff60, 0x1f9a150, 0xc00073d2c0, 0xc00063a730, 0xc00055ff60, 0xc000765020, 0xc0006b0ba0)
	github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:247 +0xe5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler(0x1d434c0, 0xc00055ff60, 0x1f9a150, 0xc000765020, 0xc00010d8c0, 0x0, 0x1f9a150, 0xc000765020, 0xc0001720c0, 0xb9)
	github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002af6c0, 0x1fa4198, 0xc000103380, 0xc00096c100, 0xc0001e6630, 0x258ad30, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc0002af6c0, 0x1fa4198, 0xc000103380, 0xc00096c100, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc000118260, 0xc0002af6c0, 0x1fa4198, 0xc000103380, 0xc00096c100)
	google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
```