### PR TITLE
[WIP] Add Device Authorization grant type to okta_oauth_app resource

### DIFF
--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -23,11 +23,12 @@ type (
 
 // I wish the SDK provided these
 const (
-	authorizationCode string = "authorization_code"
-	implicit          string = "implicit"
-	password          string = "password"
-	refreshToken      string = "refresh_token"
-	clientCredentials string = "client_credentials"
+	authorizationCode   string = "authorization_code"
+	implicit            string = "implicit"
+	password            string = "password"
+	refreshToken        string = "refresh_token"
+	clientCredentials   string = "client_credentials"
+	deviceAuthorization string = "urn:ietf:params:oauth:grant-type:device_code"
 )
 
 // Building out structure for the conditional validation logic. It looks like customizing the diff
@@ -56,6 +57,7 @@ var appGrantTypeMap = map[string]*applicationMap{
 			implicit,
 			refreshToken,
 			password,
+			deviceAuthorization,
 		},
 	},
 	"browser": {
@@ -220,7 +222,7 @@ func resourceAppOAuth() *schema.Resource {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
-					ValidateDiagFunc: elemInSlice([]string{authorizationCode, implicit, password, refreshToken, clientCredentials}),
+					ValidateDiagFunc: elemInSlice([]string{authorizationCode, implicit, password, refreshToken, clientCredentials, deviceAuthorization}),
 				},
 				Optional:    true,
 				Description: "List of OAuth 2.0 grant types. Conditional validation params found here https://developer.okta.com/docs/api/resources/apps#credentials-settings-details. Defaults to minimum requirements per app type.",


### PR DESCRIPTION
First PR here, so I may have missed a step or two in the contributing doc.

Native OAuth apps can use the "Device Authorization" grant if that early access feature is enabled. In our case it is, and we have to add it manually using the Okta console, only for it to be removed if our automation is run. It is an early access feature, but it appears to be nearing release and would be nice to include.