### PR TITLE
Fix markdown typo

### DIFF
--- a/website/docs/r/role_subscription.html.markdown
+++ b/website/docs/r/role_subscription.html.markdown
@@ -24,8 +24,8 @@ resource "okta_role_subscription" "test" {
 
 ## Argument Reference
 
-- `role_type` - (Required) Type of the role. Valid values: `"SUPER_ADMIN"`, `"ORG_ADMIN"`, `"API_ACCESS_MANAGEMENT_ADMIN",
-  "APP_ADMIN"`, `"USER_ADMIN"`, `"MOBILE_ADMIN"`, `"READ_ONLY_ADMIN"`, `"HELP_DESK_ADMIN"`, `"API_ADMIN".
+- `role_type` - (Required) Type of the role. Valid values: `"SUPER_ADMIN"`, `"ORG_ADMIN"`, `"API_ACCESS_MANAGEMENT_ADMIN"`,
+  `"APP_ADMIN"`, `"USER_ADMIN"`, `"MOBILE_ADMIN"`, `"READ_ONLY_ADMIN"`, `"HELP_DESK_ADMIN"`, `"API_ADMIN".
 
 - `notification_type` - (Required) Type of the notification. Valid values: 
 


### PR DESCRIPTION
Add missing backtick characters to separate distinct valid values