### PR TITLE
Ensure okta_authenticator settings are ordered to prevent whitespace …

### DIFF
--- a/okta/resource_okta_authenticator.go
+++ b/okta/resource_okta_authenticator.go
@@ -131,6 +131,11 @@ func resourceAuthenticatorRead(ctx context.Context, d *schema.ResourceData, m in
 	_ = d.Set("type", authenticator.Type)
 	if authenticator.Settings != nil {
 		b, _ := json.Marshal(authenticator.Settings)
+
+		dataMap := map[string]interface{}{}
+		_ = json.Unmarshal([]byte(string(b)), &dataMap)
+		b, _ = json.Marshal(dataMap)
+
 		_ = d.Set("settings", string(b))
 	}
 	if authenticator.Provider != nil {


### PR DESCRIPTION
Added a unmarshall to marshall on the string (similar to the normalize function that operates on interface) to help normalize the JSON that's stored into state.

Fixes #881 

Tested locally on same resource erroring in #881 and 👍 

```
okta_authenticator.okta_verify: Refreshing state... [id=autahjkfkpX25b8WU696]
2022-01-31T18:33:20.583-0800 [INFO]  provider.terraform-provider-okta_v3.20.2.exe: 2022/01/31 18:33:20 [{"channelBinding":{"required":"NEVER","style":"NUMBER_CHALLENGE"},"compliance":{"fips":"OPTIONAL"},"userVerification":"PREFERRED"}]: timestamp=2022-01-31T18:33:20.583-0800

No changes. Your infrastructure matches the configuration.
```