### PR TITLE
#1010 Feature: implement a free form expression string

### DIFF
--- a/okta/data_source_okta_user.go
+++ b/okta/data_source_okta_user.go
@@ -41,6 +41,11 @@ func dataSourceUser() *schema.Resource {
 							Default:          "eq",
 							ValidateDiagFunc: elemInSlice([]string{"eq", "lt", "gt", "sw"}),
 						},
+						"expression": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A raw search expression string. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
+						},
 					},
 				},
 			},
@@ -121,6 +126,11 @@ func getSearchCriteria(d *schema.ResourceData) string {
 	filterList := make([]string, rawFilters.Len())
 	for i, f := range rawFilters.List() {
 		fmap := f.(map[string]interface{})
+		rawExpression := fmap["expression"]
+		if rawExpression != "" && rawExpression != nil {
+			filterList[i] = fmt.Sprintf(`%s`, fmap["expression"])
+			continue
+		}
 		filterList[i] = fmt.Sprintf(`%s %s "%s"`, fmap["name"], fmap["comparison"], fmap["value"])
 	}
 	return strings.Join(filterList, " and ")

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -36,6 +36,11 @@ func dataSourceUsers() *schema.Resource {
 							Default:          "eq",
 							ValidateDiagFunc: elemInSlice([]string{"eq", "lt", "gt", "sw"}),
 						},
+						"expression": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A raw search expression string. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
+						},
 					},
 				},
 			},

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -30,6 +30,13 @@ data "okta_user" "example" {
     value = "Doe"
   }
 }
+
+# Search for a single user based on a raw search expression string
+data "okta_user" "example" {
+  search {
+    expression  = "profile.firstName eq \"John\""
+  }
+}
 ```
 
 ## Arguments Reference
@@ -40,6 +47,7 @@ data "okta_user" "example" {
   - `name` - (Required) Name of property to search against.
   - `comparison` - (Optional) Comparison to use.
   - `value` - (Required) Value to compare with.
+  - `expression` - (Optional) A raw search expression string.
 
 - `skip_groups` - (Optional) Additional API call to collect user's groups will not be made.
 

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -30,6 +30,13 @@ data "okta_user" "example" {
     value = "Doe"
   }
 }
+
+# Search for a single user based on a raw search expression string
+data "okta_user" "example" {
+  search {
+    expression  = "profile.firstName eq \"John\""
+  }
+}
 ```
 
 ## Arguments Reference

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -20,6 +20,13 @@ data "okta_users" "example" {
     comparison = "sw"
   }
 }
+
+# Search for multiple users based on a raw search expression string
+data "okta_users" "example" {
+  search {
+    expression = "profile.department eq \"Engineering\" and (created lt \"2014-01-01T00:00:00.000Z\" or status eq \"ACTIVE\")"
+  }
+}
 ```
 
 ## Arguments Reference
@@ -28,6 +35,7 @@ data "okta_users" "example" {
   - `name` - (Required) Name of property to search against.
   - `comparison` - (Required) Comparison to use.
   - `value` - (Required) Value to compare with.
+  - `expression` - (Optional) A raw search expression string.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds a free form expression string as an alternative search criteria to `data_source_okta_user` and `data_source_okta_users` as discussed in #1010 .

Usage example:
```hcl
data "okta_users" "foo" {
  search {
    expression = "profile.department eq \"Engineering\" and (created lt \"2014-01-01T00:00:00.000Z\" or status eq \"ACTIVE\")"
  }
}
```

This allows more flexible search parameters for the datasources mentioned above.