### PR TITLE
Exitcode0 custom profile attributes

### DIFF
--- a/examples/okta_groups/datasource.tf
+++ b/examples/okta_groups/datasource.tf
@@ -11,3 +11,20 @@ resource "okta_group" "test_2" {
 data "okta_groups" "test" {
   q = "testAcc_"
 }
+
+data "okta_groups" "app_groups" {
+  type = "APP_GROUP"
+}
+
+output "special_groups" {
+  # This is an example of syntax only. Okta API only adds group of type OKTA_GROUP
+  # and so the example resource groups in this example above will be of that type.
+  # OTKA_GROUP groups only have "name" and "description" properties which are
+  # removed from okta-sdk-golang GroupProfileMap that is used to populate the bare
+  # JSON custom_profile_attributes on the group data.
+
+  # Groups of type APP_GROUP have customizable profile properties and a more
+  # meaningful lookup example could be done like so:
+  value = join(",", [for group in data.okta_groups.app_groups.groups : group.name 
+             if lookup(jsondecode(group.custom_profile_attributes), "some_attribute", "") == "Some Value"])
+}

--- a/okta/data_source_okta_groups.go
+++ b/okta/data_source_okta_groups.go
@@ -52,7 +52,7 @@ func dataSourceGroups() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"profile": {
+						"custom_profile_attributes": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -90,11 +90,11 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, m interfa
 			return diag.Errorf("failed to read custom profile attributes from group: %s", groups[i].Profile.Name)
 		}
 		arr[i] = map[string]interface{}{
-			"id":          groups[i].Id,
-			"name":        groups[i].Profile.Name,
-			"type":        groups[i].Type,
-			"description": groups[i].Profile.Description,
-			"profile":     string(customProfile),
+			"id":                        groups[i].Id,
+			"name":                      groups[i].Profile.Name,
+			"type":                      groups[i].Type,
+			"description":               groups[i].Profile.Description,
+			"custom_profile_attributes": string(customProfile),
 		}
 	}
 	_ = d.Set("groups", arr)

--- a/okta/data_source_okta_groups_test.go
+++ b/okta/data_source_okta_groups_test.go
@@ -28,6 +28,8 @@ func TestAccOktaDataSourceGroups_read(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_groups.test", "id"),
 					resource.TestCheckResourceAttr("data.okta_groups.test", "groups.#", "2"),
+					// the example enumeration doesn't match anything so as a string the output will be a blank string
+					resource.TestCheckOutput("special_groups", ""),
 				),
 			},
 		},

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -36,4 +36,4 @@ data "okta_groups" "example" {
     - `name` - Group name.
     - `description` - Group description.
     - `type` - Group type.
-    - `custom_profile_attributes` - raw JSON containing all custom profile attributes.
+    - `custom_profile_attributes` - raw JSON containing all custom profile attributes. Likely only useful on groups of type `APP_GROUP`.

--- a/website/docs/d/groups.html.markdown
+++ b/website/docs/d/groups.html.markdown
@@ -36,3 +36,4 @@ data "okta_groups" "example" {
     - `name` - Group name.
     - `description` - Group description.
     - `type` - Group type.
+    - `custom_profile_attributes` - raw JSON containing all custom profile attributes.


### PR DESCRIPTION
Bringing @exitcode0's code #1033 into an Okta branch. Added additional explanation to the PR.


Original PR salutation:

fix https://github.com/okta/terraform-provider-okta/issues/1009 
code was mostly inspired by existing code in the repo at [resource_okta_group.go#L128-L133](https://github.com/okta/terraform-provider-okta/blob/master/okta/resource_okta_group.go#L128-L133)

Still very new to Go and TF providers, so if this implementation is sub-par please let me know 😄 

intended to work with the below example config
```hcl 
data "okta_groups" "test" {
  type = "OKTA_GROUP"
}

output "test" {
  value = [for group in data.okta_groups.test.groups : group.name if lookup(jsondecode(group.profile), "admin", false) == true]
}
```