### PR TITLE
Ensure VERIFIED domains return true

### DIFF
--- a/okta/resource_okta_domain_verification.go
+++ b/okta/resource_okta_domain_verification.go
@@ -62,6 +62,7 @@ func resourceDomainVerificationDelete(ctx context.Context, d *schema.ResourceDat
 func isDomainValidated(validationStatus string) bool {
 	switch validationStatus {
 	case "VERIFIED":
+		return true
 	case "COMPLETED":
 		return true
 	}

--- a/okta/resource_okta_domain_verification_test.go
+++ b/okta/resource_okta_domain_verification_test.go
@@ -1,0 +1,28 @@
+package okta
+
+import (
+	"testing"
+)
+
+func TestDomainValidationString(t *testing.T) {
+	tests := []struct {
+		element  string
+		expected bool
+	}{
+		{"VERIFIED", true},
+		{"COMPLETED", true},
+		{"NOT_STARTED", false},
+		{"IN_PROGRESS", false},
+		{"verified", false},
+		{"completed", false},
+		{"invalid", false},
+	}
+
+	for _, test := range tests {
+		actual := isDomainValidated(test.element)
+
+		if actual != test.expected {
+			t.Errorf("domain validation status failed for status = \"%s\" - Expected: %t, Actual: %t", test.element, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Fixes: #930 

Golang doesn't fall through in switch by default like other languages. Small oversight in previous PR.

- [x] Added additional tests for validation method