### PR TITLE
add custom_profile_attributes to data_source_okta_groups

### DIFF
--- a/okta/data_source_okta_groups.go
+++ b/okta/data_source_okta_groups.go
@@ -52,7 +52,7 @@ func dataSourceGroups() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"profile": {
+						"custom_profile_attributes": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -90,11 +90,11 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, m interfa
 			return diag.Errorf("failed to read custom profile attributes from group: %s", groups[i].Profile.Name)
 		}
 		arr[i] = map[string]interface{}{
-			"id":          groups[i].Id,
-			"name":        groups[i].Profile.Name,
-			"type":        groups[i].Type,
-			"description": groups[i].Profile.Description,
-			"profile":     string(customProfile),
+			"id":                        groups[i].Id,
+			"name":                      groups[i].Profile.Name,
+			"type":                      groups[i].Type,
+			"description":               groups[i].Profile.Description,
+			"custom_profile_attributes": string(customProfile),
 		}
 	}
 	_ = d.Set("groups", arr)

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -36,3 +36,4 @@ data "okta_groups" "example" {
     - `name` - Group name.
     - `description` - Group description.
     - `type` - Group type.
+    - `custom_profile_attributes` - raw JSON containing all custom profile attributes.


### PR DESCRIPTION
fix https://github.com/okta/terraform-provider-okta/issues/1009 
code was mostly inspired by existing code in the repo at [resource_okta_group.go#L128-L133](https://github.com/okta/terraform-provider-okta/blob/master/okta/resource_okta_group.go#L128-L133)

Still very new to Go and TF providers, so if this implementation is sub-par please let me know 😄 

intended to work with the below example config
```hcl 
data "okta_groups" "test" {
  type = "OKTA_GROUP"
}

output "test" {
  value = [for group in data.okta_groups.test.groups : group.name if lookup(jsondecode(group.profile), "admin", false) == true]
}
```