### PR TITLE
Added new `identity_provider` and `identity_provider_ids` fields to the `okta_policy_rule_signon` resource

### DIFF
--- a/examples/okta_policy_rule_signon/okta_identity_provider.tf
+++ b/examples/okta_policy_rule_signon/okta_identity_provider.tf
@@ -1,0 +1,29 @@
+data "okta_group" "all" {
+  name = "Everyone"
+}
+
+resource "okta_policy_signon" "test" {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = [
+    data.okta_group.all.id
+  ]
+}
+
+resource "okta_policy_rule_signon" "test" {
+  policy_id         = okta_policy_signon.test.id
+  name              = "testAcc_replace_with_uuid"
+  status            = "ACTIVE"
+  mfa_required      = true
+  mfa_lifetime      = 15
+  mfa_prompt        = "SESSION"
+  identity_provider = "OKTA"
+}
+
+resource "okta_network_zone" "test" {
+  name     = "testAcc_replace_with_uuid"
+  type     = "IP"
+  gateways = ["1.2.3.4/24", "2.3.4.5-2.3.4.15"]
+  proxies  = ["2.2.3.4/24", "3.3.4.5-3.3.4.15"]
+}

--- a/examples/okta_policy_rule_signon/other_identity_provider.tf
+++ b/examples/okta_policy_rule_signon/other_identity_provider.tf
@@ -1,0 +1,35 @@
+data "okta_group" "all" {
+  name = "Everyone"
+}
+
+resource "okta_idp_social" "google" {
+  type                = "GOOGLE"
+  protocol_type       = "OIDC"
+  name                = "Google"
+  provisioning_action = "DISABLED"
+  scopes              = [
+    "profile",
+    "email",
+    "openid",
+  ]
+
+  client_id         = "foo"
+  client_secret     = "bar"
+  username_template = "idpuser.email"
+}
+
+resource "okta_policy_signon" "test" {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = [data.okta_group.all.id]
+}
+
+resource "okta_policy_rule_signon" "test" {
+  policy_id             = okta_policy_signon.test.id
+  name                  = "testAcc_replace_with_uuid"
+  status                = "ACTIVE"
+  mfa_required          = false
+  identity_provider     = "SPECIFIC_IDP"
+  identity_provider_ids = [okta_idp_social.google.id]
+}

--- a/okta/policy_rule.go
+++ b/okta/policy_rule.go
@@ -295,7 +295,5 @@ func deleteRule(ctx context.Context, d *schema.ResourceData, m interface{}, chec
 			return err
 		}
 	}
-	// remove the policy rule resource from terraform
-	d.SetId("")
 	return nil
 }

--- a/okta/resource_okta_policy_rule_sign_on.go
+++ b/okta/resource_okta_policy_rule_sign_on.go
@@ -130,6 +130,19 @@ func resourcePolicySignOnRule() *schema.Resource {
 					},
 				},
 			},
+			"identity_provider": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: elemInSlice([]string{"ANY", "OKTA", "SPECIFIC_IDP"}),
+				Description:      "Apply rule based on the IdP used: ANY, OKTA or SPECIFIC_IDP.",
+				Default:          "ANY",
+			},
+			"identity_provider_ids": { // identity_provider must be SPECIFIC_IDP
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "When identity_provider is SPECIFIC_IDP then this is the list of IdP IDs to apply the rule on",
+			},
 		}),
 	}
 }
@@ -182,7 +195,14 @@ func resourcePolicySignOnRuleRead(ctx context.Context, d *schema.ResourceData, m
 				return diag.Errorf("failed to set sign-on policy rule behaviors: %v", err)
 			}
 		}
+		if rule.Conditions.IdentityProvider != nil {
+			_ = d.Set("identity_provider", rule.Conditions.IdentityProvider.Provider)
+			if rule.Conditions.IdentityProvider.Provider == "SPECIFIC_IDP" {
+				_ = d.Set("identity_provider_ids", convertStringSliceToInterfaceSlice(rule.Conditions.IdentityProvider.IdpIds))
+			}
+		}
 	}
+
 	if rule.Actions.SignOn.Access == "CHALLENGE" {
 		chain := rule.Actions.SignOn.Challenge.Chain
 		arr := make([]map[string]interface{}, len(chain))
@@ -249,6 +269,10 @@ func buildSignOnPolicyRule(d *schema.ResourceData) sdk.PolicyRule {
 		},
 		Network: buildPolicyNetworkCondition(d),
 		People:  getUsers(d),
+		IdentityProvider: &okta.IdentityProviderPolicyRuleCondition{
+			Provider: d.Get("identity_provider").(string),
+			IdpIds:   convertInterfaceToStringArr(d.Get("identity_provider_ids")),
+		},
 	}
 	bi, ok := d.GetOk("behaviors")
 	if ok {
@@ -326,6 +350,10 @@ func validateSignOnPolicyRule(d *schema.ResourceData) error {
 		if ok && d.(bool) {
 			return errors.New("'mfa_remember_device' can only be set when mfa_prompt='DEVICE'")
 		}
+	}
+	ip, ok := d.GetOk("identity_provider")
+	if ok && ip == "SPECIFIC_IDP" && len(convertInterfaceToStringArrNullable(d.Get("identity_provider_ids"))) < 1 {
+		return errors.New("'identity_provider_ids' should have at least one element when 'identity_provider' is 'SPECIFIC_IDP'")
 	}
 	return nil
 }

--- a/okta/resource_okta_policy_rule_sign_on_test.go
+++ b/okta/resource_okta_policy_rule_sign_on_test.go
@@ -36,6 +36,8 @@ func TestAccOktaPolicyRuleSignon_crud(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 	excludedNetwork := mgr.GetFixtures("excluded_network.tf", ri, t)
+	oktaIdentityProvider := mgr.GetFixtures("okta_identity_provider.tf", ri, t)
+	otherIdentityProvider := mgr.GetFixtures("other_identity_provider.tf", ri, t)
 	factorSequence := mgr.GetFixtures("factor_sequence.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", policyRuleSignOn)
 
@@ -73,6 +75,27 @@ func TestAccOktaPolicyRuleSignon_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
 					resource.TestCheckResourceAttr(resourceName, "access", "DENY"),
 					resource.TestCheckResourceAttr(resourceName, "network_connection", "ZONE"),
+				),
+			},
+			{
+				Config: oktaIdentityProvider,
+				Check: resource.ComposeTestCheckFunc(
+					ensureRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc_%d", ri)),
+					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
+					resource.TestCheckResourceAttr(resourceName, "mfa_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider", "OKTA"),
+				),
+			},
+			{
+				Config: otherIdentityProvider,
+				Check: resource.ComposeTestCheckFunc(
+					ensureRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc_%d", ri)),
+					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
+					resource.TestCheckResourceAttr(resourceName, "mfa_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider", "SPECIFIC_IDP"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_ids.#", "1"),
 				),
 			},
 			{

--- a/website/docs/r/policy_rule_signon.html.markdown
+++ b/website/docs/r/policy_rule_signon.html.markdown
@@ -143,6 +143,12 @@ The following arguments are supported:
 
 - `users_excluded` - (Optional) The list of user IDs that would be excluded when rules are processed.
 
+- `identity_provider` - (Optional) Defines the identity provider for this rule. Valid values are `"ANY"`, `"OKTA"`, and `"SPECIFIC_IDP"`. Default is `"ANY"`.
+  
+  ~> **WARNING**: Use of `identity_provider` requires a feature flag to be enabled.
+
+- `identity_provider_ids` - (Optional) When identity_provider is `"SPECIFIC_IDP"` then this is the list of IdP IDs to apply the rule on.
+
 ## Attributes Reference
 
 - `id` - ID of the Rule.


### PR DESCRIPTION
Fix #277 