### PR TITLE
Update all App docs to match provider schema

### DIFF
--- a/website/docs/r/app_auto_login.html.markdown
+++ b/website/docs/r/app_auto_login.html.markdown
@@ -41,64 +41,68 @@ JSON
 
 The following arguments are supported:
 
-- `label` - (Required) The Application's display name.
-
-- `status` - (Optional) The status of the application, by default, it is `"ACTIVE"`.
-
-- `preconfigured_app` - (Optional) Tells Okta to use an existing application in their application catalog, as opposed to a custom application.
-
-- `sign_on` - (Required) App login page URL
-
-- `sign_on_redirect_url` - (Optional) Redirect URL; if going to the login page URL redirects to another page, then enter that URL here
-
-- `credentials_scheme` - (Optional) One of: `"EDIT_USERNAME_AND_PASSWORD"`, `"ADMIN_SETS_CREDENTIALS"`, `"EDIT_PASSWORD_ONLY"`, `"EXTERNAL_PASSWORD_SYNC"`, or `"SHARED_USERNAME_AND_PASSWORD"`.
-
-- `shared_username` - (Optional) Shared username, required for certain schemes
-
-- `shared_password` - (Optional) Shared password, required for certain schemes
-
-- `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
-
-- `user_name_template_suffix` - (Optional) Username template suffix.
-
-- `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
-
-- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
-
-- `hide_web` - (Optional) Do not display application icon to users.
-
-- `hide_ios` - (Optional) Do not display application icon on mobile app.
-
-- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
-
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
 - `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
-- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
-  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
+- `admin_note` - (Optional) Application notes for admins.
+
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
+
+- `app_settings_json` - (Optional) Application settings in JSON format.
+
+- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
+
+- `credentials_scheme` - (Optional) One of: `"EDIT_USERNAME_AND_PASSWORD"`, `"ADMIN_SETS_CREDENTIALS"`, `"EDIT_PASSWORD_ONLY"`, `"EXTERNAL_PASSWORD_SYNC"`, or `"SHARED_USERNAME_AND_PASSWORD"`.
+
+- `enduser_note` - (Optional) Application notes for end users.
 
 - `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
   - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
+- `hide_ios` - (Optional) Do not display application icon on mobile app.
+
+- `hide_web` - (Optional) Do not display application icon to users.
+
+- `label` - (Required) The Application's display name.
+
 - `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
-- `admin_note` - (Optional) Application notes for admins.
+- `preconfigured_app` - (Optional) Tells Okta to use an existing application in their application catalog, as opposed to a custom application.
 
-- `enduser_note` - (Optional) Application notes for end users.
+- `reveal_password` - (Optional) Allow user to reveal password. It can not be set to `true` if `credentials_scheme` is `"ADMIN_SETS_CREDENTIALS"`, `"SHARED_USERNAME_AND_PASSWORD"` or `"EXTERNAL_PASSWORD_SYNC"`.
 
-- `app_settings_json` - (Optional) Application settings in JSON format.
+- `shared_password` - (Optional) Shared password, required for certain schemes
+
+- `shared_username` - (Optional) Shared username, required for certain schemes
+
+- `sign_on_redirect_url` - (Optional) Redirect URL; if going to the login page URL redirects to another page, then enter that URL here
+
+- `sign_on_url` - (Required) App login page URL
+
+- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
 
 - `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
 
-- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+- `status` - (Optional) The status of the application, by default, it is `"ACTIVE"`.
+
+- `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
+
+- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+
+- `user_name_template_suffix` - (Optional) Username template suffix.
+
+- `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
+
+- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 ## Attributes Reference
 
 - `name` - Name assigned to the application by Okta.
-  
+
 - `sign_on_mode` - Sign-on mode of the application.
 
 - `logo_url` - Direct link of application logo.

--- a/website/docs/r/app_basic_auth.html.markdown
+++ b/website/docs/r/app_basic_auth.html.markdown
@@ -24,41 +24,43 @@ resource "okta_app_basic_auth" "example" {
 
 The following arguments are supported:
 
-- `label` - (Required) The Application's display name.
-
-- `url` - (Required) The URL of the sign-in page for this app.
-
-- `auth_url` - (Required) The URL of the authenticating site for this app.
-
-- `users` - (Optional) Users associated with the application.
-  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
-
-- `groups` - (Optional) Groups associated with the application.
-  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
-
-- `status` - (Optional) Status of application. (`"ACTIVE"` or `"INACTIVE"`).
-
-- `hide_web` - (Optional) Do not display application icon to users.
-
-- `hide_ios` - (Optional) Do not display application icon on mobile app.
-
-- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
-
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
 - `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
-- `logo` - (Optional) Local path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
-
 - `admin_note` - (Optional) Application notes for admins.
+
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
+
+- `auth_url` - (Required) The URL of the authenticating site for this app.
+
+- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
 
 - `enduser_note` - (Optional) Application notes for end users.
 
-- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`. 
+- `groups` - (Optional) Groups associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
+
+- `hide_ios` - (Optional) Do not display application icon on mobile app.
+
+- `hide_web` - (Optional) Do not display application icon to users.
+
+- `label` - (Required) The Application's display name.
+
+- `logo` - (Optional) Local path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+
+- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
+
+- `status` - (Optional) Status of application. (`"ACTIVE"` or `"INACTIVE"`).
+
+- `url` - (Required) The URL of the sign-in page for this app.
+
+- `users` - (Optional) Users associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/app_bookmark.html.markdown
+++ b/website/docs/r/app_bookmark.html.markdown
@@ -23,41 +23,43 @@ resource "okta_app_bookmark" "example" {
 
 The following arguments are supported:
 
-- `label` - (Required) The Application's display name.
-
-- `url` - (Optional) The URL of the bookmark.
-
-- `request_integration` - (Optional) Would you like Okta to add an integration for this app?
-
-- `users` - (Optional) Users associated with the application.
-  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
-
-- `groups` - (Optional) Groups associated with the application.
-  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
-
-- `status` - (Optional) Status of application. (`"ACTIVE"` or `"INACTIVE"`).
-
-- `hide_web` - (Optional) Do not display application icon to users.
-
-- `hide_ios` - (Optional) Do not display application icon on mobile app.
-
-- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
-
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
 - `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
-- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
-
 - `admin_note` - (Optional) Application notes for admins.
+
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
+
+- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
 
 - `enduser_note` - (Optional) Application notes for end users.
 
-- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
+- `groups` - (Optional) Groups associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
+
+- `hide_ios` - (Optional) Do not display application icon on mobile app.
+
+- `hide_web` - (Optional) Do not display application icon to users.
+
+- `label` - (Required) The Application's display name.
+
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+
+- `request_integration` - (Optional) Would you like Okta to add an integration for this app?
 
 - `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+
+- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
+
+- `status` - (Optional) Status of application. (`"ACTIVE"` or `"INACTIVE"`).
+
+- `url` - (Optional) The URL of the bookmark.
+
+- `users` - (Optional) Users associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -43,89 +43,42 @@ resource "okta_app_oauth" "example" {
 
 The following arguments are supported:
 
-- `label` - (Required) The Application's display name.
-
-- `status` - (Optional) The status of the application, by default, it is `"ACTIVE"`.
-
-- `type` - (Required) The type of OAuth application. Valid values: `"web"`, `"native"`, `"browser"`, `"service"`.
-
-- `users` - (Optional) The users assigned to the application. It is recommended not to use this and instead use `okta_app_user`.
-  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
-
-- `groups` - (Optional) The groups assigned to the application. It is recommended not to use this and instead use `okta_app_group_assignment`.
-  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
-
-- `client_id` - (Optional) OAuth client ID. If set during creation, app is created with this id.
-
-- `omit_secret` - (Optional) This tells the provider not to persist the application's secret to state. Your app will be recreated if this ever changes from true => false.
-
-- `client_basic_secret` - (Optional) OAuth client secret key, this can be set when token_endpoint_auth_method is client_secret_basic.
-
-- `token_endpoint_auth_method` - (Optional) Requested authentication method for the token endpoint. It can be set to `"none"`, `"client_secret_post"`, `"client_secret_basic"`, `"client_secret_jwt"`, `"private_key_jwt"`. To enable PKCE, set this to `"none"`.
-
-- `auto_key_rotation` - (Optional) Requested key rotation mode.
-
-- `client_uri` - (Optional) URI to a web page providing information about the client.
-
-- `logo_uri` - (Optional) URI that references a logo for the client.
-
-- `login_uri` - (Optional) URI that initiates login. Required when `login_mode` is NOT `DISABLED`.
-
-- `redirect_uris` - (Optional) List of URIs for use in the redirect-based flow. This is required for all application types except service.
-
-- `wildcard_redirect` - (Optional) *Early Access Property*. Indicates if the client is allowed to use wildcard matching of `redirect_uris`. Valid values: `"DISABLED"`, `"SUBDOMAIN"`. Default value is `"DISABLED"`.
-
-- `post_logout_redirect_uris` - (Optional) List of URIs for redirection after logout.
-
-- `response_types` - (Optional) List of OAuth 2.0 response type strings.
-
-- `grant_types` - (Optional) List of OAuth 2.0 grant types. Conditional validation params found [here](https://developer.okta.com/docs/api/resources/apps#credentials-settings-details). 
-  Defaults to minimum requirements per app type. Valid values: `"authorization_code"`, `"implicit"`, `"password"`, `"refresh_token"`, `"client_credentials"`, 
-  `"urn:ietf:params:oauth:grant-type:saml2-bearer"` (*Early Access Property*), `"urn:ietf:params:oauth:grant-type:token-exchange"` (*Early Access Property*),
-  `"interaction_code"` (*OIE only*).
-
-- `tos_uri` - (Optional) URI to web page providing client tos (terms of service).
-
-- `policy_uri` - (Optional) URI to web page providing client policy document.
-
-- `consent_method` - (Optional) Indicates whether user consent is required or implicit. Valid values: `"REQUIRED"`, `"TRUSTED"`. Default value is `"TRUSTED"`.
-
-- `issuer_mode` - (Optional) Indicates whether the Okta Authorization Server uses the original Okta org domain URL or a custom domain URL as the issuer of ID token for this client.
-Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
-
-- `refresh_token_rotation` - (Optional) Refresh token rotation behavior. Valid values: `"STATIC"` or `"ROTATE"`.
-
-- `refresh_token_leeway` - (Optional) Grace period for token rotation. Valid values: 0 to 60 seconds.
-
-- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
-
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
 - `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
-- `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
+- `admin_note` - (Optional) Application notes for admins.
 
-- `user_name_template_suffix` - (Optional) Username template suffix.
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
 
-- `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
+- `app_settings_json` - (Optional) Application settings in JSON format.
 
-- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+- `auto_key_rotation` - (Optional) Requested key rotation mode.
 
-- `hide_ios` - (Optional) Do not display application icon on mobile app.
+- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
 
-- `hide_web` - (Optional) Do not display application icon to users.
+- `client_basic_secret` - (Optional) OAuth client secret key, this can be set when token_endpoint_auth_method is client_secret_basic.
 
-- `profile` - (Optional) Custom JSON that represents an OAuth application's profile.
+- `client_id` - (Optional) OAuth client ID. If set during creation, app is created with this id.
 
-- `implicit_assignment` - (Optional) *Early Access Property*. Enables [Federation Broker Mode]( https://help.okta.com/en/prod/Content/Topics/Apps/apps-fbm-enable.htm). When this mode is enabled, `users` and `groups` arguments are ignored.
+- `client_uri` - (Optional) URI to a web page providing information about the client.
 
-- `login_mode` - (Optional) The type of Idp-Initiated login that the client supports, if any. Valid values: `"DISABLED"`, `"SPEC"`, `"OKTA"`. Default is `"DISABLED"`.
+- `consent_method` - (Optional) Indicates whether user consent is required or implicit. Valid values: `"REQUIRED"`, `"TRUSTED"`. Default value is `"TRUSTED"`.
 
-- `login_scopes` - (Optional) List of scopes to use for the request. Valid values: `"openid"`, `"profile"`, `"email"`, `"address"`, `"phone"`. Required when `login_mode` is NOT `DISABLED`.
+- `custom_client_id` - (Optional) This property allows you to set your client_id during creation. NOTE: updating after creation will be a no-op, use client_id for that behavior instead.
+  - `DEPRECATED`: This field is being replaced by `client_id`. Please use that field instead.",
 
-- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+- `enduser_note` - (Optional) Application notes for end users.
+
+- `grant_types` - (Optional) List of OAuth 2.0 grant types. Conditional validation params found [here](https://developer.okta.com/docs/api/resources/apps#credentials-settings-details).
+  Defaults to minimum requirements per app type. Valid values: `"authorization_code"`, `"implicit"`, `"password"`, `"refresh_token"`, `"client_credentials"`,
+  `"urn:ietf:params:oauth:grant-type:saml2-bearer"` (*Early Access Property*), `"urn:ietf:params:oauth:grant-type:token-exchange"` (*Early Access Property*),
+  `"interaction_code"` (*OIE only*).
+
+- `groups` - (Optional) The groups assigned to the application. It is recommended not to use this and instead use `okta_app_group_assignment`.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `groups_claim` - (Optional) Groups claim for an OpenID Connect client application. **IMPORTANT**: this field is available only when using api token in the provider config.
   - `type` - (Required) Groups claim type. Valid values: `"FILTER"`, `"EXPRESSION"`.
@@ -133,15 +86,69 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
   - `name` - (Required) Name of the claim that will be used in the token.
   - `value` - (Required) Value of the claim. Can be an Okta Expression Language statement that evaluates at the time the token is minted.
 
-- `admin_note` - (Optional) Application notes for admins.
+- `hide_ios` - (Optional) Do not display application icon on mobile app.
 
-- `enduser_note` - (Optional) Application notes for end users.
+- `hide_web` - (Optional) Do not display application icon to users.
 
-- `app_settings_json` - (Optional) Application settings in JSON format.
+- `implicit_assignment` - (Optional) *Early Access Property*. Enables [Federation Broker Mode](https://help.okta.com/en/prod/Content/Topics/Apps/apps-fbm-enable.htm). When this mode is enabled, `users` and `groups` arguments are ignored.
+
+- `issuer_mode` - (Optional) Indicates whether the Okta Authorization Server uses the original Okta org domain URL or a custom domain URL as the issuer of ID token for this client.
+Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
+
+- `jwks` - (Optional) JSON Web Key set. [Admin Console JWK Reference](https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/main/#generate-the-jwk-in-the-admin-console)
+
+- `label` - (Required) The Application's display name.
+
+- `login_mode` - (Optional) The type of Idp-Initiated login that the client supports, if any. Valid values: `"DISABLED"`, `"SPEC"`, `"OKTA"`. Default is `"DISABLED"`.
+
+- `login_scopes` - (Optional) List of scopes to use for the request. Valid values: `"openid"`, `"profile"`, `"email"`, `"address"`, `"phone"`. Required when `login_mode` is NOT `DISABLED`.
+
+- `login_uri` - (Optional) URI that initiates login. Required when `login_mode` is NOT `DISABLED`.
+
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+
+- `logo_uri` - (Optional) URI that references a logo for the client.
+
+- `omit_secret` - (Optional) This tells the provider not to persist the application's secret to state. Your app will be recreated if this ever changes from true => false.
+
+- `policy_uri` - (Optional) URI to web page providing client policy document.
+
+- `post_logout_redirect_uris` - (Optional) List of URIs for redirection after logout.
+
+- `profile` - (Optional) Custom JSON that represents an OAuth application's profile.
+
+- `redirect_uris` - (Optional) List of URIs for use in the redirect-based flow. This is required for all application types except service.
+
+- `refresh_token_leeway` - (Optional) Grace period for token rotation. Valid values: 0 to 60 seconds.
+
+- `refresh_token_rotation` - (Optional) Refresh token rotation behavior. Valid values: `"STATIC"` or `"ROTATE"`.
+
+- `response_types` - (Optional) List of OAuth 2.0 response type strings.
+
+- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
 
 - `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
 
-- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+- `status` - (Optional) The status of the application, by default, it is `"ACTIVE"`.
+
+- `token_endpoint_auth_method` - (Optional) Requested authentication method for the token endpoint. It can be set to `"none"`, `"client_secret_post"`, `"client_secret_basic"`, `"client_secret_jwt"`, `"private_key_jwt"`. To enable PKCE, set this to `"none"`.
+
+- `tos_uri` - (Optional) URI to web page providing client tos (terms of service).
+
+- `type` - (Required) The type of OAuth application. Valid values: `"web"`, `"native"`, `"browser"`, `"service"`.
+
+- `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
+
+- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+
+- `user_name_template_suffix` - (Optional) Username template suffix.
+
+- `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
+
+- `users` - (Optional) The users assigned to the application. It is recommended not to use this and instead use `okta_app_user`.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
+
+- `wildcard_redirect` - (Optional) *Early Access Property*. Indicates if the client is allowed to use wildcard matching of `redirect_uris`. Valid values: `"DISABLED"`, `"SUBDOMAIN"`. Default value is `"DISABLED"`.
 
 ## Attributes Reference
 

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -153,77 +153,21 @@ JSON
 
 The following arguments are supported:
 
-- `label` - (Required) label of application.
-
-- `preconfigured_app` - (Optional) name of application from the Okta Integration Network, if not included a custom app will be created.
-
-- `status` - (Optional) status of application.
-
-- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
-
-- `hide_ios` - (Optional) Do not display application icon on mobile app.
-
-- `hide_web` - (Optional) Do not display application icon to users
-
-- `implicit_assignment` - (Optional) *Early Access Property*. Enables [Federation Broker Mode]( https://help.okta.com/en/prod/Content/Topics/Apps/apps-fbm-enable.htm). When this mode is enabled, `users` and `groups` arguments are ignored.
-
-- `default_relay_state` - (Optional) Identifies a specific application resource in an IDP initiated SSO scenario.
-
-- `sso_url` - (Optional) Single Sign-on Url.
-
-- `recipient` - (Optional) The location where the app may present the SAML assertion.
-
-- `destination` - (Optional) Identifies the location where the SAML response is intended to be sent inside the SAML assertion.
-
-- `audience` - (Optional) Audience restriction.
-
-- `idp_issuer` - (Optional) SAML issuer ID.
-
-- `sp_issuer` - (Optional) SAML service provider issuer.
-
-- `subject_name_id_template` - (Optional) Template for app user's username when a user is assigned to the app.
-
-- `subject_name_id_format` - (Optional) Identifies the SAML processing rules.
-
-- `response_signed` - (Optional) Determines whether the SAML auth response message is digitally signed.
-
-- `request_compressed` - (Optional) Denotes whether the request is compressed or not.
-
-- `assertion_signed` - (Optional) Determines whether the SAML assertion is digitally signed.
-
-- `signature_algorithm` - (Optional) Signature algorithm used ot digitally sign the assertion and response.
-
-- `digest_algorithm` - (Optional) Determines the digest algorithm used to digitally sign the SAML assertion and response.
-
-- `honor_force_authn` - (Optional) Prompt user to re-authenticate if SP asks for it.
-
-- `authn_context_class_ref` - (Optional) Identifies the SAML authentication context class for the assertion’s authentication statement.
-
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
 - `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
-- `features` - (Optional) features enabled. Notice: you can't currently configure provisioning features via the API.
+- `acs_endpoints` - An array of ACS endpoints. You can configure a maximum of 100 endpoints.
 
-- `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
+- `admin_note` - (Optional) Application notes for admins.
 
-- `user_name_template_suffix` - (Optional) Username template suffix.
-
-- `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
-
-- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
 
 - `app_settings_json` - (Optional) Application settings in JSON format.
 
-- `acs_endpoints` - An array of ACS endpoints. You can configure a maximum of 100 endpoints.
-
-- `users` - (Optional) Users associated with the application.
-  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
-
-- `groups` - (Optional) Groups associated with the application.
-  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
+- `assertion_signed` - (Optional) Determines whether the SAML assertion is digitally signed.
 
 - `attribute_statements` - (Optional) List of SAML Attribute statements.
   - `name` - (Required) The name of the attribute statement.
@@ -233,32 +177,88 @@ The following arguments are supported:
   - `type` - (Optional) The type of attribute statement value. Valid values are: `"EXPRESSION"` or `"GROUP"`. Default is `"EXPRESSION"`.
   - `values` - (Optional) Array of values to use.
 
+- `audience` - (Optional) Audience restriction.
+
+- `authn_context_class_ref` - (Optional) Identifies the SAML authentication context class for the assertion’s authentication statement.
+
+- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
+
+- `default_relay_state` - (Optional) Identifies a specific application resource in an IDP initiated SSO scenario.
+
+- `destination` - (Optional) Identifies the location where the SAML response is intended to be sent inside the SAML assertion.
+
+- `digest_algorithm` - (Optional) Determines the digest algorithm used to digitally sign the SAML assertion and response.
+
+- `enduser_note` - (Optional) Application notes for end users.
+
+- `features` - (Optional) features enabled. Notice: you can't currently configure provisioning features via the API.
+
+- `groups` - (Optional) Groups associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
+
+- `hide_ios` - (Optional) Do not display application icon on mobile app.
+
+- `hide_web` - (Optional) Do not display application icon to users
+
+- `honor_force_authn` - (Optional) Prompt user to re-authenticate if SP asks for it.
+
+- `idp_issuer` - (Optional) SAML issuer ID.
+
+- `implicit_assignment` - (Optional) *Early Access Property*. Enables [Federation Broker Mode]( https://help.okta.com/en/prod/Content/Topics/Apps/apps-fbm-enable.htm). When this mode is enabled, `users` and `groups` arguments are ignored.
+
 - `inline_hook_id` - (Optional) Saml Inline Hook associated with the application.
+
+- `key_name` - (Optional) Certificate name. This modulates the rotation of keys. New name == new key. Required to be set with `key_years_valid`.
 
 - `key_years_valid` - (Optional) Number of years the certificate is valid (2 - 10 years).
 
-- `key_name` - (Optional) Certificate name. This modulates the rotation of keys. New name == new key. Required to be set with `key_years_valid`.
+- `label` - (Required) label of application.
+
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+
+- `preconfigured_app` - (Optional) name of application from the Okta Integration Network, if not included a custom app will be created.
+
+- `recipient` - (Optional) The location where the app may present the SAML assertion.
+
+- `request_compressed` - (Optional) Denotes whether the request is compressed or not.
+
+- `response_signed` - (Optional) Determines whether the SAML auth response message is digitally signed.
+
+- `saml_version` - (Optional) SAML version for the app's sign-on mode. Valid values are: `"2.0"` or `"1.1"`. Default is `"2.0"`.
+
+- `signature_algorithm` - (Optional) Signature algorithm used ot digitally sign the assertion and response.
+
+- `single_logout_certificate` - (Optional) x509 encoded certificate that the Service Provider uses to sign Single Logout requests.
+  Note: should be provided without `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`, see [official documentation](https://developer.okta.com/docs/reference/api/apps/#service-provider-certificate).
 
 - `single_logout_issuer` - (Optional) The issuer of the Service Provider that generates the Single Logout request.
 
 - `single_logout_url` - (Optional) The location where the logout response is sent.
 
-- `single_logout_certificate` - (Optional) x509 encoded certificate that the Service Provider uses to sign Single Logout requests.
-  Note: should be provided without `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`, see [official documentation](https://developer.okta.com/docs/reference/api/apps/#service-provider-certificate).
-
-- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
-
-- `admin_note` - (Optional) Application notes for admins.
-
-- `enduser_note` - (Optional) Application notes for end users.
-
-- `saml_version` - (Optional) SAML version for the app's sign-on mode. Valid values are: `"2.0"` or `"1.1"`. Default is `"2.0"`.
-
-- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for the link should be boolean.
+- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
 
 - `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
 
-- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+- `sp_issuer` - (Optional) SAML service provider issuer.
+
+- `sso_url` - (Optional) Single Sign-on Url.
+
+- `status` - (Optional) status of application.
+
+- `subject_name_id_format` - (Optional) Identifies the SAML processing rules.
+
+- `subject_name_id_template` - (Optional) Template for app user's username when a user is assigned to the app.
+
+- `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
+
+- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+
+- `user_name_template_suffix` - (Optional) Username template suffix.
+
+- `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
+
+- `users` - (Optional) Users associated with the application.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/app_secure_password_store.html.markdown
+++ b/website/docs/r/app_secure_password_store.html.markdown
@@ -26,13 +26,32 @@ resource "okta_app_secure_password_store" "example" {
 
 The following arguments are supported:
 
+- `accessibility_error_redirect_url` - (Optional) Custom error page URL.
+
+- `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
+
+- `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
+
+- `admin_note` - (Optional) Application notes for admins.
+
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
+
+- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
+
+- `credentials_scheme` - (Optional) Application credentials scheme. Can be set to `"EDIT_USERNAME_AND_PASSWORD"`, `"ADMIN_SETS_CREDENTIALS"`, `"EDIT_PASSWORD_ONLY"`, `"EXTERNAL_PASSWORD_SYNC"`, or `"SHARED_USERNAME_AND_PASSWORD"`.
+
+- `enduser_note` - (Optional) Application notes for end users.
+
+- `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
+
+- `hide_ios` - (Optional) Do not display application icon on mobile app.
+
+- `hide_web` - (Optional) Do not display application icon to users.
+
 - `label` - (Required) The display name of the Application.
 
-- `password_field` - (Required) Login password field.
-
-- `username_field` - (Required) Login username field.
-
-- `url` - (Required) Login URL.
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 
 - `optional_field1` - (Optional) Name of optional param in the login form.
 
@@ -46,45 +65,34 @@ The following arguments are supported:
 
 - `optional_field3_value` - (Optional) Name of optional value in the login form.
 
-- `credentials_scheme` - (Optional) Application credentials scheme. Can be set to `"EDIT_USERNAME_AND_PASSWORD"`, `"ADMIN_SETS_CREDENTIALS"`, `"EDIT_PASSWORD_ONLY"`, `"EXTERNAL_PASSWORD_SYNC"`, or `"SHARED_USERNAME_AND_PASSWORD"`.
+- `password_field` - (Required) Login password field.
 
 - `reveal_password` - (Optional) Allow user to reveal password. It can not be set to `true` if `credentials_scheme` is `"ADMIN_SETS_CREDENTIALS"`, `"SHARED_USERNAME_AND_PASSWORD"` or `"EXTERNAL_PASSWORD_SYNC"`.
 
-- `shared_username` - (Optional) Shared username, required for certain schemes.
-
 - `shared_password` - (Optional) Shared password, required for certain schemes.
 
-- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
-  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
+- `shared_username` - (Optional) Shared username, required for certain schemes.
 
-- `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
-  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
+- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+
+- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
 
 - `status` - (Optional) Status of application. By default, it is `"ACTIVE"`.
 
-- `accessibility_error_redirect_url` - (Optional) Custom error page URL.
-
-- `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
-
-- `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
-
-- `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
-
-- `hide_ios` - (Optional) Do not display application icon on mobile app.
-
-- `hide_web` - (Optional) Do not display application icon to users.
+- `url` - (Required) Login URL.
 
 - `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
+
+- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
 
 - `user_name_template_suffix` - (Optional) Username template suffix.
 
 - `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
 
-- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+- `username_field` - (Required) Login username field.
 
-- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
-
-- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/app_shared_credentials.html.markdown
+++ b/website/docs/r/app_shared_credentials.html.markdown
@@ -1,8 +1,8 @@
 ---
-layout: 'okta' 
-page_title: 'Okta: okta_app_shared_credentials' 
-sidebar_current: 'docs-okta-resource-app-shared-credentials' 
-description: |- 
+layout: 'okta'
+page_title: 'Okta: okta_app_shared_credentials'
+sidebar_current: 'docs-okta-resource-app-shared-credentials'
+description: |-
     Creates a SWA shared credentials app.
 ---
 
@@ -45,15 +45,24 @@ The following arguments are supported:
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
+- `admin_note` - (Optional) Application notes for admins.
+
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
+
 - `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
 
 - `button_field` - (Optional) CSS selector for the Sign-In button in the sign-in form.
 
 - `checkbox` - (Optional) CSS selector for the checkbox.
 
-- `hide_web` - (Optional) Do not display application icon to users.
+- `enduser_note` - (Optional) Application notes for end users.
+
+- `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `hide_ios` - (Optional) Do not display application icon on mobile app.
+
+- `hide_web` - (Optional) Do not display application icon to users.
 
 - `label` - (Required) The Application's display name.
 
@@ -61,11 +70,17 @@ The following arguments are supported:
 
 - `password_field` - (Optional) CSS selector for the Password field in the sign-in form.
 
-- `redirect_url` - (Optional) Redirect URL.
+- `preconfigured_app` - (Optional) name of application from the Okta Integration Network, if not included a custom app will be created.
+
+- `redirect_url` - (Optional) Redirect URL. If going to the login page URL redirects to another page, then enter that URL here.
 
 - `shared_password` - (Optional) Shared password, required for certain schemes.
 
 - `shared_username` - (Optional) Shared username, required for certain schemes.
+
+- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+
+- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
 
 - `status` - (Optional) The status of the application, by default, it is `"ACTIVE"`.
 
@@ -75,17 +90,16 @@ The following arguments are supported:
 
 - `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
 
+- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+
 - `user_name_template_suffix` - (Optional) Username template suffix.
 
 - `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
 
-- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
-
 - `username_field` - (Optional) CSS selector for the username field.
 
-- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
-
-- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/app_swa.html.markdown
+++ b/website/docs/r/app_swa.html.markdown
@@ -26,61 +26,63 @@ resource "okta_app_swa" "example" {
 
 The following arguments are supported:
 
-- `label` - (Required) The display name of the Application.
-
-- `button_field` - (Required) Login button field.
-
-- `preconfigured_app` - (Optional) name of application from the Okta Integration Network, if not included a custom app will be created.
-
-- `password_field` - (Optional) Login password field.
-
-- `username_field` - (Optional) Login username field.
-
-- `url` - (Optional) Login URL.
-
-- `url_regex` - (Optional) A regex that further restricts URL to the specified regex.
-
-- `redirect_url` - (Optional) If going to the login page URL redirects to another page, then enter that URL here.
-
-- `checkbox` - (Optional) CSS selector for the checkbox.
-
-- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
-  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
-
-- `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
-  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
-
-- `status` - (Optional) Status of application. By default, it is `"ACTIVE"`.
-
 - `accessibility_error_redirect_url` - (Optional) Custom error page URL.
 
 - `accessibility_login_redirect_url` - (Optional) Custom login page for this application.
 
 - `accessibility_self_service` - (Optional) Enable self-service. By default, it is `false`.
 
+- `admin_note` - (Optional) Application notes for admins.
+
+- `app_links_json` - (Optional) Displays specific appLinks for the app. The value for each application link should be boolean.
+
 - `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
+
+- `button_field` - (Required) Login button field.
+
+- `checkbox` - (Optional) CSS selector for the checkbox.
+
+- `enduser_note` - (Optional) Application notes for end users.
+
+- `groups` - (Optional) Groups associated with the application. See `okta_app_group_assignment` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_group_assignments` (or `okta_app_group_assignment`) resource.
 
 - `hide_ios` - (Optional) Do not display application icon on mobile app.
 
 - `hide_web` - (Optional) Do not display application icon to users.
 
+- `label` - (Required) The display name of the Application.
+
+- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
+
+- `password_field` - (Optional) Login password field.
+
+- `preconfigured_app` - (Optional) name of application from the Okta Integration Network, if not included a custom app will be created.
+
+- `redirect_url` - (Optional) Redirect URL. If going to the login page URL redirects to another page, then enter that URL here.
+
+- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+
+- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
+
+- `status` - (Optional) Status of application. By default, it is `"ACTIVE"`.
+
+- `url` - (Optional) The URL of the sign-in page for this app.
+
+- `url_regex` - (Optional) A regular expression that further restricts url to the specified regular expression.
+
 - `user_name_template` - (Optional) Username template. Default: `"${source.login}"`
+
+- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
 
 - `user_name_template_suffix` - (Optional) Username template suffix.
 
 - `user_name_template_type` - (Optional) Username template type. Default: `"BUILT_IN"`.
 
-- `user_name_template_push_status` - (Optional) Push username on update. Valid values: `"PUSH"` and `"DONT_PUSH"`.
+- `username_field` - (Optional) Login username field.
 
-- `logo` - (Optional) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
-
-- `admin_note` - (Optional) Application notes for admins.
-
-- `enduser_note` - (Optional) Application notes for end users.
-
-- `skip_users` - (Optional) Indicator that allows the app to skip `users` sync (it's also can be provided during import). Default is `false`.
-
-- `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
+- `users` - (Optional) The users assigned to the application. See `okta_app_user` for a more flexible approach.
+  - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is mostly cosmetic cleanup that resulted from using the documentation for some applications to confirm some fields that I noticed were missing. As a result of tracking down a few of the small ones that were missing ... I just went through all of the current app-* resources and updated them for 100% consistency.

* Alphabetized all schema arguments for all app resources
* Added missing arguments (`admin_notes`, `end_user_notes`, `preconfigured_app`, etc.) and fixed some incorrect arguments for various apps (Used the effective language server parser to confirm and double check each resource)

Fixes #994 