### PR TITLE
Data sources and resources for branded email customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,7 @@ ENHANCEMENTS:
     * TestAccOktaPolicySignOn_crud
     * TestAccAppOAuthApplication_postLogoutRedirectCrud
   * Backoff/retry on application delete
-<<<<<<< HEAD
 * Update okta_app_saml resource documentation. [#1076](https://github.com/okta/terraform-provider-okta/pull/1076). Thanks, [@jphuynh](https://github.com/jphuynh)!
-=======
->>>>>>> 10fd978f (Prep for v3.25.0)
 
 ## 3.24.0 (April 15, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,10 @@ ENHANCEMENTS:
     * TestAccOktaPolicySignOn_crud
     * TestAccAppOAuthApplication_postLogoutRedirectCrud
   * Backoff/retry on application delete
+<<<<<<< HEAD
 * Update okta_app_saml resource documentation. [#1076](https://github.com/okta/terraform-provider-okta/pull/1076). Thanks, [@jphuynh](https://github.com/jphuynh)!
+=======
+>>>>>>> 10fd978f (Prep for v3.25.0)
 
 ## 3.24.0 (April 15, 2022)
 

--- a/examples/okta_brand/README.md
+++ b/examples/okta_brand/README.md
@@ -1,0 +1,11 @@
+# okta_brand
+
+This resource represents a brand for an Okta organization. For more information
+can be found in the
+[Brand](https://developer.okta.com/docs/reference/api/brands/#brand-object) API
+documentation.
+
+- Example [datastore.tf](./datasource.tf)
+- Example [basic.tf](./basic.tf)
+- Example [updated.tf](./updated.tf)
+- Example [import.tf](./import.tf)

--- a/examples/okta_brand/README.md
+++ b/examples/okta_brand/README.md
@@ -1,7 +1,7 @@
 # okta_brand
 
-This resource represents a brand for an Okta organization. For more information
-can be found in the
+This resource represents a brand for an Okta organization. More information can
+be found in the
 [Brand](https://developer.okta.com/docs/reference/api/brands/#brand-object) API
 documentation.
 

--- a/examples/okta_brand/basic.tf
+++ b/examples/okta_brand/basic.tf
@@ -1,0 +1,8 @@
+# This example is part of the test harness. The okta_brand resource state has
+# already been imported via import.tf
+
+resource "okta_brand" "example" {
+  agree_to_custom_privacy_policy = true
+  custom_privacy_policy_url      = "https://example.com/privacy-policy"
+  remove_powered_by_okta         = false
+}

--- a/examples/okta_brand/datasource.tf
+++ b/examples/okta_brand/datasource.tf
@@ -1,0 +1,6 @@
+data "okta_brands" "test" {
+}
+
+data "okta_brand" "example" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+}

--- a/examples/okta_brand/import.tf
+++ b/examples/okta_brand/import.tf
@@ -1,0 +1,7 @@
+# This example 
+data "okta_brands" "test" {
+}
+
+resource "okta_brand" "example" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+}

--- a/examples/okta_brand/updated.tf
+++ b/examples/okta_brand/updated.tf
@@ -1,0 +1,8 @@
+# This example is part of the test harness. The okta_brand resource state has
+# already been imported via import.tf
+
+resource "okta_brand" "example" {
+  agree_to_custom_privacy_policy = true
+  custom_privacy_policy_url      = "https://example.com/privacy-policy-updated"
+  remove_powered_by_okta         = true
+}

--- a/examples/okta_brands/README.md
+++ b/examples/okta_brands/README.md
@@ -1,0 +1,6 @@
+# okta_brands
+
+This resource represents brands configuration for an Okta organization. For more information see
+the [API docs](https://developer.okta.com/docs/reference/api/brands/)
+
+- Example [can be found here](./datasource.tf)

--- a/examples/okta_brands/README.md
+++ b/examples/okta_brands/README.md
@@ -1,6 +1,6 @@
 # okta_brands
 
-This resource represents brands configuration for an Okta organization. For more information see
-the [API docs](https://developer.okta.com/docs/reference/api/brands/)
+This resource represents brands of an Okta organization. For more information
+see the API docs for [Brands](https://developer.okta.com/docs/reference/api/brands/)
 
-- Example [can be found here](./datasource.tf)
+- Example [datastore.tf](./datasource.tf)

--- a/examples/okta_brands/datasource.tf
+++ b/examples/okta_brands/datasource.tf
@@ -1,0 +1,2 @@
+data "okta_brands" "test" {
+}

--- a/examples/okta_email_customization/README.md
+++ b/examples/okta_email_customization/README.md
@@ -1,0 +1,7 @@
+# okta_email_customizations
+
+Use this data source to retrieve the [email
+customization](https://developer.okta.com/docs/reference/api/brands/#get-email-customization)
+of an email template belonging to a brand in an Okta organization.
+
+- Example [datastore.tf](./datasource.tf)

--- a/examples/okta_email_customization/README.md
+++ b/examples/okta_email_customization/README.md
@@ -5,3 +5,5 @@ customization](https://developer.okta.com/docs/reference/api/brands/#get-email-c
 of an email template belonging to a brand in an Okta organization.
 
 - Example [datastore.tf](./datasource.tf)
+- Example [basic.tf](./basic.tf)
+- Example [updated.tf](./updated.tf)

--- a/examples/okta_email_customization/basic.tf
+++ b/examples/okta_email_customization/basic.tf
@@ -1,0 +1,16 @@
+data "okta_brands" "test" {
+}
+
+data "okta_email_customizations" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}
+
+resource "okta_email_customization" "forgot_password_en_alt" {
+  brand_id      = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+  language      = "cs" # Setting the language to Czech for acceptance testing
+  is_default    = false # A true is_default will cause an error during create if there is already a default customization. In general, use for update.
+  subject       = "Forgot Password"
+  body          = "Hi $$user.firstName,<br/><br/>Click this link to reset your password: $$resetPasswordLink"
+}

--- a/examples/okta_email_customization/datasource.tf
+++ b/examples/okta_email_customization/datasource.tf
@@ -6,7 +6,6 @@ data "okta_email_customizations" "forgot_password" {
   template_name = "ForgotPassword"
 }
 
-
 data "okta_email_customization" "forgot_password_en" {
   customization_id = tolist(data.okta_email_customizations.forgot_password.email_customizations)[0].id
   brand_id = tolist(data.okta_brands.test.brands)[0].id

--- a/examples/okta_email_customization/datasource.tf
+++ b/examples/okta_email_customization/datasource.tf
@@ -1,0 +1,14 @@
+data "okta_brands" "test" {
+}
+
+data "okta_email_customizations" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}
+
+
+data "okta_email_customization" "forgot_password_en" {
+  customization_id = tolist(data.okta_email_customizations.forgot_password.email_customizations)[0].id
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}

--- a/examples/okta_email_customization/updated.tf
+++ b/examples/okta_email_customization/updated.tf
@@ -10,6 +10,7 @@ resource "okta_email_customization" "forgot_password_en_alt" {
   brand_id      = tolist(data.okta_brands.test.brands)[0].id
   template_name = "ForgotPassword"
   language      = "cs"
+  is_default    = false
   subject       = "Forgot Password"
   body          = "Hello $$user.firstName,<br/><br/>Click this link to reset your password: $$resetPasswordLink"
 }

--- a/examples/okta_email_customization/updated.tf
+++ b/examples/okta_email_customization/updated.tf
@@ -1,0 +1,15 @@
+data "okta_brands" "test" {
+}
+
+data "okta_email_customizations" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}
+
+resource "okta_email_customization" "forgot_password_en_alt" {
+  brand_id      = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+  language      = "cs"
+  subject       = "Forgot Password"
+  body          = "Hello $$user.firstName,<br/><br/>Click this link to reset your password: $$resetPasswordLink"
+}

--- a/examples/okta_email_customizations/README.md
+++ b/examples/okta_email_customizations/README.md
@@ -1,0 +1,7 @@
+# okta_email_customizations
+
+This data source represents email customizations for a brand in an Okta
+organization. For more information see the API docs for [Email
+Customizations](https://developer.okta.com/docs/reference/api/brands/#email-customizations)
+
+- Example [datastore.tf](./datasource.tf)

--- a/examples/okta_email_customizations/datasource.tf
+++ b/examples/okta_email_customizations/datasource.tf
@@ -1,0 +1,7 @@
+data "okta_brands" "test" {
+}
+
+data "okta_email_customizations" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}

--- a/examples/okta_email_template/README.md
+++ b/examples/okta_email_template/README.md
@@ -1,0 +1,7 @@
+# okta_email_template
+
+This data source represents an email template for a brand in an Okta
+organization. For more information see the API docs for [Email
+Template](https://developer.okta.com/docs/reference/api/brands/#email-template)
+
+- Example [datastore.tf](./datasource.tf)

--- a/examples/okta_email_template/datasource.tf
+++ b/examples/okta_email_template/datasource.tf
@@ -1,0 +1,7 @@
+data "okta_brands" "test" {
+}
+
+data "okta_email_template" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  name = "ForgotPassword"
+}

--- a/examples/okta_email_templates/README.md
+++ b/examples/okta_email_templates/README.md
@@ -1,0 +1,7 @@
+# okta_email_templates
+
+This data source represents email templates for a brand in an Okta
+organization. For more information see the API docs for [Email
+Templates](https://developer.okta.com/docs/reference/api/brands/#email-templates)
+
+- Example [datastore.tf](./datasource.tf)

--- a/examples/okta_email_templates/datasource.tf
+++ b/examples/okta_email_templates/datasource.tf
@@ -1,0 +1,6 @@
+data "okta_brands" "test" {
+}
+
+data "okta_email_templates" "test" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+}

--- a/okta/brand.go
+++ b/okta/brand.go
@@ -7,7 +7,57 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
-var brandDataSchema = map[string]*schema.Schema{
+var brandResourceSchema = map[string]*schema.Schema{
+	"id": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Brand ID",
+	},
+	"brand_id": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Brand ID - Note: Okta API for brands only reads and updates therefore the okta_brand resource needs to act as a quasi data source. Do this by setting brand_id.",
+	},
+	"agree_to_custom_privacy_policy": {
+		Type:         schema.TypeBool,
+		Optional:     true,
+		Description:  "Consent for updating the custom privacy policy URL.",
+		RequiredWith: []string{"custom_privacy_policy_url"},
+	},
+	"custom_privacy_policy_url": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		Description:      "Custom privacy policy URL",
+		DiffSuppressFunc: suppressDuringCreate,
+	},
+	"links": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the brand",
+	},
+	"remove_powered_by_okta": {
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		Description:      `Removes "Powered by Okta" from the Okta-hosted sign-in page and "© 2021 Okta, Inc." from the Okta End-User Dashboard`,
+		DiffSuppressFunc: suppressDuringCreate,
+	},
+}
+
+func suppressDuringCreate(k, old, new string, d *schema.ResourceData) bool {
+	// If brand_id has changed assume this is create and treat the properties as readers not caring about what would otherwise apear to be drift.
+	if d.HasChange("brand_id") {
+		return true
+	}
+	return old == new
+}
+
+var brandDataSourceSchema = map[string]*schema.Schema{
+	"brand_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Brand ID",
+	},
 	"custom_privacy_policy_url": {
 		Type:        schema.TypeString,
 		Computed:    true,
@@ -16,7 +66,30 @@ var brandDataSchema = map[string]*schema.Schema{
 	"links": {
 		Type:        schema.TypeString,
 		Computed:    true,
-		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the app",
+		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the brand",
+	},
+	"remove_powered_by_okta": {
+		Type:        schema.TypeBool,
+		Computed:    true,
+		Description: `Removes "Powered by Okta" from the Okta-hosted sign-in page and "© 2021 Okta, Inc." from the Okta End-User Dashboard`,
+	},
+}
+
+var brandsDataSourceSchema = map[string]*schema.Schema{
+	"id": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Brand ID",
+	},
+	"custom_privacy_policy_url": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Custom privacy policy URL",
+	},
+	"links": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the brand",
 	},
 	"remove_powered_by_okta": {
 		Type:        schema.TypeBool,
@@ -27,11 +100,17 @@ var brandDataSchema = map[string]*schema.Schema{
 
 func flattenBrand(brand *okta.Brand) map[string]interface{} {
 	attrs := map[string]interface{}{}
-
-	attrs["custom_privacy_policy_url"] = brand.CustomPrivacyPolicyUrl
+	// NOTE: explicitly set defaults on brand
+	attrs["custom_privacy_policy_url"] = ""
+	if brand.CustomPrivacyPolicyUrl != "" {
+		attrs["custom_privacy_policy_url"] = brand.CustomPrivacyPolicyUrl
+	}
 	links, _ := json.Marshal(brand.Links)
 	attrs["links"] = string(links)
-	attrs["remove_powered_by_okta"] = *brand.RemovePoweredByOkta
+	attrs["remove_powered_by_okta"] = false
+	if brand.RemovePoweredByOkta != nil {
+		attrs["remove_powered_by_okta"] = *brand.RemovePoweredByOkta
+	}
 
 	return attrs
 }

--- a/okta/brand.go
+++ b/okta/brand.go
@@ -1,0 +1,37 @@
+package okta
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+var brandDataSchema = map[string]*schema.Schema{
+	"custom_privacy_policy_url": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Custom privacy policy URL",
+	},
+	"links": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the app",
+	},
+	"remove_powered_by_okta": {
+		Type:        schema.TypeBool,
+		Computed:    true,
+		Description: `Removes "Powered by Okta" from the Okta-hosted sign-in page and "© 2021 Okta, Inc." from the Okta End-User Dashboard`,
+	},
+}
+
+func flattenBrand(brand *okta.Brand) map[string]interface{} {
+	attrs := map[string]interface{}{}
+
+	attrs["custom_privacy_policy_url"] = brand.CustomPrivacyPolicyUrl
+	links, _ := json.Marshal(brand.Links)
+	attrs["links"] = string(links)
+	attrs["remove_powered_by_okta"] = *brand.RemovePoweredByOkta
+
+	return attrs
+}

--- a/okta/data_source_okta_brand.go
+++ b/okta/data_source_okta_brand.go
@@ -1,0 +1,37 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func dataSourceBrand() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBrandRead,
+		Schema:      brandDataSourceSchema,
+	}
+}
+
+func dataSourceBrandRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var brand *okta.Brand
+	var err error
+	brandID, ok := d.GetOk("brand_id")
+	if ok {
+		logger(m).Info("reading brand by ID", "id", brandID.(string))
+		brand, _, err = getOktaClientFromMetadata(m).Brand.GetBrand(ctx, brandID.(string))
+		if err != nil {
+			return diag.Errorf("failed to get brand: %v", err)
+		}
+	}
+	d.SetId(brand.Id)
+	rawMap := flattenBrand(brand)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set brand's properties: %v", err)
+	}
+
+	return nil
+}

--- a/okta/data_source_okta_brand_test.go
+++ b/okta/data_source_okta_brand_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceOktaBrands_read(t *testing.T) {
+func TestAccDataSourceOktaBrand_read(t *testing.T) {
 	ri := acctest.RandInt()
-	mgr := newFixtureManager(brands)
+	mgr := newFixtureManager(brand)
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
@@ -17,12 +17,11 @@ func TestAccDataSourceOktaBrands_read(t *testing.T) {
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config:  config,
+				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.okta_brands.test", "brands.#"),
-					resource.TestCheckResourceAttr("data.okta_brands.test", "brands.#", "1"),
-					resource.TestCheckResourceAttrSet("data.okta_brands.test", "brands.0.id"),
-					resource.TestCheckResourceAttrSet("data.okta_brands.test", "brands.0.links"),
+					resource.TestCheckResourceAttrSet("data.okta_brand.example", "brand_id"),
+					resource.TestCheckResourceAttrSet("data.okta_brand.example", "links"),
 				),
 			},
 		},

--- a/okta/data_source_okta_brands.go
+++ b/okta/data_source_okta_brands.go
@@ -1,0 +1,49 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceBrands() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBrandsRead,
+		Schema: map[string]*schema.Schema{
+			"brands": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: buildSchema(
+						brandDataSchema,
+						map[string]*schema.Schema{
+							"id": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Brand ID",
+							},
+						}),
+				},
+			},
+		},
+	}
+}
+
+func dataSourceBrandsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	brands, _, err := getOktaClientFromMetadata(m).Brand.ListBrands(ctx)
+	if err != nil {
+		return diag.Errorf("failed to list brands: %v", err)
+	}
+
+	d.SetId("brands") // there is only one brands list on the org
+	arr := make([]map[string]interface{}, len(brands))
+	for i, brand := range brands {
+		rawMap := flattenBrand(brand)
+		rawMap["id"] = brand.Id
+		arr[i] = rawMap
+	}
+	_ = d.Set("brands", arr)
+
+	return nil
+}

--- a/okta/data_source_okta_brands.go
+++ b/okta/data_source_okta_brands.go
@@ -36,10 +36,10 @@ func dataSourceBrandsRead(ctx context.Context, d *schema.ResourceData, m interfa
 		rawMap["id"] = brand.Id
 		arr[i] = rawMap
 	}
-	brandResource := &schema.Resource{
+	brandDataSource := &schema.Resource{
 		Schema: brandResourceSchema,
 	}
-	_ = d.Set("brands", schema.NewSet(schema.HashResource(brandResource), arr))
+	_ = d.Set("brands", schema.NewSet(schema.HashResource(brandDataSource), arr))
 
 	return nil
 }

--- a/okta/data_source_okta_brands_test.go
+++ b/okta/data_source_okta_brands_test.go
@@ -1,0 +1,28 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaDataSourceBrands_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(brands)
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_brands.test", "brands.#"),
+					resource.TestCheckResourceAttr("data.okta_brands.test", "brands.#", "1"),
+				),
+			},
+		},
+	})
+}

--- a/okta/data_source_okta_email_customization.go
+++ b/okta/data_source_okta_email_customization.go
@@ -1,0 +1,56 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func dataSourceEmailCustomization() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEmailCustomizationRead,
+		Schema:      emailCustomizationDataSourceSchema,
+	}
+}
+
+func dataSourceEmailCustomizationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var brand *okta.Brand
+	var err error
+	brandID, ok := d.GetOk("brand_id")
+	if ok {
+		logger(m).Info("reading brand by ID", "id", brandID.(string))
+		brand, _, err = getOktaClientFromMetadata(m).Brand.GetBrand(ctx, brandID.(string))
+		if err != nil {
+			return diag.Errorf("failed to get brand for email template: %v", err)
+		}
+	} else {
+		return diag.Errorf("brand_id required for email template: %v", err)
+	}
+
+	templateName, ok := d.GetOk("template_name")
+	if !ok {
+		return diag.Errorf("template name required for email template: %v", err)
+	}
+
+	customizationId, ok := d.GetOk("customization_id")
+	if !ok {
+		return diag.Errorf("customization_id required for email customization: %v", err)
+	}
+
+	customization, _, err := getOktaClientFromMetadata(m).Brand.GetEmailTemplateCustomization(ctx, brandID.(string), templateName.(string), customizationId.(string))
+	if err != nil {
+		return diag.Errorf("failed to get email template: %v", err)
+	}
+
+	d.SetId(fmt.Sprintf("email_customization-%s-%s-%s", customization.Id, templateName, brand.Id))
+	rawMap := flattenEmailCustomization(brandID.(string), templateName.(string), customization)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set email customization properties: %v", err)
+	}
+
+	return nil
+}

--- a/okta/data_source_okta_email_customization.go
+++ b/okta/data_source_okta_email_customization.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
 func dataSourceEmailCustomization() *schema.Resource {
@@ -17,27 +16,19 @@ func dataSourceEmailCustomization() *schema.Resource {
 }
 
 func dataSourceEmailCustomizationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var brand *okta.Brand
-	var err error
 	brandID, ok := d.GetOk("brand_id")
-	if ok {
-		logger(m).Info("reading brand by ID", "id", brandID.(string))
-		brand, _, err = getOktaClientFromMetadata(m).Brand.GetBrand(ctx, brandID.(string))
-		if err != nil {
-			return diag.Errorf("failed to get brand for email template: %v", err)
-		}
-	} else {
-		return diag.Errorf("brand_id required for email template: %v", err)
+	if !ok {
+		return diag.Errorf("brand_id required for email template")
 	}
 
 	templateName, ok := d.GetOk("template_name")
 	if !ok {
-		return diag.Errorf("template name required for email template: %v", err)
+		return diag.Errorf("template name required for email template")
 	}
 
 	customizationId, ok := d.GetOk("customization_id")
 	if !ok {
-		return diag.Errorf("customization_id required for email customization: %v", err)
+		return diag.Errorf("customization_id required for email customization")
 	}
 
 	customization, _, err := getOktaClientFromMetadata(m).Brand.GetEmailTemplateCustomization(ctx, brandID.(string), templateName.(string), customizationId.(string))
@@ -45,8 +36,8 @@ func dataSourceEmailCustomizationRead(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("failed to get email template: %v", err)
 	}
 
-	d.SetId(fmt.Sprintf("email_customization-%s-%s-%s", customization.Id, templateName, brand.Id))
-	rawMap := flattenEmailCustomization(brandID.(string), templateName.(string), customization)
+	d.SetId(fmt.Sprintf("email_customization-%s-%s-%s", customization.Id, templateName.(string), brandID.(string)))
+	rawMap := flattenEmailCustomization(brandID.(string), templateName.(string), true, customization)
 	err = setNonPrimitives(d, rawMap)
 	if err != nil {
 		return diag.Errorf("failed to set email customization properties: %v", err)

--- a/okta/data_source_okta_email_customization_test.go
+++ b/okta/data_source_okta_email_customization_test.go
@@ -1,0 +1,40 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaEmailCustomization_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(emailCustomization)
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "customization_id"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "id"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "brand_id"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "template_name"),
+					resource.TestCheckResourceAttr("data.okta_email_customization.forgot_password_en", "template_name", "ForgotPassword"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "language"),
+					resource.TestCheckResourceAttr("data.okta_email_customization.forgot_password_en", "language", "en"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "is_default"),
+					resource.TestCheckResourceAttr("data.okta_email_customization.forgot_password_en", "is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "subject"),
+					resource.TestCheckResourceAttr("data.okta_email_customization.forgot_password_en", "subject", "Stuff"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "body"),
+					resource.TestCheckResourceAttr("data.okta_email_customization.forgot_password_en", "body", "Hi $$user.firstName,<br/><br/>Blah blah $$resetPasswordLink"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customization.forgot_password_en", "links"),
+				),
+			},
+		},
+	})
+}

--- a/okta/data_source_okta_email_customizations.go
+++ b/okta/data_source_okta_email_customizations.go
@@ -1,0 +1,56 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func dataSourceEmailCustomizations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEmailCustomizationsRead,
+		Schema:      emailCustomizationsDataSourceSchema,
+	}
+}
+
+func dataSourceEmailCustomizationsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var brand *okta.Brand
+	var err error
+	brandID, ok := d.GetOk("brand_id")
+	if ok {
+		logger(m).Info("reading brand by ID", "id", brandID.(string))
+		brand, _, err = getOktaClientFromMetadata(m).Brand.GetBrand(ctx, brandID.(string))
+		if err != nil {
+			return diag.Errorf("failed to get brand for email customizations: %v", err)
+		}
+	} else {
+		return diag.Errorf("brand_id required for email customizations: %v", err)
+	}
+
+	templateName, ok := d.GetOk("template_name")
+	if !ok {
+		return diag.Errorf("template name required for email customizations: %v", err)
+	}
+
+	customizations, _, err := getOktaClientFromMetadata(m).Brand.ListEmailTemplateCustomizations(ctx, brand.Id, templateName.(string))
+	if err != nil {
+		return diag.Errorf("failed to list email customizations: %v", err)
+	}
+
+	d.SetId(fmt.Sprintf("email_customizations-%s-%s", templateName, brand.Id))
+	arr := make([]interface{}, len(customizations))
+	for i, customization := range customizations {
+		rawMap := flattenEmailCustomization(brand.Id, templateName.(string), customization)
+		arr[i] = rawMap
+	}
+
+	err = d.Set("email_customizations", schema.NewSet(hashEmailCustomization, arr))
+	if err != nil {
+		return diag.Errorf("failed to set email customizations: %v", err)
+	}
+
+	return nil
+}

--- a/okta/data_source_okta_email_customizations_test.go
+++ b/okta/data_source_okta_email_customizations_test.go
@@ -1,0 +1,50 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaEmailCustomizations_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(emailCustomizations)
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.#"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.#", "2"),
+
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.0.id"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.0.language"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.0.language", "en"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.0.is_default"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.0.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.0.subject"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.0.subject", "Stuff"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.0.body"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.0.body", "Hi $$user.firstName,<br/><br/>Blah blah $$resetPasswordLink"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.0.links"),
+
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.1.id"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.1.language"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.1.language", "es"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.1.is_default"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.1.is_default", "false"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.1.subject"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.1.subject", "Cosas"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.1.body"),
+					resource.TestCheckResourceAttr("data.okta_email_customizations.forgot_password", "email_customizations.1.body", "Hola $$user.firstName,<br/><br/>Puedo ir al bano $$resetPasswordLink"),
+					resource.TestCheckResourceAttrSet("data.okta_email_customizations.forgot_password", "email_customizations.1.links"),
+				),
+			},
+		},
+	})
+}

--- a/okta/data_source_okta_email_template.go
+++ b/okta/data_source_okta_email_template.go
@@ -1,0 +1,51 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func dataSourceEmailTemplate() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEmailTemplateRead,
+		Schema:      emailTemplateDataSourceSchema,
+	}
+}
+
+func dataSourceEmailTemplateRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var brand *okta.Brand
+	var err error
+	brandID, ok := d.GetOk("brand_id")
+	if ok {
+		logger(m).Info("reading brand by ID", "id", brandID.(string))
+		brand, _, err = getOktaClientFromMetadata(m).Brand.GetBrand(ctx, brandID.(string))
+		if err != nil {
+			return diag.Errorf("failed to get brand for email template: %v", err)
+		}
+	} else {
+		return diag.Errorf("brand_id required for email template: %v", err)
+	}
+
+	templateName, ok := d.GetOk("name")
+	if !ok {
+		return diag.Errorf("name required for email template: %v", err)
+	}
+
+	template, _, err := getOktaClientFromMetadata(m).Brand.GetEmailTemplate(ctx, brandID.(string), templateName.(string))
+	if err != nil {
+		return diag.Errorf("failed to get email template: %v", err)
+	}
+
+	d.SetId(fmt.Sprintf("email_template-%s-%s", templateName, brand.Id))
+	rawMap := flattenEmailTemplate(template)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set email template's properties: %v", err)
+	}
+
+	return nil
+}

--- a/okta/data_source_okta_email_template_test.go
+++ b/okta/data_source_okta_email_template_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccDataSourceOktaEmailTemplate_read(t *testing.T) {
 	ri := acctest.RandInt()
-	mgr := newFixtureManager(email_template)
+	mgr := newFixtureManager(emailTemplate)
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{

--- a/okta/data_source_okta_email_template_test.go
+++ b/okta/data_source_okta_email_template_test.go
@@ -1,0 +1,31 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaEmailTemplate_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(email_template)
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:  config,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_email_template.forgot_password", "brand_id"),
+					resource.TestCheckResourceAttrSet("data.okta_email_template.forgot_password", "name"),
+					resource.TestCheckResourceAttr("data.okta_email_template.forgot_password", "name", "ForgotPassword"),
+					resource.TestCheckResourceAttrSet("data.okta_email_template.forgot_password", "links"),
+				),
+			},
+		},
+	})
+}

--- a/okta/data_source_okta_email_templates.go
+++ b/okta/data_source_okta_email_templates.go
@@ -1,0 +1,48 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func dataSourceEmailTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEmailTemplatesRead,
+		Schema:      emailTemplatesDataSourceSchema,
+	}
+}
+
+func dataSourceEmailTemplatesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var brand *okta.Brand
+	var err error
+	brandID, ok := d.GetOk("brand_id")
+	if ok {
+		logger(m).Info("reading brand by ID", "id", brandID.(string))
+		brand, _, err = getOktaClientFromMetadata(m).Brand.GetBrand(ctx, brandID.(string))
+		if err != nil {
+			return diag.Errorf("failed to get brand for email templates: %v", err)
+		}
+	}
+
+	templates, _, err := getOktaClientFromMetadata(m).Brand.ListEmailTemplates(ctx, brand.Id, nil)
+	if err != nil {
+		return diag.Errorf("failed to list email templates: %v", err)
+	}
+
+	d.SetId(fmt.Sprintf("email_templates-%s", brand.Id))
+	arr := make([]interface{}, len(templates))
+	for i, template := range templates {
+		rawMap := flattenEmailTemplate(template)
+		arr[i] = rawMap
+	}
+	emailTemplatesDataSource := &schema.Resource{
+		Schema: emailTemplateDataSourceSchema,
+	}
+	_ = d.Set("email_templates", schema.NewSet(schema.HashResource(emailTemplatesDataSource), arr))
+
+	return nil
+}

--- a/okta/data_source_okta_email_templates.go
+++ b/okta/data_source_okta_email_templates.go
@@ -26,6 +26,8 @@ func dataSourceEmailTemplatesRead(ctx context.Context, d *schema.ResourceData, m
 		if err != nil {
 			return diag.Errorf("failed to get brand for email templates: %v", err)
 		}
+	} else {
+		return diag.Errorf("brand_id required for email templates: %v", err)
 	}
 
 	templates, _, err := getOktaClientFromMetadata(m).Brand.ListEmailTemplates(ctx, brand.Id, nil)

--- a/okta/data_source_okta_email_templates_test.go
+++ b/okta/data_source_okta_email_templates_test.go
@@ -23,6 +23,8 @@ func TestAccDataSourceOktaEmailTemplates_read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.okta_email_templates.test", "email_templates.#", "10"),
 					resource.TestCheckResourceAttrSet("data.okta_email_templates.test", "email_templates.0.name"),
 					resource.TestCheckResourceAttrSet("data.okta_email_templates.test", "email_templates.0.links"),
+					resource.TestCheckResourceAttrSet("data.okta_email_templates.test", "email_templates.1.name"),
+					resource.TestCheckResourceAttrSet("data.okta_email_templates.test", "email_templates.1.links"),
 				),
 			},
 		},

--- a/okta/data_source_okta_email_templates_test.go
+++ b/okta/data_source_okta_email_templates_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccDataSourceOktaEmailTemplates_read(t *testing.T) {
 	ri := acctest.RandInt()
-	mgr := newFixtureManager(email_templates)
+	mgr := newFixtureManager(emailTemplates)
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{

--- a/okta/data_source_okta_email_templates_test.go
+++ b/okta/data_source_okta_email_templates_test.go
@@ -1,0 +1,30 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaEmailTemplates_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(email_templates)
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_email_templates.test", "email_templates.#"),
+					resource.TestCheckResourceAttr("data.okta_email_templates.test", "email_templates.#", "10"),
+					resource.TestCheckResourceAttrSet("data.okta_email_templates.test", "email_templates.0.name"),
+					resource.TestCheckResourceAttrSet("data.okta_email_templates.test", "email_templates.0.links"),
+				),
+			},
+		},
+	})
+}

--- a/okta/email_customization.go
+++ b/okta/email_customization.go
@@ -79,9 +79,54 @@ var emailCustomizationDataSourceSchema = map[string]*schema.Schema{
 	},
 }
 
-func flattenEmailCustomization(brandId, templateName string, emailCustomization *okta.EmailTemplateCustomization) map[string]interface{} {
+var emailCustomizationResourceSchema = map[string]*schema.Schema{
+	"id": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The ID of the customization",
+	},
+	"brand_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Brand ID",
+	},
+	"template_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Template Name",
+	},
+	"links": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the email template",
+	},
+	"language": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The language supported by the customization",
+	},
+	"is_default": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Whether the customization is the default",
+	},
+	"subject": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The subject of the customization",
+	},
+	"body": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The body of the customization",
+	},
+}
+
+func flattenEmailCustomization(brandId, templateName string, isDataSource bool, emailCustomization *okta.EmailTemplateCustomization) map[string]interface{} {
 	attrs := map[string]interface{}{}
-	attrs["customization_id"] = emailCustomization.Id
+	if isDataSource {
+		attrs["customization_id"] = emailCustomization.Id
+	}
 	attrs["id"] = emailCustomization.Id
 	attrs["brand_id"] = brandId
 	attrs["template_name"] = templateName

--- a/okta/email_customization.go
+++ b/okta/email_customization.go
@@ -32,6 +32,11 @@ var emailCustomizationsDataSourceSchema = map[string]*schema.Schema{
 }
 
 var emailCustomizationDataSourceSchema = map[string]*schema.Schema{
+	"customization_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The ID of the customization",
+	},
 	"id": {
 		Type:        schema.TypeString,
 		Computed:    true,
@@ -76,6 +81,7 @@ var emailCustomizationDataSourceSchema = map[string]*schema.Schema{
 
 func flattenEmailCustomization(brandId, templateName string, emailCustomization *okta.EmailTemplateCustomization) map[string]interface{} {
 	attrs := map[string]interface{}{}
+	attrs["customization_id"] = emailCustomization.Id
 	attrs["id"] = emailCustomization.Id
 	attrs["brand_id"] = brandId
 	attrs["template_name"] = templateName
@@ -96,7 +102,8 @@ func hashEmailCustomization(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf(
-		"%s-%s-%s-%s-",
+		"%s-%s-%s-%s-%s-",
+		m["customization_id"].(string),
 		m["brand_id"].(string),
 		m["template_name"].(string),
 		m["language"].(string),

--- a/okta/email_customization.go
+++ b/okta/email_customization.go
@@ -1,0 +1,106 @@
+package okta
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+var emailCustomizationsDataSourceSchema = map[string]*schema.Schema{
+	"brand_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Brand ID",
+	},
+	"template_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Template Name",
+	},
+	"email_customizations": {
+		Type:        schema.TypeSet,
+		Computed:    true,
+		Description: "List of `okta_email_customization` belonging to the named email template of the brand in the organization",
+		Elem: &schema.Resource{
+			Schema: emailCustomizationDataSourceSchema,
+		},
+		Set: hashEmailCustomization,
+	},
+}
+
+var emailCustomizationDataSourceSchema = map[string]*schema.Schema{
+	"id": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The ID of the customization",
+	},
+	"brand_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Brand ID",
+	},
+	"template_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Template Name",
+	},
+	"links": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the email template",
+	},
+	"language": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The language supported by the customization",
+	},
+	"is_default": {
+		Type:        schema.TypeBool,
+		Computed:    true,
+		Description: "Whether the customization is the default",
+	},
+	"subject": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The subject of the customization",
+	},
+	"body": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The body of the customization",
+	},
+}
+
+func flattenEmailCustomization(brandId, templateName string, emailCustomization *okta.EmailTemplateCustomization) map[string]interface{} {
+	attrs := map[string]interface{}{}
+	attrs["id"] = emailCustomization.Id
+	attrs["brand_id"] = brandId
+	attrs["template_name"] = templateName
+	attrs["language"] = emailCustomization.Language
+	attrs["is_default"] = false
+	if emailCustomization.IsDefault != nil {
+		attrs["is_default"] = emailCustomization.IsDefault
+	}
+	attrs["subject"] = emailCustomization.Subject
+	attrs["body"] = emailCustomization.Body
+	links, _ := json.Marshal(emailCustomization.Links)
+	attrs["links"] = string(links)
+
+	return attrs
+}
+
+func hashEmailCustomization(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf(
+		"%s-%s-%s-%s-",
+		m["brand_id"].(string),
+		m["template_name"].(string),
+		m["language"].(string),
+		m["subject"].(string),
+	))
+	return schema.HashString(buf.String())
+}

--- a/okta/email_template.go
+++ b/okta/email_template.go
@@ -1,0 +1,46 @@
+package okta
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+var emailTemplatesDataSourceSchema = map[string]*schema.Schema{
+	"brand_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Brand ID",
+	},
+	"email_templates": {
+		Type:        schema.TypeSet,
+		Computed:    true,
+		Description: "List of `okta_email_template` belonging to a brand in the organization",
+		Elem: &schema.Resource{
+			Schema: emailTemplateDataSourceSchema,
+		},
+	},
+}
+
+var emailTemplateDataSourceSchema = map[string]*schema.Schema{
+	"name": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The name of the email template",
+	},
+	"links": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Link relations for this object - JSON HAL - Discoverable resources related to the email template",
+	},
+}
+
+func flattenEmailTemplate(emailTemplate *okta.EmailTemplate) map[string]interface{} {
+	attrs := map[string]interface{}{}
+	attrs["name"] = emailTemplate.Name
+	links, _ := json.Marshal(emailTemplate.Links)
+	attrs["links"] = string(links)
+
+	return attrs
+}

--- a/okta/email_template.go
+++ b/okta/email_template.go
@@ -24,9 +24,14 @@ var emailTemplatesDataSourceSchema = map[string]*schema.Schema{
 }
 
 var emailTemplateDataSourceSchema = map[string]*schema.Schema{
+	"brand_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Brand ID",
+	},
 	"name": {
 		Type:        schema.TypeString,
-		Computed:    true,
+		Required:    true,
 		Description: "The name of the email template",
 	},
 	"links": {

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -66,6 +66,7 @@ const (
 	domainVerification            = "okta_domain_verification"
 	emailSender                   = "okta_email_sender"
 	emailSenderVerification       = "okta_email_sender_verification"
+	email_template                = "okta_email_template"
 	email_templates               = "okta_email_templates"
 	eventHook                     = "okta_event_hook"
 	eventHookVerification         = "okta_event_hook_verification"
@@ -361,6 +362,7 @@ func Provider() *schema.Provider {
 			behaviors:                dataSourceBehaviors(),
 			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
+			email_template:           dataSourceEmailTemplate(),
 			email_templates:          dataSourceEmailTemplates(),
 			defaultPolicies:          deprecatedPolicies,
 			defaultPolicy:            dataSourceDefaultPolicy(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -55,6 +55,7 @@ const (
 	authServerScopes              = "okta_auth_server_scopes"
 	behavior                      = "okta_behavior"
 	behaviors                     = "okta_behaviors"
+	brand                         = "okta_brand"
 	brands                        = "okta_brands"
 	captcha                       = "okta_captcha"
 	captchaOrgWideSettings        = "okta_captcha_org_wide_settings"
@@ -259,6 +260,7 @@ func Provider() *schema.Provider {
 			authServerPolicyRule:          resourceAuthServerPolicyRule(),
 			authServerScope:               resourceAuthServerScope(),
 			behavior:                      resourceBehavior(),
+			brand:                         resourceBrand(),
 			captcha:                       resourceCaptcha(),
 			captchaOrgWideSettings:        resourceCaptchaOrgWideSettings(),
 			domain:                        resourceDomain(),
@@ -356,6 +358,7 @@ func Provider() *schema.Provider {
 			authServerScopes:         dataSourceAuthServerScopes(),
 			behavior:                 dataSourceBehavior(),
 			behaviors:                dataSourceBehaviors(),
+			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
 			defaultPolicies:          deprecatedPolicies,
 			defaultPolicy:            dataSourceDefaultPolicy(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -55,6 +55,7 @@ const (
 	authServerScopes              = "okta_auth_server_scopes"
 	behavior                      = "okta_behavior"
 	behaviors                     = "okta_behaviors"
+	brands                        = "okta_brands"
 	captcha                       = "okta_captcha"
 	captchaOrgWideSettings        = "okta_captcha_org_wide_settings"
 	defaultPolicies               = "okta_default_policies"
@@ -355,6 +356,7 @@ func Provider() *schema.Provider {
 			authServerScopes:         dataSourceAuthServerScopes(),
 			behavior:                 dataSourceBehavior(),
 			behaviors:                dataSourceBehaviors(),
+			brands:                   dataSourceBrands(),
 			defaultPolicies:          deprecatedPolicies,
 			defaultPolicy:            dataSourceDefaultPolicy(),
 			group:                    dataSourceGroup(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -66,6 +66,7 @@ const (
 	domainVerification            = "okta_domain_verification"
 	emailSender                   = "okta_email_sender"
 	emailSenderVerification       = "okta_email_sender_verification"
+	emailCustomization            = "okta_email_customization"
 	emailCustomizations           = "okta_email_customizations"
 	emailTemplate                 = "okta_email_template"
 	emailTemplates                = "okta_email_templates"
@@ -363,6 +364,7 @@ func Provider() *schema.Provider {
 			behaviors:                dataSourceBehaviors(),
 			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
+			emailCustomization:       dataSourceEmailCustomization(),
 			emailCustomizations:      dataSourceEmailCustomizations(),
 			emailTemplate:            dataSourceEmailTemplate(),
 			emailTemplates:           dataSourceEmailTemplates(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -270,6 +270,7 @@ func Provider() *schema.Provider {
 			domain:                        resourceDomain(),
 			domainCertificate:             resourceDomainCertificate(),
 			domainVerification:            resourceDomainVerification(),
+			emailCustomization:            resourceEmailCustomization(),
 			emailSender:                   resourceEmailSender(),
 			emailSenderVerification:       resourceEmailSenderVerification(),
 			eventHook:                     resourceEventHook(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -66,8 +66,8 @@ const (
 	domainVerification            = "okta_domain_verification"
 	emailSender                   = "okta_email_sender"
 	emailSenderVerification       = "okta_email_sender_verification"
-	email_template                = "okta_email_template"
-	email_templates               = "okta_email_templates"
+	emailTemplate                 = "okta_email_template"
+	emailTemplates                = "okta_email_templates"
 	eventHook                     = "okta_event_hook"
 	eventHookVerification         = "okta_event_hook_verification"
 	factor                        = "okta_factor"
@@ -362,8 +362,8 @@ func Provider() *schema.Provider {
 			behaviors:                dataSourceBehaviors(),
 			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
-			email_template:           dataSourceEmailTemplate(),
-			email_templates:          dataSourceEmailTemplates(),
+			emailTemplate:            dataSourceEmailTemplate(),
+			emailTemplates:           dataSourceEmailTemplates(),
 			defaultPolicies:          deprecatedPolicies,
 			defaultPolicy:            dataSourceDefaultPolicy(),
 			group:                    dataSourceGroup(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -66,6 +66,7 @@ const (
 	domainVerification            = "okta_domain_verification"
 	emailSender                   = "okta_email_sender"
 	emailSenderVerification       = "okta_email_sender_verification"
+	emailCustomizations           = "okta_email_customizations"
 	emailTemplate                 = "okta_email_template"
 	emailTemplates                = "okta_email_templates"
 	eventHook                     = "okta_event_hook"
@@ -362,6 +363,7 @@ func Provider() *schema.Provider {
 			behaviors:                dataSourceBehaviors(),
 			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
+			emailCustomizations:      dataSourceEmailCustomizations(),
 			emailTemplate:            dataSourceEmailTemplate(),
 			emailTemplates:           dataSourceEmailTemplates(),
 			defaultPolicies:          deprecatedPolicies,

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -66,6 +66,7 @@ const (
 	domainVerification            = "okta_domain_verification"
 	emailSender                   = "okta_email_sender"
 	emailSenderVerification       = "okta_email_sender_verification"
+	email_templates               = "okta_email_templates"
 	eventHook                     = "okta_event_hook"
 	eventHookVerification         = "okta_event_hook_verification"
 	factor                        = "okta_factor"
@@ -360,6 +361,7 @@ func Provider() *schema.Provider {
 			behaviors:                dataSourceBehaviors(),
 			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
+			email_templates:          dataSourceEmailTemplates(),
 			defaultPolicies:          deprecatedPolicies,
 			defaultPolicy:            dataSourceDefaultPolicy(),
 			group:                    dataSourceGroup(),

--- a/okta/resource_okta_brand.go
+++ b/okta/resource_okta_brand.go
@@ -1,0 +1,114 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func resourceBrand() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBrandCreate,
+		ReadContext:   resourceBrandRead,
+		UpdateContext: resourceBrandUpdate,
+		DeleteContext: resourceBrandDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceBrandImportStateContext,
+		},
+		Schema: brandResourceSchema,
+	}
+}
+
+func resourceBrandCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	brandId := d.Get("brand_id").(string)
+	// check that the brand exists, create is short circuited as a reader
+	brand, resp, err := getOktaClientFromMetadata(m).Brand.GetBrand(ctx, brandId)
+	if err := suppressErrorOn404(resp, err); err != nil {
+		return diag.Errorf("failed to get brand %q: %v", brandId, err)
+	}
+	logger(m).Info("setting brand id", "id", brandId)
+	d.SetId(brandId)
+	rawMap := flattenBrand(brand)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set brand's properties in read: %v", err)
+	}
+	return nil
+}
+
+func resourceBrandRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("reading brand", "id", d.Id())
+	brand, resp, err := getOktaClientFromMetadata(m).Brand.GetBrand(ctx, d.Id())
+	if err := suppressErrorOn404(resp, err); err != nil {
+		return diag.Errorf("failed to get brand: %v", err)
+	}
+	if brand == nil {
+		d.SetId("")
+		return nil
+	}
+	rawMap := flattenBrand(brand)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set brand's properties in read: %v", err)
+	}
+
+	return nil
+}
+
+func resourceBrandUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("updating brand", "id", d.Id())
+
+	brand := okta.Brand{}
+	agree, ok := d.GetOk("agree_to_custom_privacy_policy")
+	if ok {
+		brand.AgreeToCustomPrivacyPolicy = boolPtr(agree.(bool))
+	} else {
+		brand.AgreeToCustomPrivacyPolicy = boolPtr(false)
+	}
+	if val, ok := d.GetOk("custom_privacy_policy_url"); ok {
+		brand.CustomPrivacyPolicyUrl = val.(string)
+	}
+	if val, ok := d.GetOk("remove_powered_by_okta"); ok {
+		brand.RemovePoweredByOkta = boolPtr(val.(bool))
+	}
+	_, _, err := getOktaClientFromMetadata(m).Brand.UpdateBrand(ctx, d.Id(), brand)
+	if err != nil {
+		return diag.Errorf("failed to update brand: %v", err)
+	}
+
+	// NOTE: don't do a tail call on resource read, populate the result here
+	rawMap := flattenBrand(&brand)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set brand's properties in update: %v", err)
+	}
+
+	return nil
+}
+
+func resourceBrandDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// fake delete
+	d.SetId("")
+	return nil
+}
+
+func resourceBrandImportStateContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if _, ok := d.GetOk("brand_id"); !ok {
+		_ = d.Set("brand_id", d.Id())
+	}
+	brand, _, err := getOktaClientFromMetadata(m).Brand.GetBrand(ctx, d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(brand.Id)
+	rawMap := flattenBrand(brand)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/okta/resource_okta_brand_test.go
+++ b/okta/resource_okta_brand_test.go
@@ -1,0 +1,68 @@
+package okta
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceOktaBrand_import_update(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(brand)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("updated.tf", ri, t)
+	importConfig := mgr.GetFixtures("import.tf", ri, t)
+
+	// okta_brand is read and update only, so set up the test by importing the brand first
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				// this is set up only for import state test, ignore check as import.tf is for testing
+				ExpectNonEmptyPlan: true,
+				Config:             importConfig,
+			},
+			{
+				ResourceName: "okta_brand.example",
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					// import should only net one brand
+					if len(s) != 1 {
+						return errors.New("failed to import into resource into state")
+					}
+					// simple check
+					if len(s[0].Attributes["links"]) <= 2 {
+						return fmt.Errorf("there should more than two attributes set on the instance %+v", s[0].Attributes)
+
+					}
+					return nil
+				},
+			},
+			{
+				Config:  config,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("okta_brand.example", "id"),
+					resource.TestCheckResourceAttr("okta_brand.example", "custom_privacy_policy_url", "https://example.com/privacy-policy"),
+					resource.TestCheckResourceAttrSet("okta_brand.example", "links"),
+					resource.TestCheckResourceAttr("okta_brand.example", "remove_powered_by_okta", "false"),
+				),
+			},
+			{
+				Config:  updatedConfig,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("okta_brand.example", "id"),
+					resource.TestCheckResourceAttr("okta_brand.example", "custom_privacy_policy_url", "https://example.com/privacy-policy-updated"),
+					resource.TestCheckResourceAttrSet("okta_brand.example", "links"),
+					resource.TestCheckResourceAttr("okta_brand.example", "remove_powered_by_okta", "true"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_brand_test.go
+++ b/okta/resource_okta_brand_test.go
@@ -21,6 +21,10 @@ func TestAccResourceOktaBrand_import_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			// brand api doens't have real delete for a brand
+			return nil
+		},
 		Steps: []resource.TestStep{
 			{
 				// this is set up only for import state test, ignore check as import.tf is for testing

--- a/okta/resource_okta_email_customization.go
+++ b/okta/resource_okta_email_customization.go
@@ -1,0 +1,157 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func resourceEmailCustomization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEmailCustomizationCreate,
+		ReadContext:   resourceEmailCustomizationRead,
+		UpdateContext: resourceEmailCustomizationUpdate,
+		DeleteContext: resourceEmailCustomizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: emailCustomizationResourceSchema,
+	}
+}
+
+func resourceEmailCustomizationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	brandID, ok := d.GetOk("brand_id")
+	if !ok {
+		return diag.Errorf("brand_id required to create email customization")
+	}
+
+	templateName, ok := d.GetOk("template_name")
+	if !ok {
+		return diag.Errorf("template name required to create email customization")
+	}
+
+	etcr := okta.EmailTemplateCustomizationRequest{}
+	if language, ok := d.GetOk("language"); ok {
+		etcr.Language = language.(string)
+	}
+	if isDefault, ok := d.GetOk("is_default"); ok {
+		etcr.IsDefault = boolPtr(isDefault.(bool))
+	}
+	if subject, ok := d.GetOk("subject"); ok {
+		etcr.Subject = subject.(string)
+	}
+	if body, ok := d.GetOk("body"); ok {
+		etcr.Body = body.(string)
+	}
+
+	customization, _, err := getOktaClientFromMetadata(m).Brand.CreateEmailTemplateCustomization(ctx, brandID.(string), templateName.(string), etcr)
+	if err != nil {
+		return diag.Errorf("failed to create email customization: %v", err)
+	}
+
+	d.SetId(customization.Id)
+	rawMap := flattenEmailCustomization(brandID.(string), templateName.(string), false, customization)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set new email customization properties: %v", err)
+	}
+
+	return nil
+}
+
+func resourceEmailCustomizationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	etcr, diagErr := etcrValues("read", d)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	customization, resp, err := getOktaClientFromMetadata(m).Brand.GetEmailTemplateCustomization(ctx, etcr.brandID, etcr.templateName, d.Id())
+	if err := suppressErrorOn404(resp, err); err != nil {
+		return diag.Errorf("failed to get email customization: %v", err)
+	}
+	if customization == nil {
+		d.SetId("")
+		return nil
+	}
+
+	rawMap := flattenEmailCustomization(etcr.brandID, etcr.templateName, false, customization)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set email customization properties: %v", err)
+	}
+
+	return nil
+}
+
+func resourceEmailCustomizationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	etcr, diagErr := etcrValues("update", d)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	cr := okta.EmailTemplateCustomizationRequest{}
+	if language, ok := d.GetOk("language"); ok {
+		cr.Language = language.(string)
+	}
+	if isDefault, ok := d.GetOk("is_default"); ok {
+		cr.IsDefault = boolPtr(isDefault.(bool))
+	}
+	if subject, ok := d.GetOk("subject"); ok {
+		cr.Subject = subject.(string)
+	}
+	if body, ok := d.GetOk("body"); ok {
+		cr.Body = body.(string)
+	}
+
+	customization, _, err := getOktaClientFromMetadata(m).Brand.UpdateEmailTemplateCustomization(ctx, etcr.brandID, etcr.templateName, d.Id(), cr)
+	if err != nil {
+		return diag.Errorf("failed to update email customization: %v", err)
+	}
+
+	d.SetId(customization.Id)
+	rawMap := flattenEmailCustomization(etcr.brandID, etcr.templateName, false, customization)
+	err = setNonPrimitives(d, rawMap)
+	if err != nil {
+		return diag.Errorf("failed to set email customization properties: %v", err)
+	}
+
+	return nil
+}
+
+func resourceEmailCustomizationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	etcr, diagErr := etcrValues("delete", d)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	_, err := getOktaClientFromMetadata(m).Brand.DeleteEmailTemplateCustomization(ctx, etcr.brandID, etcr.templateName, d.Id())
+	if err != nil {
+		return diag.Errorf("failed to delete email customization: %v", err)
+	}
+
+	return nil
+}
+
+type etcrHelper struct {
+	brandID      string
+	templateName string
+}
+
+func etcrValues(action string, d *schema.ResourceData) (*etcrHelper, diag.Diagnostics) {
+	brandID, ok := d.GetOk("brand_id")
+	if !ok {
+		return nil, diag.Errorf("brand_id required to %s email customization", action)
+	}
+
+	templateName, ok := d.GetOk("template_name")
+	if !ok {
+		return nil, diag.Errorf("template name required to %s email customization", action)
+	}
+
+	return &etcrHelper{
+		brandID:      brandID.(string),
+		templateName: templateName.(string),
+	}, nil
+}

--- a/okta/resource_okta_email_customization_test.go
+++ b/okta/resource_okta_email_customization_test.go
@@ -1,0 +1,58 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceOktaEmailCustomization_crud(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(emailCustomization)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("updated.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "id"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "brand_id"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "template_name"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "template_name", "ForgotPassword"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "language"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "language", "cs"), // setting the language to Czech for testing
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "is_default"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "is_default", "false"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "subject"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "subject", "Forgot Password"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "body"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "body", "Hi $$user.firstName,<br/><br/>Click this link to reset your password: $$resetPasswordLink"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "links"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "id"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "brand_id"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "template_name"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "template_name", "ForgotPassword"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "language"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "language", "cs"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "is_default"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "is_default", "false"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "subject"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "subject", "Forgot Password"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "body"),
+					resource.TestCheckResourceAttr("okta_email_customization.forgot_password_en_alt", "body", "Hello $$user.firstName,<br/><br/>Click this link to reset your password: $$resetPasswordLink"),
+					resource.TestCheckResourceAttrSet("okta_email_customization.forgot_password_en_alt", "links"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_template_email.go
+++ b/okta/resource_okta_template_email.go
@@ -77,10 +77,11 @@ var (
 
 func resourceTemplateEmail() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceTemplateEmailCreate,
-		ReadContext:   resourceTemplateEmailRead,
-		UpdateContext: resourceTemplateEmailUpdate,
-		DeleteContext: resourceTemplateEmailDelete,
+		DeprecationMessage: "Resource okta_template_email utilizes a private Okta API whose behavior may change or even removed. Resource okta_template_emal has been replaced by resource okta_email_customization which is supported by public Okta API.",
+		CreateContext:      resourceTemplateEmailCreate,
+		ReadContext:        resourceTemplateEmailRead,
+		UpdateContext:      resourceTemplateEmailUpdate,
+		DeleteContext:      resourceTemplateEmailDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/website/docs/d/brand.html.markdown
+++ b/website/docs/d/brand.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_brand'
+sidebar_current: 'docs-okta-datasource-brand'
+description: |-
+  Get a single Brand from Okta.
+---
+
+# okta_brand
+
+Use this data source to retrieve a [Brand](https://developer.okta.com/docs/reference/api/brands/#brand-object) from Okta.
+
+## Example Usage
+
+```hcl
+data "okta_brands" "test" {
+}
+
+data "okta_brand" "test" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+}
+```
+
+## Arguments Reference
+
+- `brand_id` - (Required) Brand ID
+
+## Attributes Reference
+
+- `custom_privacy_policy_url` - Custom privacy policy URL
+
+- `links` - Link relations for this object - JSON HAL - Discoverable resources related to the brand
+
+- `remove_powered_by_okta` - Removes "Powered by Okta" from the Okta-hosted sign-in page, and "© 2021 Okta, Inc." from the Okta End-User Dashboard

--- a/website/docs/d/brands.html.markdown
+++ b/website/docs/d/brands.html.markdown
@@ -24,4 +24,4 @@ No arguments.
 
 ## Attribute Reference
 
-- `brands` - List of `okta_brand` belonging to the organization.
+- `brands` - List of `okta_brand` belonging to the organization

--- a/website/docs/d/brands.html.markdown
+++ b/website/docs/d/brands.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_brands'
+sidebar_current: 'docs-okta-datasource-brands'
+description: |-
+Get the brands belonging to an Okta organization.
+---
+
+
+# okta_brands
+
+Use this data source to retrieve the brands belonging to an Okta organization.
+
+## Example Usage
+
+```hcl
+data "okta_brands" "test" {
+}
+```
+
+## Argument Reference
+
+No arguments.
+
+## Attribute Reference
+
+- `brands` - List of `okta_brand` belonging to the organization.

--- a/website/docs/d/email_customization.html.markdown
+++ b/website/docs/d/email_customization.html.markdown
@@ -38,7 +38,7 @@ data "okta_email_customization" "forgot_password_en" {
 
 ## Attributes Reference
 
-- `id` - (Required) Customization ID
+- `id` - Customization ID
 - `links` - Link relations for this object - JSON HAL - Discoverable resources related to the email template
 - `language` - The language supported by the customization
 - `is_default` - Whether the customization is the default

--- a/website/docs/d/email_customization.html.markdown
+++ b/website/docs/d/email_customization.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_email_customization'
+sidebar_current: 'docs-okta-datasource-email-customization'
+description: |-
+Get the email customization of an email template belonging to a brand in an Okta organization.
+---
+
+# okta_email_customization
+
+Use this data source to retrieve the [email
+customization](https://developer.okta.com/docs/reference/api/brands/#get-email-customization)
+of an email template belonging to a brand in an Okta organization.
+
+## Example Usage
+
+```hcl
+data "okta_brands" "test" {
+}
+
+data "okta_email_customizations" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}
+
+data "okta_email_customization" "forgot_password_en" {
+  customization_id = tolist(data.okta_email_customizations.forgot_password.email_customizations)[0].id
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}
+```
+
+## Arguments Reference
+
+- `customization_id` - (Required) Customization ID
+- `brand_id` - (Required) Brand ID
+- `template_name` - (Required) Template Name
+
+## Attributes Reference
+
+- `id` - (Required) Customization ID
+- `links` - Link relations for this object - JSON HAL - Discoverable resources related to the email template
+- `language` - The language supported by the customization
+- `is_default` - Whether the customization is the default
+- `subject` - The subject of the customization
+- `body` - The body of the customization

--- a/website/docs/d/email_customizations.html.markdown
+++ b/website/docs/d/email_customizations.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_email_customizations'
+sidebar_current: 'docs-okta-datasource-email-customizations'
+description: |-
+Get the email customizations of an email template belonging to a brand in an Okta organization.
+---
+
+
+# okta_email_customizations
+
+Use this data source to retrieve the [email
+customizations](https://developer.okta.com/docs/reference/api/brands/#list-email-customizations)
+of an email template belonging to a brand in an Okta organization.
+
+## Example Usage
+
+```hcl
+data "okta_brands" "test" {
+}
+
+data "okta_email_customizations" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}
+```
+
+## Argument Reference
+
+- `brand_id` - (Required) Brand ID
+- `template_name` - (Required) Name of an Email Template
+
+## Attribute Reference
+
+- `email_customizations` - List of `okta_email_customization` belonging to the named email template of the brand

--- a/website/docs/d/email_template.html.markdown
+++ b/website/docs/d/email_template.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_email_template'
+sidebar_current: 'docs-okta-datasource-email_template'
+description: |-
+  Get a single Email Template for a Brand belonging to an Okta organization.
+---
+
+# okta_brand
+
+Use this data source to retrieve a specific [email
+template](https://developer.okta.com/docs/reference/api/brands/#email-template)
+of a brand in an Okta organization.
+
+
+## Example Usage
+
+```hcl
+data "okta_brands" "test" {
+}
+
+data "okta_email_template" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  name = "ForgotPassword"
+}
+```
+
+## Arguments Reference
+
+- `brand_id` - (Required) Brand ID
+- `name` - (Required) Template Name
+
+## Attributes Reference
+
+- `links` - Link relations for this object - JSON HAL - Discoverable resources related to the email template

--- a/website/docs/d/email_template.html.markdown
+++ b/website/docs/d/email_template.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: 'okta'
 page_title: 'Okta: okta_email_template'
-sidebar_current: 'docs-okta-datasource-email_template'
+sidebar_current: 'docs-okta-datasource-email-template'
 description: |-
   Get a single Email Template for a Brand belonging to an Okta organization.
 ---

--- a/website/docs/d/email_templates.html.markdown
+++ b/website/docs/d/email_templates.html.markdown
@@ -9,7 +9,9 @@ Get the email templates belonging to a brand in an Okta organization.
 
 # okta_email_templates
 
-Use this data source to retrieve the email templates of a brand in an Okta organization.
+Use this data source to retrieve the [email
+templates](https://developer.okta.com/docs/reference/api/brands/#email-template)
+of a brand in an Okta organization.
 
 ## Example Usage
 

--- a/website/docs/d/email_templates.html.markdown
+++ b/website/docs/d/email_templates.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_email_templates'
+sidebar_current: 'docs-okta-datasource-email_templates'
+description: |-
+Get the email templates belonging to a brand in an Okta organization.
+---
+
+
+# okta_email_templates
+
+Use this data source to retrieve the email templates of a brand in an Okta organization.
+
+## Example Usage
+
+```hcl
+data "okta_brands" "test" {
+}
+
+data "okta_email_templates" "test" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+}
+```
+
+## Argument Reference
+
+- `brand_id` - (Required) Brand ID
+
+## Attribute Reference
+
+- `email_templates` - List of `okta_email_template` belonging to the brand

--- a/website/docs/d/email_templates.html.markdown
+++ b/website/docs/d/email_templates.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: 'okta'
 page_title: 'Okta: okta_email_templates'
-sidebar_current: 'docs-okta-datasource-email_templates'
+sidebar_current: 'docs-okta-datasource-email-templates'
 description: |-
 Get the email templates belonging to a brand in an Okta organization.
 ---

--- a/website/docs/r/brand.html.markdown
+++ b/website/docs/r/brand.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_brand'
+sidebar_current: 'docs-okta-resource-brand'
+description: |-
+  Gets, updates, an Okta Brand.
+---
+
+# okta_brand
+
+This resource allows you to get and update an Okta [Brand](https://developer.okta.com/docs/reference/api/brands/#brand-object).
+
+## Example Usage
+
+```hcl
+# resource has been imported into current state
+resource "okta_brand" "example" {
+  agree_to_custom_privacy_policy = true
+  custom_privacy_policy_url      = "https://example.com/privacy-policy"
+  remove_powered_by_okta         = true
+}
+```
+
+## Argument Reference
+
+- `brand_id` - (Optional) Brand ID, used for read (faux-create)
+
+## Attributes Reference
+
+- `id` - (Read-only) Brand ID
+
+- `agree_to_custom_privacy_policy` - Is a required input flag with when changing custom_privacy_url, shouldn't be considered as a readable property
+
+- `custom_privacy_policy_url` - (Optional) Custom privacy policy URL
+
+- `links` - (Read-only) Link relations for this object - JSON HAL - Discoverable resources related to the brand
+
+- `remove_powered_by_okta` - (Optional) Removes "Powered by Okta" from the Okta-hosted sign-in page, and "© 2021 Okta, Inc." from the Okta End-User Dashboard
+
+## Import
+
+An Okta Brand can be imported via the ID.
+
+```
+$ terraform import okta_brand.example <brand id>
+```

--- a/website/docs/r/email_customization.html.markdown
+++ b/website/docs/r/email_customization.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_email_customization'
+sidebar_current: 'docs-okta-resource-email-customization'
+description: |-
+Create an email customization of an email template belonging to a brand in an Okta organization.
+---
+
+# okta_email_customization
+
+Use this resource to create an [email
+customization](https://developer.okta.com/docs/reference/api/brands/#create-email-customization)
+of an email template belonging to a brand in an Okta organization.
+
+## Example Usage
+
+```hcl
+data "okta_brands" "test" {
+}
+
+data "okta_email_customizations" "forgot_password" {
+  brand_id = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+}
+
+resource "okta_email_customization" "forgot_password_en_alt" {
+  brand_id      = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "ForgotPassword"
+  language      = "cs"
+  is_default    = false
+  subject       = "Forgot Password"
+  body          = "Hi $$user.firstName,<br/><br/>Click this link to reset your password: $$resetPasswordLink"
+}
+```
+
+## Arguments Reference
+
+- `brand_id` - (Required) Brand ID
+- `template_name` - (Required) Template Name
+
+## Attributes Reference
+
+- `id` - (Read-Only) Customization ID
+- `links` - (Read-Only) Link relations for this object - JSON HAL - Discoverable resources related to the email template
+- `language` - The language supported by the customization
+- `is_default` - Whether the customization is the default. If `is_default` is true and there is already a default customization when this resource is created will cause an error. Only set to true for updating a resource.
+- `subject` - The subject of the customization
+- `body` - The body of the customization

--- a/website/docs/r/template_email.html.markdown
+++ b/website/docs/r/template_email.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # okta_template_email
 
+** This resource is deprecated. Swith over to the email_customization resource.
+
 Creates an Okta Email Template.
 
 This resource allows you to create and configure an Okta Email Template.

--- a/website/okta.erb
+++ b/website/okta.erb
@@ -181,6 +181,9 @@
           <li<%= sidebar_current("docs-okta-resource-domain") %>>
             <a href="/docs/providers/okta/r/domain.html">okta_domain</a>
           </li>
+          <li<%= sidebar_current("docs-okta-resource-email-customization") %>>
+            <a href="/docs/providers/okta/r/email_customization.html">okta_email_customization</a>
+          </li>
           <li<%= sidebar_current("docs-okta-resource-event-hook") %>>
             <a href="/docs/providers/okta/r/event_hook.html">okta_event_hook</a>
           </li>

--- a/website/okta.erb
+++ b/website/okta.erb
@@ -43,6 +43,12 @@
             <li<%= sidebar_current("docs-okta-datasource-behaviors") %>>
               <a href="/docs/providers/okta/d/behaviors.html">okta_behaviors</a>
             </li>
+            <li<%= sidebar_current("docs-okta-datasource-brand") %>>
+              <a href="/docs/providers/okta/d/brand.html">okta_brand</a>
+            </li>
+            <li<%= sidebar_current("docs-okta-datasource-brands") %>>
+              <a href="/docs/providers/okta/d/brands.html">okta_brands</a>
+            </li>
             <li<%= sidebar_current("docs-okta-datasource-default-policy") %>>
               <a href="/docs/providers/okta/d/default_policy.html">okta_default_policy</a>
             </li>
@@ -156,6 +162,9 @@
           </li>
           <li<%= sidebar_current("docs-okta-resource-behavior") %>>
             <a href="/docs/providers/okta/r/behavior.html">okta_behavior</a>
+          </li>
+          <li<%= sidebar_current("docs-okta-resource-brand") %>>
+            <a href="/docs/providers/okta/r/behavior.html">okta_brand</a>
           </li>
           <li<%= sidebar_current("docs-okta-resource-domain") %>>
             <a href="/docs/providers/okta/r/domain.html">okta_domain</a>

--- a/website/okta.erb
+++ b/website/okta.erb
@@ -52,6 +52,9 @@
             <li<%= sidebar_current("docs-okta-datasource-default-policy") %>>
               <a href="/docs/providers/okta/d/default_policy.html">okta_default_policy</a>
             </li>
+            <li<%= sidebar_current("docs-okta-datasource-email-customization") %>>
+              <a href="/docs/providers/okta/d/email_customization.html">okta_email_customization</a>
+            </li>
             <li<%= sidebar_current("docs-okta-datasource-email-customizations") %>>
               <a href="/docs/providers/okta/d/email_customizations.html">okta_email_customizations</a>
             </li>

--- a/website/okta.erb
+++ b/website/okta.erb
@@ -52,6 +52,9 @@
             <li<%= sidebar_current("docs-okta-datasource-default-policy") %>>
               <a href="/docs/providers/okta/d/default_policy.html">okta_default_policy</a>
             </li>
+            <li<%= sidebar_current("docs-okta-datasource-email-templates") %>>
+              <a href="/docs/providers/okta/d/email_templates.html">okta_email_templates</a>
+            </li>
             <li<%= sidebar_current("docs-okta-datasource-everyone-group") %>>
               <a href="/docs/providers/okta/d/everyone_group.html">okta_everyone_group</a>
             </li>

--- a/website/okta.erb
+++ b/website/okta.erb
@@ -52,6 +52,9 @@
             <li<%= sidebar_current("docs-okta-datasource-default-policy") %>>
               <a href="/docs/providers/okta/d/default_policy.html">okta_default_policy</a>
             </li>
+            <li<%= sidebar_current("docs-okta-datasource-email-template") %>>
+              <a href="/docs/providers/okta/d/email_template.html">okta_email_template</a>
+            </li>
             <li<%= sidebar_current("docs-okta-datasource-email-templates") %>>
               <a href="/docs/providers/okta/d/email_templates.html">okta_email_templates</a>
             </li>

--- a/website/okta.erb
+++ b/website/okta.erb
@@ -52,6 +52,9 @@
             <li<%= sidebar_current("docs-okta-datasource-default-policy") %>>
               <a href="/docs/providers/okta/d/default_policy.html">okta_default_policy</a>
             </li>
+            <li<%= sidebar_current("docs-okta-datasource-email-customizations") %>>
+              <a href="/docs/providers/okta/d/email_customizations.html">okta_email_customizations</a>
+            </li>
             <li<%= sidebar_current("docs-okta-datasource-email-template") %>>
               <a href="/docs/providers/okta/d/email_template.html">okta_email_template</a>
             </li>


### PR DESCRIPTION
Support for managing branded email customization with data sources and resources for [Brands](https://developer.okta.com/docs/reference/api/brands/#get-started), [Email Templates](https://developer.okta.com/docs/reference/api/brands/#email-templates), and [Email Customizations](https://developer.okta.com/docs/reference/api/brands/#email-customizations).

New resources
- `okta_brand`
- `okta_email_customization`

New datd sources
- `okta_brands`
- `okta_brand`
- `okta_email_customizations`
- `okta_email_customization`
- `okta_email_templates`
- `okta_email_template`