### PR TITLE
Add pagination when getting user groups

### DIFF
--- a/okta/user.go
+++ b/okta/user.go
@@ -320,18 +320,33 @@ func setAllGroups(ctx context.Context, d *schema.ResourceData, c *okta.Client) e
 
 // set groups attached to the user that can be changed
 func setGroups(ctx context.Context, d *schema.ResourceData, c *okta.Client) error {
-	groups, _, err := c.User.ListUserGroups(ctx, d.Id())
+	groups, response, err := c.User.ListUserGroups(ctx, d.Id())
 	if err != nil {
 		return fmt.Errorf("failed to list user groups: %v", err)
 	}
+
 	groupIDs := make([]interface{}, 0)
-	// ignore saving build-in or app groups into state so we don't end up with perpetual diffs,
-	// because it's impossible to remove user from build-in or app group via API
-	for _, group := range groups {
-		if group.Type != "BUILT_IN" && group.Type != "APP_GROUP" {
-			groupIDs = append(groupIDs, group.Id)
+
+	for {
+		// ignore saving build-in or app groups into state so we don't end up with perpetual diffs,
+		// because it's impossible to remove user from build-in or app group via API
+		for _, group := range groups {
+			if group.Type != "BUILT_IN" && group.Type != "APP_GROUP" {
+				groupIDs = append(groupIDs, group.Id)
+			}
+		}
+
+		if !response.HasNextPage() {
+			break
+		}
+
+		response, err = response.Next(ctx, &groups)
+
+		if err != nil {
+			return fmt.Errorf("failed to list user groups: %v", err)
 		}
 	}
+
 	return setNonPrimitives(d, map[string]interface{}{
 		"group_memberships": schema.NewSet(schema.HashString, groupIDs),
 	})

--- a/okta/user_test.go
+++ b/okta/user_test.go
@@ -1,0 +1,95 @@
+package okta
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func NewTestHttpClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: fn,
+	}
+}
+
+func TestUserSetAllGroups(t *testing.T) {
+	s := dataSourceUser().Schema
+	d := schema.TestResourceDataRaw(t, s, map[string]interface{}{
+		"id": "foo",
+	})
+	ctx := context.Background()
+
+	firstPageOfGroups, err := json.Marshal([]*okta.Group{
+		{Id: "foo"},
+		{Id: "bar"},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondPageOfGroups, err := json.Marshal([]*okta.Group{
+		{Id: "baz"},
+		{Id: "qux"},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewTestHttpClient(func(req *http.Request) *http.Response {
+		q := req.URL.Query()
+
+		if q.Has("after") {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(secondPageOfGroups)),
+				Header:     make(http.Header),
+			}
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader(firstPageOfGroups)),
+			Header: http.Header{
+				"Link": []string{"<https://foo.okta.com?limit=2&after=0>; rel=\"next\""},
+			},
+		}
+	})
+
+	oktaCtx, c, err := okta.NewClient(
+		ctx,
+		okta.WithOrgUrl("https://foo.okta.com"),
+		okta.WithToken("f0oT0k3n"),
+		okta.WithHttpClientPtr(h),
+	)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = setAllGroups(oktaCtx, d, c)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	groups := convertInterfaceToStringSetNullable(d.Get("group_memberships"))
+
+	if len(groups) != 4 {
+		t.Fatalf("expected 4 groups; got %d", len(groups))
+	}
+
+}

--- a/okta/utils_for_test.go
+++ b/okta/utils_for_test.go
@@ -1,11 +1,14 @@
 package okta
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
 type checkUpstream func(string) (bool, error)
@@ -68,4 +71,35 @@ func condenseError(errorList []error) error {
 		}
 	}
 	return fmt.Errorf("series of errors occurred: %s", strings.Join(msgList, ", "))
+}
+
+type roundTripFunc func(req *http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func newTestHttpClient(fn roundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: fn,
+	}
+}
+
+func newTestOktaClientWithResponse(response roundTripFunc) (context.Context, *okta.Client, error) {
+	ctx := context.Background()
+
+	h := newTestHttpClient(response)
+
+	oktaCtx, c, err := okta.NewClient(
+		ctx,
+		okta.WithOrgUrl("https://foo.okta.com"),
+		okta.WithToken("f0oT0k3n"),
+		okta.WithHttpClientPtr(h),
+	)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oktaCtx, c, nil
 }


### PR DESCRIPTION
We have users with a lot of groups assigned. More than the 200 default limit. When getting groups, we're seeing transient errors due to whether or not a particular group we're interested in is present in that first set of 200. This will use the okta client's built in pagination support to keep fetching groups until there are no more pages.