### PR TITLE
Panic bumper on buildEnum

### DIFF
--- a/okta/user_schema_property.go
+++ b/okta/user_schema_property.go
@@ -293,29 +293,6 @@ func buildOneOf(ae []interface{}, elemType string) ([]*okta.UserSchemaAttributeE
 	return oneOf, nil
 }
 
-func buildEnum(ae []interface{}, elemType string) ([]interface{}, error) {
-	enum := make([]interface{}, len(ae))
-	for i := range ae {
-		switch elemType {
-		case "number":
-			f, err := strconv.ParseFloat(ae[i].(string), 64)
-			if err != nil {
-				return nil, errInvalidElemFormat
-			}
-			enum[i] = f
-		case "integer":
-			f, err := strconv.Atoi(ae[i].(string))
-			if err != nil {
-				return nil, errInvalidElemFormat
-			}
-			enum[i] = f
-		default:
-			enum[i] = ae[i].(string)
-		}
-	}
-	return enum, nil
-}
-
 func flattenEnum(enum []interface{}) []interface{} {
 	result := make([]interface{}, len(enum))
 	for i := range enum {

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -340,4 +341,40 @@ func validatePriority(in, out int64) error {
 		return fmt.Errorf("provided priority was not valid, got: %d, API responded with: %d. See schema for attribute details", in, out)
 	}
 	return nil
+}
+
+func buildEnum(ae []interface{}, elemType string) ([]interface{}, error) {
+	enum := make([]interface{}, len(ae))
+	for i, aeVal := range ae {
+		if aeVal == nil {
+			switch elemType {
+			case "number":
+				enum[i] = float64(0)
+			case "integer":
+				enum[i] = 0
+			default:
+				enum[i] = ""
+			}
+			continue
+		}
+
+		aeStr := aeVal.(string)
+		switch elemType {
+		case "number":
+			f, err := strconv.ParseFloat(aeStr, 64)
+			if err != nil {
+				return nil, errInvalidElemFormat
+			}
+			enum[i] = f
+		case "integer":
+			f, err := strconv.Atoi(aeStr)
+			if err != nil {
+				return nil, errInvalidElemFormat
+			}
+			enum[i] = f
+		default:
+			enum[i] = aeStr
+		}
+	}
+	return enum, nil
 }

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -358,7 +358,10 @@ func buildEnum(ae []interface{}, elemType string) ([]interface{}, error) {
 			continue
 		}
 
-		aeStr := aeVal.(string)
+		aeStr, ok := aeVal.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected %+v value to cast to string", aeVal)
+		}
 		switch elemType {
 		case "number":
 			f, err := strconv.ParseFloat(aeStr, 64)

--- a/okta/utils_test.go
+++ b/okta/utils_test.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -87,6 +88,63 @@ func TestBuildSchema(t *testing.T) {
 		if actual != test.expected {
 			t.Errorf("buildSchema test failed, test maps: %v, elements %s, expected %v, actual %v",
 				testMaps, test.element, test.expected, actual)
+		}
+	}
+}
+
+func TestBuildEnum(t *testing.T) {
+	tests := []struct {
+		name        string
+		ae          []interface{}
+		elemType    string
+		expected    []interface{}
+		shouldError bool
+	}{
+		{
+			"number slice including empty value",
+			[]interface{}{"1.1", nil},
+			"number",
+			[]interface{}{1.1, 0.0},
+			false,
+		},
+		{
+			"integer slice including empty value",
+			[]interface{}{"1", nil},
+			"integer",
+			[]interface{}{1, 0},
+			false,
+		},
+		{
+			"string slice including empty value",
+			[]interface{}{"one", nil},
+			"string",
+			[]interface{}{"one", ""},
+			false,
+		},
+		{
+			"number slice with invalid value and empty value",
+			[]interface{}{"one", nil},
+			"number",
+			nil,
+			true,
+		},
+		{
+			"integer slice with invalid value and empty value",
+			[]interface{}{"one", nil},
+			"integer",
+			nil,
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := buildEnum(test.ae, test.elemType)
+		if test.shouldError && err == nil {
+			t.Errorf("%q - buildEnum should have errored on %+v, %s, got %+v", test.name, test.ae, test.elemType, actual)
+
+		}
+		if !reflect.DeepEqual(test.expected, actual) {
+			t.Errorf("%q - buildEnum expected %+v, got %+v", test.name, test.expected, actual)
 		}
 	}
 }

--- a/okta/utils_test.go
+++ b/okta/utils_test.go
@@ -135,6 +135,13 @@ func TestBuildEnum(t *testing.T) {
 			nil,
 			true,
 		},
+		{
+			"ae slice is not string slice",
+			[]interface{}{1, 2, 3},
+			"integer",
+			nil,
+			true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Moved buildEnum to utils.go as it is used in multiple files.
Allows buildEnum input ae slice to have a nil value.
Protects for all other values in ae slice are strings.
Adds unit test to illustrate intent on all edge chases.

Closes #1047