### PR TITLE
Update supported scopes

### DIFF
--- a/okta/resource_okta_app_oauth_api_scope.go
+++ b/okta/resource_okta_app_oauth_api_scope.go
@@ -10,10 +10,13 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
+# validScopes is a list of supported scopes as per https://developer.okta.com/docs/guides/implement-oauth-for-okta/scopes/.
 var validScopes = []string{
 	"okta.apps.manage", "okta.apps.read",
 	"okta.authorizationServers.manage", "okta.authorizationServers.read",
 	"okta.clients.manage", "okta.clients.read", "okta.clients.register",
+	"okta.devices.manage", "okta.devices.read",
+	"okta.domains.manage", "okta.domains.read",
 	"okta.eventHooks.manage", "okta.eventHooks.read",
 	"okta.events.read",
 	"okta.factors.manage", "okta.factors.read",


### PR DESCRIPTION
This aligns the scopes with the supported list provided via https://developer.okta.com/docs/guides/implement-oauth-for-okta/scopes/#scope-naming.