### PR TITLE
Use a correct comment type

### DIFF
--- a/okta/resource_okta_app_oauth_api_scope.go
+++ b/okta/resource_okta_app_oauth_api_scope.go
@@ -10,7 +10,7 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
-# validScopes is a list of supported scopes as per https://developer.okta.com/docs/guides/implement-oauth-for-okta/scopes/.
+// validScopes is a list of supported scopes as per https://developer.okta.com/docs/guides/implement-oauth-for-okta/scopes/.
 var validScopes = []string{
 	"okta.apps.manage", "okta.apps.read",
 	"okta.authorizationServers.manage", "okta.authorizationServers.read",


### PR DESCRIPTION
Fixes the error `invalid character U+0023 '#'` as spotted by @monde 

This issue was introduced in https://github.com/okta/terraform-provider-okta/pull/712 and sadly not caught by a linter in the CI.