### PR TITLE
Ensure the name is sync'd on read in okta_domain resource

### DIFF
--- a/okta/resource_okta_domain.go
+++ b/okta/resource_okta_domain.go
@@ -99,6 +99,9 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, m interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	d.Set("name", domain.Domain)
+
 	if vd != nil {
 		_ = d.Set("validation_status", vd.ValidationStatus)
 	} else {


### PR DESCRIPTION
This ensures on state refresh and import, the "name" property is kept in sync. The name property is a ForceNew=true property and thus this is vital. Without it, when you import a domain, it will always recreate the resource. I sadly do not have an env setup to run acc tests, hoping a maintainer is able to validate the tests.

Fixes #844 