### PR TITLE
skip_groups and skip_roles on data source okta_user. 

### DIFF
--- a/examples/okta_user/datasource.tf
+++ b/examples/okta_user/datasource.tf
@@ -43,3 +43,9 @@ data "okta_user" "test" {
 data "okta_user" "read_by_id" {
   user_id = okta_user.test.id
 }
+
+data "okta_user" "read_by_id_with_skip" {
+  user_id = okta_user.test.id
+  skip_groups = true
+  skip_roles = true
+}

--- a/okta/data_source_okta_user_test.go
+++ b/okta/data_source_okta_user_test.go
@@ -10,8 +10,9 @@ import (
 func TestAccOktaDataSourceUser_read(t *testing.T) {
 	ri := acctest.RandInt()
 	mgr := newFixtureManager(user)
-	config := mgr.GetFixtures("datasource.tf", ri, t)
-	createUser := mgr.GetFixtures("datasource_create_user.tf", ri, t)
+	baseConfig := mgr.GetFixtures("datasource.tf", ri, t)
+	createUserConfig := mgr.GetFixtures("datasource_create_user.tf", ri, t)
+	rolesGroupsSkipsConfig := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -20,13 +21,13 @@ func TestAccOktaDataSourceUser_read(t *testing.T) {
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: createUser,
+				Config: createUserConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("okta_user.test", "id"),
 				),
 			},
 			{
-				Config: config,
+				Config: baseConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_user.test", "id"),
 					resource.TestCheckResourceAttr("data.okta_user.test", "first_name", "TestAcc"),
@@ -34,6 +35,16 @@ func TestAccOktaDataSourceUser_read(t *testing.T) {
 					resource.TestCheckResourceAttrSet("okta_user.test", "id"),
 					resource.TestCheckResourceAttr("data.okta_user.read_by_id", "first_name", "TestAcc"),
 					resource.TestCheckResourceAttr("data.okta_user.read_by_id", "last_name", "Smith"),
+				),
+			},
+			{
+				Config: rolesGroupsSkipsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_user.read_by_id_with_skip", "id"),
+					resource.TestCheckResourceAttrSet("data.okta_user.read_by_id_with_skip", "skip_groups"),
+					resource.TestCheckResourceAttrSet("data.okta_user.read_by_id_with_skip", "skip_roles"),
+					resource.TestCheckResourceAttr("data.okta_user.read_by_id_with_skip", "skip_groups", "true"),
+					resource.TestCheckResourceAttr("data.okta_user.read_by_id_with_skip", "skip_roles", "true"),
 				),
 			},
 		},

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -41,6 +41,10 @@ data "okta_user" "example" {
   - `comparison` - (Optional) Comparison to use.
   - `value` - (Required) Value to compare with.
 
+- `skip_groups` - (Optional) Additional API call to collect user's groups will not be made.
+
+- `skip_roles` - (Optional) Additional API call to collect user's roles will not be made.
+
 ## Attributes Reference
 
 - `admin_roles` - Administrator roles assigned to user.


### PR DESCRIPTION
`skip_roles` and `skip_groups` on `okta_user` data source to prevent additional API calls when they are not required.

On a sample app with 1000 users this drops the example in #1007 from 3068 GET requests running around 6 minutes to 1008 GET requests running in 40 seconds on my test org.

closes #1007