### PR TITLE
Field `always_include_in_token` is now editable for all the default claims except `sub`

### DIFF
--- a/examples/okta_auth_server_claim_default/updated.tf
+++ b/examples/okta_auth_server_claim_default/updated.tf
@@ -1,0 +1,11 @@
+resource "okta_auth_server_claim_default" "test" {
+  name                    = "address"
+  auth_server_id          = okta_auth_server.test.id
+  always_include_in_token = true
+}
+
+resource "okta_auth_server" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "test"
+  audiences   = ["whatever.rise.zone"]
+}

--- a/okta/resource_okta_auth_server_claim_default_test.go
+++ b/okta/resource_okta_auth_server_claim_default_test.go
@@ -13,6 +13,7 @@ func TestAccOktaAuthServerClaimDefault(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", authServerClaimDefault)
 	mgr := newFixtureManager(authServerClaimDefault)
 	config := mgr.GetFixtures("basic.tf", ri, t)
+	updated := mgr.GetFixtures("updated.tf", ri, t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProvidersFactories,
@@ -25,6 +26,17 @@ func TestAccOktaAuthServerClaimDefault(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "address"),
 					resource.TestCheckResourceAttr(resourceName, "value_type", "SYSTEM"),
 					resource.TestCheckResourceAttr(resourceName, "claim_type", "IDENTITY"),
+					resource.TestCheckResourceAttr(resourceName, "always_include_in_token", "false"),
+				),
+			},
+			{
+				Config: updated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
+					resource.TestCheckResourceAttr(resourceName, "name", "address"),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "SYSTEM"),
+					resource.TestCheckResourceAttr(resourceName, "claim_type", "IDENTITY"),
+					resource.TestCheckResourceAttr(resourceName, "always_include_in_token", "true"),
 				),
 			},
 		},


### PR DESCRIPTION
Fix #781