### PR TITLE
Support Okta Managed certificates

### DIFF
--- a/okta/resource_okta_domain.go
+++ b/okta/resource_okta_domain.go
@@ -25,6 +25,12 @@ func resourceDomain() *schema.Resource {
 				Description: "Custom Domain name",
 				ForceNew:    true,
 			},
+			"certificate_source_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Optional. Certificate source type that indicates whether the certificate is provided by the user or Okta. Accepted values: MANUAL, OKTA_MANAGED. Warning: Use of OKTA_MANAGED requires a feature flag to be enabled. Default value = MANUAL",
+				Default:     "MANUAL",
+			},
 			"verify": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -167,6 +173,6 @@ func validateDomain(ctx context.Context, d *schema.ResourceData, m interface{}, 
 func buildDomain(d *schema.ResourceData) okta.Domain {
 	return okta.Domain{
 		Domain:                d.Get("name").(string),
-		CertificateSourceType: "MANUAL",
+		CertificateSourceType: d.Get("certificate_source_type").(string),
 	}
 }

--- a/okta/resource_okta_domain_verification.go
+++ b/okta/resource_okta_domain_verification.go
@@ -36,7 +36,7 @@ func resourceDomainVerificationCreate(ctx context.Context, d *schema.ResourceDat
 		if err != nil {
 			return backoff.Permanent(fmt.Errorf("failed to verify domain: %v", err))
 		}
-		if domain.ValidationStatus != "VERIFIED" {
+		if !isDomainValidated(domain.ValidationStatus) {
 			return fmt.Errorf("failed to verify domain after several attempts, current validation status: %s", domain.ValidationStatus)
 		}
 		return nil
@@ -56,4 +56,14 @@ func resourceDomainVerificationRead(ctx context.Context, d *schema.ResourceData,
 // nothing to do here, since domain cannot be re-verified
 func resourceDomainVerificationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	return nil
+}
+
+// Status of the domain. Accepted values: NOT_STARTED, IN_PROGRESS, VERIFIED, COMPLETED
+func isDomainValidated(validationStatus string) bool {
+	switch validationStatus {
+		case "VERIFIED":
+		case "COMPLETED":
+			return true
+	}
+	return false
 }

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -24,7 +24,11 @@ The following arguments are supported:
 
 - `name` - (Required) Custom Domain name.
 
-- `verify` - (Optional) Indicates whether the domain should be verified. 
+- `certificate_source_type` - (Optional) Certificate source type that indicates whether the certificate is provided by the user or Okta. Accepted values: `MANUAL`, `OKTA_MANAGED`. Default value = `MANUAL`
+
+  ~> **WARNING**: Use of `OKTA_MANAGED` requires a feature flag to be enabled.
+
+- `verify` - (Optional) Indicates whether the domain should be verified.
   - `DEPRECATED`: Please use `okta_domain_verification` resource instead.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes #882 

Confirmed locally testing creation of new `OKTA_MANAGED` cert and getting the resource to create/manage it. The READ wasn't necessary as originally suspected it was since I guess we still won't import but handle it first time on create which works properly handling the other success case `COMPLETED`.

Backwards compatible with the addition of the `certificate_source_type` parameter by using existing default value of `MANUAL` and setting as optional. Ideally, it might make sense to change this to **required** on next version bump and remove the `MANUAL` as default as it's really an explicit user choice (and this mirrors the Okta API). If that were a preference for next version, I could quickly update.

/cc @bogdanprodan-okta 