### PR TITLE
Fix for v3.25.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.25.1 (April 26, 2022)
+
+BUGS:
+
+ * Fix incomplete `compound_search_operator` on data source `okta_users`.  [#1077](https://github.com/okta/terraform-provider-okta/issues/1077). Thanks, [@monde](https://github.com/monde)!
+ * Fix default value regression on `okta_policy_rule_sign_on` for `identity_provider` attribute.  [#1079](https://github.com/okta/terraform-provider-okta/issues/1079). Thanks, [@monde](https://github.com/monde)!
+
 ## 3.25.0 (April 21, 2022)
 
 ENHANCEMENTS:

--- a/examples/okta_policy_rule_signon/okta_identity_provider.tf
+++ b/examples/okta_policy_rule_signon/okta_identity_provider.tf
@@ -18,7 +18,6 @@ resource "okta_policy_rule_signon" "test" {
   mfa_required      = true
   mfa_lifetime      = 15
   mfa_prompt        = "SESSION"
-  identity_provider = "OKTA"
 }
 
 resource "okta_network_zone" "test" {

--- a/examples/okta_users/datasource.tf
+++ b/examples/okta_users/datasource.tf
@@ -1,0 +1,18 @@
+data "okta_users" "compound_search" {
+  compound_search_operator = "and"
+
+  search {
+    name  = "profile.firstName"
+    value = "TestAcc"
+  }
+
+  search {
+    name  = "profile.lastName"
+    value = "Jones"
+  }
+
+  search {
+    name  = "profile.email"
+    comparison = "pr"
+  }
+}

--- a/okta/config.go
+++ b/okta/config.go
@@ -101,7 +101,7 @@ func (c *Config) loadAndValidate(ctx context.Context) error {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.25.0"),
+		okta.WithUserAgentExtra("okta-terraform/3.25.1"),
 	}
 	if c.apiToken == "" {
 		setters = append(setters, okta.WithAuthorizationMode("PrivateKey"))

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -36,6 +36,13 @@ func dataSourceUsers() *schema.Resource {
 						}),
 				},
 			},
+			"compound_search_operator": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "and",
+				ValidateDiagFunc: elemInSlice([]string{"and", "or"}),
+				Description:      "Search operator used when joining mulitple search clauses",
+			},
 		},
 	}
 }

--- a/okta/data_source_okta_users_test.go
+++ b/okta/data_source_okta_users_test.go
@@ -12,6 +12,7 @@ func TestAccOktaDataSourceUsers_read(t *testing.T) {
 	mgr := newFixtureManager(users)
 	users := mgr.GetFixtures("users.tf", ri, t)
 	config := mgr.GetFixtures("basic.tf", ri, t)
+	dataSource := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -34,6 +35,15 @@ func TestAccOktaDataSourceUsers_read(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_users.test", "users.#"),
+				),
+			},
+			{
+				Config: dataSource,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_users.compound_search", "compound_search_operator"),
+					resource.TestCheckResourceAttr("data.okta_users.compound_search", "compound_search_operator", "and"),
+					resource.TestCheckResourceAttrSet("data.okta_users.compound_search", "users.#"),
+					resource.TestCheckResourceAttr("data.okta_users.compound_search", "users.#", "1"),
 				),
 			},
 		},

--- a/okta/resource_okta_policy_rule_sign_on.go
+++ b/okta/resource_okta_policy_rule_sign_on.go
@@ -79,7 +79,8 @@ func resourcePolicySignOnRule() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: elemInSlice([]string{"", "ANY", "LOW", "MEDIUM", "HIGH"}),
 				Description:      "Risc level: ANY, LOW, MEDIUM or HIGH",
-				Default:          "ANY",
+				// On reads the Okta API can return a default value of "ANY" when not present in local TF config
+				DiffSuppressFunc: valueDiffDefaultAPIValueToLocalValue("ANY", ""),
 			},
 			"behaviors": {
 				Type:        schema.TypeSet,
@@ -135,7 +136,8 @@ func resourcePolicySignOnRule() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: elemInSlice([]string{"ANY", "OKTA", "SPECIFIC_IDP"}),
 				Description:      "Apply rule based on the IdP used: ANY, OKTA or SPECIFIC_IDP.",
-				Default:          "ANY",
+				// On reads the Okta API can return a default value of "ANY" when not present in local TF config
+				DiffSuppressFunc: valueDiffDefaultAPIValueToLocalValue("ANY", ""),
 			},
 			"identity_provider_ids": { // identity_provider must be SPECIFIC_IDP
 				Type:        schema.TypeList,
@@ -193,12 +195,6 @@ func resourcePolicySignOnRuleRead(ctx context.Context, d *schema.ResourceData, m
 			})
 			if err != nil {
 				return diag.Errorf("failed to set sign-on policy rule behaviors: %v", err)
-			}
-		}
-		if rule.Conditions.IdentityProvider != nil {
-			_ = d.Set("identity_provider", rule.Conditions.IdentityProvider.Provider)
-			if rule.Conditions.IdentityProvider.Provider == "SPECIFIC_IDP" {
-				_ = d.Set("identity_provider_ids", convertStringSliceToInterfaceSlice(rule.Conditions.IdentityProvider.IdpIds))
 			}
 		}
 	}
@@ -269,14 +265,6 @@ func buildSignOnPolicyRule(d *schema.ResourceData) sdk.PolicyRule {
 		},
 		Network: buildPolicyNetworkCondition(d),
 		People:  getUsers(d),
-	}
-
-	provider, ok := d.GetOk("identity_provider")
-	if ok {
-		template.Conditions.IdentityProvider = &okta.IdentityProviderPolicyRuleCondition{
-			Provider: provider.(string),
-			IdpIds:   convertInterfaceToStringArr(d.Get("identity_provider_ids")),
-		}
 	}
 
 	bi, ok := d.GetOk("behaviors")

--- a/okta/resource_okta_policy_rule_sign_on_test.go
+++ b/okta/resource_okta_policy_rule_sign_on_test.go
@@ -84,7 +84,6 @@ func TestAccOktaPolicyRuleSignon_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc_%d", ri)),
 					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
 					resource.TestCheckResourceAttr(resourceName, "mfa_required", "true"),
-					resource.TestCheckResourceAttr(resourceName, "identity_provider", "OKTA"),
 				),
 			},
 			{
@@ -94,10 +93,12 @@ func TestAccOktaPolicyRuleSignon_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc_%d", ri)),
 					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
 					resource.TestCheckResourceAttr(resourceName, "mfa_required", "false"),
-					resource.TestCheckResourceAttr(resourceName, "identity_provider", "SPECIFIC_IDP"),
-					resource.TestCheckResourceAttr(resourceName, "identity_provider_ids.#", "1"),
 				),
 			},
+
+			// This test is failing on our OIE test orgs but not on the non-OIE
+			// org. Some orgs need a feature flag for behaviors and/or it isn't
+			// supported on OIE orgs
 			{
 				Config: factorSequence,
 				Check: resource.ComposeTestCheckFunc(

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -215,6 +215,16 @@ func createValueDiffSuppression(newValueToIgnore string) schema.SchemaDiffSuppre
 	}
 }
 
+// ignore schema diff change if value changes from default value (TF old) to local value (TF new)
+func valueDiffDefaultAPIValueToLocalValue(defaultAPIValue, localValue string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		if old == defaultAPIValue && new == localValue {
+			return true
+		}
+		return false
+	}
+}
+
 func ensureNotDefault(d *schema.ResourceData, t string) error {
 	thing := fmt.Sprintf("Default %s", t)
 

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -45,7 +45,7 @@ data "okta_user" "example" {
 
 - `search` - (Optional) Map of search criteria. It supports the following properties.
   - `name` - (Required w/ comparison and value) Name of property to search against.
-  - `comparison` - (Required w/ name and value) Comparison to use.
+  - `comparison` - (Required w/ name and value) Comparison to use. Comparitors for strings: [`eq`, `ge`, `gt`, `le`, `lt`, `ne`, `pr`, `sw`](https://developer.okta.com/docs/reference/core-okta-api/#operators).
   - `value` - (Required w/ comparison and name) Value to compare with.
   - `expression` - (Optional, but overrides name/comparison/value) A raw search expression string. If present it will override name/comparison/value.
 - `compound_search_operator` - (Optional) Given multiple search elements they will be compounded together with the op. Default is `and`, `or` is also valid.

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -33,7 +33,7 @@ data "okta_users" "example" {
 
 - `search` - (Optional) Map of search criteria. It supports the following properties.
   - `name` - (Required w/ comparison and value) Name of property to search against.
-  - `comparison` - (Required w/ name and value) Comparison to use.
+  - `comparison` - (Required w/ name and value) Comparison to use. Comparitors for strings: [`eq`, `ge`, `gt`, `le`, `lt`, `ne`, `pr`, `sw`](https://developer.okta.com/docs/reference/core-okta-api/#operators).
   - `value` - (Required w/ comparison and name) Value to compare with.
   - `expression` - (Optional, but overrides name/comparison/value) A raw search expression string. If present it will override name/comparison/value.
 - `compound_search_operator` - (Optional) Given multiple search elements they will be compounded together with the op. Default is `and`, `or` is also valid.


### PR DESCRIPTION
 * Fix incomplete `compound_search_operator` on data source `okta_users`.
* Fix default value regression on `okta_policy_rule_sign_on` for `identity_provider` attribute. 