### PR TITLE
Added `LDAP` option to the `auth_provider` field in the `okta_policy_password` resource

### DIFF
--- a/okta/resource_okta_policy_password.go
+++ b/okta/resource_okta_policy_password.go
@@ -22,8 +22,8 @@ func resourcePolicyPassword() *schema.Resource {
 			"auth_provider": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateDiagFunc: elemInSlice([]string{"OKTA", "ACTIVE_DIRECTORY"}),
-				Description:      "Authentication Provider: OKTA or ACTIVE_DIRECTORY.",
+				ValidateDiagFunc: elemInSlice([]string{"OKTA", "ACTIVE_DIRECTORY", "LDAP"}),
+				Description:      "Authentication Provider: OKTA, ACTIVE_DIRECTORY or LDAP",
 				Default:          "OKTA",
 			},
 			"password_min_length": {

--- a/website/docs/r/policy_password.html.markdown
+++ b/website/docs/r/policy_password.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 - `groups_included` - (Optional) List of Group IDs to Include.
 
-- `auth_provider` - (Optional) Authentication Provider: `"OKTA"` or `"ACTIVE_DIRECTORY"`. Default is `"OKTA"`.
+- `auth_provider` - (Optional) Authentication Provider: `"OKTA"`, `"ACTIVE_DIRECTORY"` or `"LDAP"`. Default is `"OKTA"`.
 
 - `password_min_length` - (Optional) Minimum password length. Default is 8.
 


### PR DESCRIPTION
Fix #867 