### PR TITLE
fixed create/update resource_app_user_custom_schema_property operation

### DIFF
--- a/okta/resource_okta_app_user_custom_schema_property.go
+++ b/okta/resource_okta_app_user_custom_schema_property.go
@@ -152,11 +152,7 @@ func resourceAppUserSchemaRead(ctx context.Context, d *schema.ResourceData, m in
 	}
 	if err != nil {
 		return diag.Errorf("failed to set application user schema properties: %v", err)
-	} else {
-		out, err := json.Marshal(d)
-		fmt.Println(string(out))
 	}
-
 	return nil
 }
 

--- a/okta/resource_okta_app_user_custom_schema_property.go
+++ b/okta/resource_okta_app_user_custom_schema_property.go
@@ -152,7 +152,11 @@ func resourceAppUserSchemaRead(ctx context.Context, d *schema.ResourceData, m in
 	}
 	if err != nil {
 		return diag.Errorf("failed to set application user schema properties: %v", err)
+	} else {
+		out, err := json.Marshal(d)
+		fmt.Println(string(out))
 	}
+
 	return nil
 }
 

--- a/okta/resource_okta_app_user_custom_schema_property.go
+++ b/okta/resource_okta_app_user_custom_schema_property.go
@@ -24,7 +24,7 @@ func resourceAppUserSchemaProperty() *schema.Resource {
 			userSchemaSchema,
 			userBaseSchemaSchema,
 			userTypeSchema,
-			userPatternSchema,
+			// userPatternSchema,
 			map[string]*schema.Schema{
 				"app_id": {
 					Type:     schema.TypeString,


### PR DESCRIPTION
removed `pattern` attribute from schema property, as it's not accepted by POST call to update app user profile schema