### PR TITLE
Stop tracking the local path to the logo in state.

### DIFF
--- a/okta/app.go
+++ b/okta/app.go
@@ -93,9 +93,9 @@ var (
 			StateFunc: func(val interface{}) string {
 				logoPath := val.(string)
 				if logoPath == "" {
-					return logoPath
+					return ""
 				}
-				return fmt.Sprintf("%s (%s)", logoPath, computeFileHash(logoPath))
+				return computeFileHash(logoPath)
 			},
 		},
 		"logo_url": {


### PR DESCRIPTION
Fixes #1036 by not tracking the logo path in the state and just tracking the hash.