### PR TITLE
Changes app.logo description to more accurately reflect its usage

### DIFF
--- a/okta/app.go
+++ b/okta/app.go
@@ -98,7 +98,7 @@ var (
 			Type:             schema.TypeString,
 			Optional:         true,
 			ValidateDiagFunc: logoValid(),
-			Description:      "Logo of the application.",
+			Description:      "Local path to logo of the application.",
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 				return new == ""
 			},

--- a/website/docs/r/app_auto_login.html.markdown
+++ b/website/docs/r/app_auto_login.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 - `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
   - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `admin_note` - (Optional) Application notes for admins.
 

--- a/website/docs/r/app_basic_auth.html.markdown
+++ b/website/docs/r/app_basic_auth.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `admin_note` - (Optional) Application notes for admins.
 

--- a/website/docs/r/app_bookmark.html.markdown
+++ b/website/docs/r/app_bookmark.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `admin_note` - (Optional) Application notes for admins.
 

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -116,7 +116,7 @@ The following arguments are supported:
 
 - `login_scopes` - (Optional) List of scopes to use for the request. Valid values: `"openid"`, `"profile"`, `"email"`, `"address"`, `"phone"`. Required when `login_mode` is NOT `DISABLED`.
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `groups_claim` - (Optional) Groups claim for an OpenID Connect client application.
   - `type` - (Required) Groups claim type. Valid values: `"FILTER"`, `"EXPRESSION"`.

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -244,7 +244,7 @@ The following arguments are supported:
 - `single_logout_certificate` - (Optional) x509 encoded certificate that the Service Provider uses to sign Single Logout requests.
   Note: should be provided without `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`, see [official documentation](https://developer.okta.com/docs/reference/api/apps/#service-provider-certificate).
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `admin_note` - (Optional) Application notes for admins.
 

--- a/website/docs/r/app_shared_credentials.html.markdown
+++ b/website/docs/r/app_shared_credentials.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 - `label` - (Required) The Application's display name.
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `password_field` - (Optional) CSS selector for the Password field in the sign-in form.
 

--- a/website/docs/r/app_swa.html.markdown
+++ b/website/docs/r/app_swa.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 - `hide_web` - (Optional) Do not display application icon to users.
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `admin_note` - (Optional) Application notes for admins.
 

--- a/website/docs/r/app_three_field.html.markdown
+++ b/website/docs/r/app_three_field.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 - `hide_web` - (Optional) Do not display application icon to users.
 
-- `logo` - (Optional) Application logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `admin_note` - (Optional) Application notes for admins.
 


### PR DESCRIPTION
It is unclear whether this field should contain some sort of binary data, or a file path.  This PR makes a small adjustment to the docs.  I'm open to suggestions if you think something else would be amore appropriate