### PR TITLE
API Mutex Fix For `apps/{id}` endpoint

### DIFF
--- a/okta/internal/apimutex/apimutex.go
+++ b/okta/internal/apimutex/apimutex.go
@@ -146,11 +146,15 @@ func (m *APIMutex) normalizeKey(method, endPoint string) string {
 	postPutDelete := (http.MethodPost == method) ||
 		(http.MethodPut == method) ||
 		(http.MethodDelete == method)
+	getPostPutDelete := (http.MethodGet == method) ||
+		(http.MethodPost == method) ||
+		(http.MethodPut == method) ||
+		(http.MethodDelete == method)
 	var result string
 
 	switch {
-	//  1. [GET|PUT|DELETE] /api/v1/apps/${id}
-	case reAppId.MatchString(endPoint) && getPutDelete:
+	//  1. [GET|POST|PUT|DELETE] /api/v1/apps/${id}
+	case reAppId.MatchString(endPoint) && getPostPutDelete:
 		result = APPID_KEY
 
 	//  2. starts with /api/v1/apps

--- a/okta/internal/apimutex/apimutex.go
+++ b/okta/internal/apimutex/apimutex.go
@@ -126,7 +126,7 @@ func (m *APIMutex) Status(method, endPoint string) *APIStatus {
 }
 
 var (
-	reAppId   = regexp.MustCompile("/api/v1/apps/[^/]+$")
+	reAppId   = regexp.MustCompile(`/api/v1/apps/[^/]+[/\w]*$`)
 	reGroupId = regexp.MustCompile("/api/v1/groups/[^/]+$")
 	reUserId  = regexp.MustCompile("/api/v1/users/[^/]+$")
 )

--- a/okta/internal/apimutex/apimutex_test.go
+++ b/okta/internal/apimutex/apimutex_test.go
@@ -125,6 +125,12 @@ func TestNormalizeKey(t *testing.T) {
 		{method: http.MethodPut, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
 		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
 		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/users", expected: "apps-id"},
+		{method: http.MethodPost, endPoint: "/api/v1/apps/TESTID/users/USERID", expected: "apps-id"},
+		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID/users/USERID", expected: "apps-id"},
+		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/groups", expected: "apps-id"},
+		{method: http.MethodPut, endPoint: "/api/v1/apps/TESTID/groups/GROUPID", expected: "apps-id"},
+		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID/groups/GROUPID", expected: "apps-id"},
+		{method: http.MethodPost, endPoint: "/api/v1/apps/TESTID/logo", expected: "apps-id"},
 
 		//  2. starts with /api/v1/apps
 		{method: http.MethodGet, endPoint: "/api/v1/apps", expected: "apps"},

--- a/okta/internal/apimutex/apimutex_test.go
+++ b/okta/internal/apimutex/apimutex_test.go
@@ -124,10 +124,10 @@ func TestNormalizeKey(t *testing.T) {
 		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
 		{method: http.MethodPut, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
 		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
+		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/users", expected: "apps-id"},
 
 		//  2. starts with /api/v1/apps
 		{method: http.MethodGet, endPoint: "/api/v1/apps", expected: "apps"},
-		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/users", expected: "apps"},
 
 		//  3. [GET|PUT|DELETE] /api/v1/groups/${id}
 		{method: http.MethodGet, endPoint: "/api/v1/groups/TESTID", expected: "group-id"},

--- a/okta/internal/apimutex/apimutex_test.go
+++ b/okta/internal/apimutex/apimutex_test.go
@@ -120,17 +120,17 @@ func TestNormalizeKey(t *testing.T) {
 		endPoint string
 		expected string
 	}{
-		//  1. [GET|PUT|DELETE] /api/v1/apps/${id}
+		//  1. [GET|POST|PUT|DELETE] /api/v1/apps/${id}
 		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
 		{method: http.MethodPut, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
 		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID", expected: "app-id"},
-		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/users", expected: "apps-id"},
-		{method: http.MethodPost, endPoint: "/api/v1/apps/TESTID/users/USERID", expected: "apps-id"},
-		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID/users/USERID", expected: "apps-id"},
-		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/groups", expected: "apps-id"},
-		{method: http.MethodPut, endPoint: "/api/v1/apps/TESTID/groups/GROUPID", expected: "apps-id"},
-		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID/groups/GROUPID", expected: "apps-id"},
-		{method: http.MethodPost, endPoint: "/api/v1/apps/TESTID/logo", expected: "apps-id"},
+		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/users", expected: "app-id"},
+		{method: http.MethodPost, endPoint: "/api/v1/apps/TESTID/users/USERID", expected: "app-id"},
+		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID/users/USERID", expected: "app-id"},
+		{method: http.MethodGet, endPoint: "/api/v1/apps/TESTID/groups", expected: "app-id"},
+		{method: http.MethodPut, endPoint: "/api/v1/apps/TESTID/groups/GROUPID", expected: "app-id"},
+		{method: http.MethodDelete, endPoint: "/api/v1/apps/TESTID/groups/GROUPID", expected: "app-id"},
+		{method: http.MethodPost, endPoint: "/api/v1/apps/TESTID/logo", expected: "app-id"},
 
 		//  2. starts with /api/v1/apps
 		{method: http.MethodGet, endPoint: "/api/v1/apps", expected: "apps"},


### PR DESCRIPTION
This corrects the behavior of the API mutex to ensure that all the per app operations are correctly being allocated to the RL bucket for the individual app endpoint (per #913), instead of being allocated to the top level bucket.

Test Results:
```
➜  terraform-provider-okta git:(rl-bucket-fix) make test
go mod tidy
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
go test: -i flag is deprecated
echo $(go list ./... |grep -v 'vendor') | \
                xargs -t -n4 go test   -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/okta/terraform-provider-okta github.com/okta/terraform-provider-okta/okta github.com/okta/terraform-provider-okta/okta/internal/apimutex github.com/okta/terraform-provider-okta/okta/internal/transport
?       github.com/okta/terraform-provider-okta [no test files]
ok      github.com/okta/terraform-provider-okta/okta    (cached)
ok      github.com/okta/terraform-provider-okta/okta/internal/apimutex  4.057s
ok      github.com/okta/terraform-provider-okta/okta/internal/transport (cached)
go test -timeout=30s -parallel=4 github.com/okta/terraform-provider-okta/sdk
?       github.com/okta/terraform-provider-okta/sdk     [no test files]
```