### PR TITLE
API Mutex Test Fixes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,6 +22,9 @@ dep: # Download required dependencies
 build: fmtcheck
 	go install
 
+clean:
+	go clean -cache -testcache -modcache ./...
+
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,6 +23,9 @@ build: fmtcheck
 	go install
 
 clean:
+	go clean -cache -testcache ./...
+
+clean-all:
 	go clean -cache -testcache -modcache ./...
 
 sweep:

--- a/okta/internal/apimutex/apimutex_test.go
+++ b/okta/internal/apimutex/apimutex_test.go
@@ -86,8 +86,8 @@ func TestGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("api mutex constructor had error %+v", err)
 	}
-	if len(amu.status) != 13 {
-		t.Fatalf("amu status map should sized 13 but was sized %d", len(amu.status))
+	if len(amu.status) != 14 {
+		t.Fatalf("amu status map should sized 14 but was sized %d", len(amu.status))
 	}
 	keys := []string{
 		"users",

--- a/okta/internal/apimutex/apimutex_test.go
+++ b/okta/internal/apimutex/apimutex_test.go
@@ -92,10 +92,17 @@ func TestGet(t *testing.T) {
 	keys := []string{
 		"users",
 		"user-id",
+		"user-me",
+		"user-id-get",
 		"apps",
 		"app-id",
 		"groups",
 		"group-id",
+		"cas-id",
+		"clients",
+		"devices",
+		"events",
+		"logs",
 		"other",
 	}
 	for _, key := range keys {


### PR DESCRIPTION
Resolves some issues with the unit test `TestGet` for the API mutex due to previous changes.

Also adds two commands to the `GNUmakefile`:
- `clean`: for cleaning the go build && test caches
- `clean-all`: for cleaning the go build, test, && mod caches