### PR TITLE
docs: fix typo and deprecation warning

### DIFF
--- a/website/docs/r/app_user.html.markdown
+++ b/website/docs/r/app_user.html.markdown
@@ -12,11 +12,11 @@ Creates an Application User.
 
 This resource allows you to create and configure an Application User.
 
-**When using this resource, make sure to add the following `lifefycle` argument to the application resource you are assigning to:**
+**When using this resource, make sure to add the following `lifecycle` argument to the application resource you are assigning to:**
 
 ```hcl
 lifecycle {
-  ignore_changes = ["users"]
+  ignore_changes = [users]
 }
 ```
 


### PR DESCRIPTION
lifefycle->lifecycle

> references are expected literally rather than in quotes

Matching the lifecycle block in [okta_app_group_assignment](https://github.com/okta/terraform-provider-okta/blob/master/website/docs/r/app_group_assignment.html.markdown)