### PR TITLE
Update profile mapping docs with OAuth2 scopes

### DIFF
--- a/website/docs/d/user_profile_mapping_source.html.markdown
+++ b/website/docs/d/user_profile_mapping_source.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to retrieve the base user Profile Mapping source or target from Okta.
 
+-> **NOTE:** If using this resource with OAuth2 scopes, this resource requires `okta.profileMappings.read` scope.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/profile_mapping.html.markdown
+++ b/website/docs/r/profile_mapping.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # okta_profile_mapping
 
-This resource allows you to manage a profile mapping by source and target IDs. 
+This resource allows you to manage a profile mapping by source and target IDs.
 
-~> **WARNING:** This feature available only when using api token in the provider config.
+-> **NOTE:** If using this resource with OAuth2 scopes, this resource requires `okta.profileMappings.manage` scope.
 
 ## Example Usage
 


### PR DESCRIPTION
Small documentation only update that removes warning that is no longer accurate as Okta has recently added `profileMappings` scope for the Mappings API.

Fixes: #927 

