### PR TITLE
Release v3.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.20.6 (February 3, 2022)
+
+ENHANCEMENTS:
+
+* Added new `identity_provider` and `identity_provider_ids` fields to the `okta_policy_rule_signon` resource [#942](https://github.com/okta/terraform-provider-okta/pull/942). Thanks, [@bogdanprodan-okta](https://github.com/bogdanprodan-okta)!
+
 ## 3.20.5 (February 2, 2022)
 
 BUGS:

--- a/okta/config.go
+++ b/okta/config.go
@@ -101,7 +101,7 @@ func (c *Config) loadAndValidate(ctx context.Context) error {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.20.5"),
+		okta.WithUserAgentExtra("okta-terraform/3.20.6"),
 	}
 	if c.apiToken == "" {
 		setters = append(setters, okta.WithAuthorizationMode("PrivateKey"))

--- a/okta/resource_okta_app_saml.go
+++ b/okta/resource_okta_app_saml.go
@@ -492,15 +492,6 @@ func resourceAppSamlUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			return diag.Errorf("failed to upload logo for SAML application: %v", err)
 		}
 	}
-	isStatusChaged := d.HasChange("status")
-	if isStatusChaged {
-		s := d.Get("status").(string)
-		if s == "ACTIVE" {
-			// activate
-		} else {
-			// deactivate
-		}
-	}
 	return resourceAppSamlRead(ctx, d, m)
 }
 


### PR DESCRIPTION
* Added new `identity_provider` and `identity_provider_ids` fields to the `okta_policy_rule_signon` resource #942