### PR TITLE
Fix markdown rendering quirk in the TF registry

### DIFF
--- a/website/docs/r/admin_role_custom.html.markdown
+++ b/website/docs/r/admin_role_custom.html.markdown
@@ -68,5 +68,5 @@ The following arguments are supported:
 Okta Custom Admin Role can be imported via the Okta ID.
 
 ```
-$ terraform import okta_admin_role_custom.example <custom role id>
+$ terraform import okta_admin_role_custom.example &#60;custom role id&#62;
 ```

--- a/website/docs/r/admin_role_custom_assignments.html.markdown
+++ b/website/docs/r/admin_role_custom_assignments.html.markdown
@@ -89,5 +89,5 @@ The following arguments are supported:
 Okta Custom Admin Role Assignments can be imported via the Okta ID.
 
 ```
-$ terraform import okta_admin_role_custom_assignments.example <resource_set_id>/<custom_role_id>
+$ terraform import okta_admin_role_custom_assignments.example &#60;resource_set_id&#62;/&#60;custom_role_id&#62;
 ```

--- a/website/docs/r/admin_role_targets.html.markdown
+++ b/website/docs/r/admin_role_targets.html.markdown
@@ -54,5 +54,5 @@ The following arguments are supported:
 Okta Admin Role Targets can be imported via the Okta ID.
 
 ```
-$ terraform import okta_admin_role_targets.example <user id>/<role type>
+$ terraform import okta_admin_role_targets.example &#60;user id&#62;/&#60;role type&#62;
 ```

--- a/website/docs/r/app_auto_login.html.markdown
+++ b/website/docs/r/app_auto_login.html.markdown
@@ -112,15 +112,15 @@ The following arguments are supported:
 Okta Auto Login App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_auto_login.example <app id>
+$ terraform import okta_app_auto_login.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_basic_auth.html.markdown
+++ b/website/docs/r/app_basic_auth.html.markdown
@@ -79,15 +79,15 @@ The following arguments are supported:
 A Basic Auth App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_bookmark.html.markdown
+++ b/website/docs/r/app_bookmark.html.markdown
@@ -76,15 +76,15 @@ The following arguments are supported:
 A Bookmark App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_bookmark.example <app id>
+$ terraform import okta_app_bookmark.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_group_assignment.html.markdown
+++ b/website/docs/r/app_group_assignment.html.markdown
@@ -63,5 +63,5 @@ The following arguments are supported:
 An application group assignment can be imported via the `app_id` and the `group_id`.
 
 ```
-$ terraform import okta_app_group_assignment.example <app_id>/<group_id>
+$ terraform import okta_app_group_assignment.example &#60;app_id&#62;/&#60;group_id&#62;
 ```

--- a/website/docs/r/app_group_assignments.html.markdown
+++ b/website/docs/r/app_group_assignments.html.markdown
@@ -67,5 +67,5 @@ The following arguments are supported:
 An application's group assignments can be imported via `app_id`.
 
 ```
-$ terraform import okta_app_group_assignments.example <app_id>
+$ terraform import okta_app_group_assignments.example &#60;app_id&#62;
 ```

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -169,15 +169,15 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 An OIDC Application can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_oauth.example <app id>
+$ terraform import okta_app_oauth.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_oauth_api_scope.html.markdown
+++ b/website/docs/r/app_oauth_api_scope.html.markdown
@@ -41,5 +41,5 @@ The following arguments are supported:
 OAuth API scopes can be imported via the Okta Application ID.
 
 ```
-$ terraform import okta_app_oauth_api_scope.example <app id>
+$ terraform import okta_app_oauth_api_scope.example &#60;app id&#62;
 ```

--- a/website/docs/r/app_oauth_post_logout_redirect_uri.html.markdown
+++ b/website/docs/r/app_oauth_post_logout_redirect_uri.html.markdown
@@ -51,5 +51,5 @@ resource "okta_app_oauth_post_logout_redirect_uri" "test" {
 A post logout redirect URI can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_oauth_post_logout_redirect_uri.example <app id>/<uri>
+$ terraform import okta_app_oauth_post_logout_redirect_uri.example &#60;app id&#62;/&#60;uri&#62;
 ```

--- a/website/docs/r/app_oauth_redirect_uri.html.markdown
+++ b/website/docs/r/app_oauth_redirect_uri.html.markdown
@@ -49,5 +49,5 @@ resource "okta_app_oauth_redirect_uri" "test" {
 A redirect URI can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_oauth_redirect_uri.example <app id>/<uri>
+$ terraform import okta_app_oauth_redirect_uri.example &#60;app id&#62;/&#60;uri&#62;
 ```

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -303,15 +303,15 @@ The following arguments are supported:
 A SAML App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_saml.example <app id>
+$ terraform import okta_app_saml.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_saml_app_settings.html.markdown
+++ b/website/docs/r/app_saml_app_settings.html.markdown
@@ -50,5 +50,5 @@ The following arguments are supported:
 A settings for the SAML App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_saml_app_settings.example <app id>
+$ terraform import okta_app_saml_app_settings.example &#60;app id&#62;
 ```

--- a/website/docs/r/app_secure_password_store.html.markdown
+++ b/website/docs/r/app_secure_password_store.html.markdown
@@ -105,15 +105,15 @@ The following arguments are supported:
 Secure Password Store Application can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_secure_password_store.example <app id>
+$ terraform import okta_app_secure_password_store.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_shared_credentials.html.markdown
+++ b/website/docs/r/app_shared_credentials.html.markdown
@@ -118,16 +118,16 @@ The following arguments are supported:
 Okta SWA Shared Credentials App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_shared_credentials.example <app id>
+$ terraform import okta_app_shared_credentials.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```
 

--- a/website/docs/r/app_signon_policy_rule.html.markdown
+++ b/website/docs/r/app_signon_policy_rule.html.markdown
@@ -328,5 +328,5 @@ The following arguments are supported:
 Okta app sign-on policy rule can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_signon_policy_rule.example <policy_id>/<rule_id>
+$ terraform import okta_app_signon_policy_rule.example &#60;policy_id&#62;/&#60;rule_id&#62;
 ```

--- a/website/docs/r/app_swa.html.markdown
+++ b/website/docs/r/app_swa.html.markdown
@@ -97,15 +97,15 @@ The following arguments are supported:
 Okta SWA App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_swa.example <app id>
+$ terraform import okta_app_swa.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_three_field.html.markdown
+++ b/website/docs/r/app_three_field.html.markdown
@@ -101,15 +101,15 @@ The following arguments are supported:
 A Three Field App can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_three_field.example <app id>
+$ terraform import okta_app_three_field.example &#60;app id&#62;
 ```
 
 It's also possible to import app without groups or/and users. In this case ID may look like this:
 
 ```
-$ terraform import okta_app_basic_auth.example <app id>/skip_users
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_users/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_users/skip_groups
 
-$ terraform import okta_app_basic_auth.example <app id>/skip_groups
+$ terraform import okta_app_basic_auth.example &#60;app id&#62;/skip_groups
 ```

--- a/website/docs/r/app_user.html.markdown
+++ b/website/docs/r/app_user.html.markdown
@@ -58,5 +58,5 @@ The following arguments are supported:
 An Application User can be imported via the Okta ID.
 
 ```
-$ terraform import okta_app_user.example <app id>/<user id>
+$ terraform import okta_app_user.example &#60;app id&#62;/&#60;user id&#62;
 ```

--- a/website/docs/r/app_user_base_schema.html.markdown
+++ b/website/docs/r/app_user_base_schema.html.markdown
@@ -55,5 +55,5 @@ The following arguments are supported:
 App user base schema property can be imported via the property index and app id.
 
 ```
-$ terraform import okta_app_user_base_schema.example <app id>/<property name>
+$ terraform import okta_app_user_base_schema.example &#60;app id&#62;/&#60;property name&#62;
 ```

--- a/website/docs/r/app_user_base_schema_property.html.markdown
+++ b/website/docs/r/app_user_base_schema_property.html.markdown
@@ -55,5 +55,5 @@ The following arguments are supported:
 App user base schema property can be imported via the property index and app id.
 
 ```
-$ terraform import okta_app_user_base_schema_property.example <app id>/<property name>
+$ terraform import okta_app_user_base_schema_property.example &#60;app id&#62;/&#60;property name&#62;
 ```

--- a/website/docs/r/app_user_schema.html.markdown
+++ b/website/docs/r/app_user_schema.html.markdown
@@ -103,5 +103,5 @@ The following arguments are supported:
 App user schema property can be imported via the property index and app id.
 
 ```
-$ terraform import okta_app_user_schema.example <app id>/<property name>
+$ terraform import okta_app_user_schema.example &#60;app id&#62;/&#60;property name&#62;
 ```

--- a/website/docs/r/app_user_schema_property.html.markdown
+++ b/website/docs/r/app_user_schema_property.html.markdown
@@ -84,5 +84,5 @@ The following arguments are supported:
 App user schema property can be imported via the property index and app id.
 
 ```
-$ terraform import okta_app_user_schema_property.example <app id>/<property name>
+$ terraform import okta_app_user_schema_property.example &#60;app id&#62;/&#60;property name&#62;
 ```

--- a/website/docs/r/auth_server.html.markdown
+++ b/website/docs/r/auth_server.html.markdown
@@ -57,5 +57,5 @@ The following arguments are supported:
 Authorization Server can be imported via the Okta ID.
 
 ```
-$ terraform import okta_auth_server.example <auth server id>
+$ terraform import okta_auth_server.example &#60;auth server id&#62;
 ```

--- a/website/docs/r/auth_server_claim.html.markdown
+++ b/website/docs/r/auth_server_claim.html.markdown
@@ -57,5 +57,5 @@ The following arguments are supported:
 Authorization Server Claim can be imported via the Auth Server ID and Claim ID.
 
 ```
-$ terraform import okta_auth_server_claim.example <auth server id>/<claim id>
+$ terraform import okta_auth_server_claim.example &#60;auth server id&#62;/&#60;claim id&#62;
 ```

--- a/website/docs/r/auth_server_claim_default.html.markdown
+++ b/website/docs/r/auth_server_claim_default.html.markdown
@@ -57,11 +57,11 @@ The following arguments are supported:
 Authorization Server Claim can be imported via the Auth Server ID and Claim ID or Claim Name.
 
 ```
-$ terraform import okta_auth_server_claim_default.example <auth server id>/<claim id>
+$ terraform import okta_auth_server_claim_default.example &#60;auth server id&#62;/&#60;claim id&#62;
 ```
 
 or
 
 ```
-$ terraform import okta_auth_server_claim_default.example <auth server id>/<claim name>
+$ terraform import okta_auth_server_claim_default.example &#60;auth server id&#62;/&#60;claim name&#62;
 ```

--- a/website/docs/r/auth_server_default.html.markdown
+++ b/website/docs/r/auth_server_default.html.markdown
@@ -53,5 +53,5 @@ The following arguments are supported:
 Authorization Server can be imported via the Okta ID.
 
 ```
-$ terraform import okta_auth_server_default.example <auth server name>
+$ terraform import okta_auth_server_default.example &#60;auth server name&#62;
 ```

--- a/website/docs/r/auth_server_policy.html.markdown
+++ b/website/docs/r/auth_server_policy.html.markdown
@@ -54,5 +54,5 @@ The following arguments are supported:
 Authorization Server Policy can be imported via the Auth Server ID and Policy ID.
 
 ```
-$ terraform import okta_auth_server_policy.example <auth server id>/<policy id>
+$ terraform import okta_auth_server_policy.example &#60;auth server id&#62;/&#60;policy id&#62;
 ```

--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -78,5 +78,5 @@ The following arguments are supported:
 Authorization Server Policy Rule can be imported via the Auth Server ID, Policy ID, and Policy Rule ID.
 
 ```
-$ terraform import okta_auth_server_policy_rule.example <auth server id>/<policy id>/<policy rule id>
+$ terraform import okta_auth_server_policy_rule.example &#60;auth server id&#62;/&#60;policy id&#62;/&#60;policy rule id&#62;
 ```

--- a/website/docs/r/auth_server_scope.html.markdown
+++ b/website/docs/r/auth_server_scope.html.markdown
@@ -52,5 +52,5 @@ The following arguments are supported:
 Okta Auth Server Scope can be imported via the Auth Server ID and Scope ID.
 
 ```
-$ terraform import okta_auth_server_scope.example <auth server id>/<scope id>
+$ terraform import okta_auth_server_scope.example &#60;auth server id&#62;/&#60;scope id&#62;
 ```

--- a/website/docs/r/authenticator.html.markdown
+++ b/website/docs/r/authenticator.html.markdown
@@ -63,5 +63,5 @@ The following arguments are supported:
 Okta authenticator can be imported via the Okta ID.
 
 ```
-$ terraform import okta_authenticator.example <authenticator_id>
+$ terraform import okta_authenticator.example &#60;authenticator_id&#62;
 ```

--- a/website/docs/r/behavior.html.markdown
+++ b/website/docs/r/behavior.html.markdown
@@ -80,5 +80,5 @@ The following arguments are supported:
 Behavior can be imported via the Okta ID.
 
 ```
-$ terraform import okta_behavior.example <behavior id>
+$ terraform import okta_behavior.example &#60;behavior id&#62;
 ```

--- a/website/docs/r/brand.html.markdown
+++ b/website/docs/r/brand.html.markdown
@@ -42,5 +42,5 @@ resource "okta_brand" "example" {
 An Okta Brand can be imported via the ID.
 
 ```
-$ terraform import okta_brand.example <brand id>
+$ terraform import okta_brand.example &#60;brand id&#62;
 ```

--- a/website/docs/r/captcha.html.markdown
+++ b/website/docs/r/captcha.html.markdown
@@ -44,5 +44,5 @@ The following arguments are supported:
 Behavior can be imported via the Okta ID.
 
 ```
-$ terraform import okta_captcha.example <captcha id>
+$ terraform import okta_captcha.example &#60;captcha id&#62;
 ```

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -48,5 +48,5 @@ The following arguments are supported:
 Okta Admin Role Targets can be imported via the Okta ID.
 
 ```
-$ terraform import okta_domain.example <domain_id>
+$ terraform import okta_domain.example &#60;domain_id&#62;
 ```

--- a/website/docs/r/email_sender.html.markdown
+++ b/website/docs/r/email_sender.html.markdown
@@ -46,5 +46,5 @@ The following arguments are supported:
 Custom email sender can be imported via the Okta ID.
 
 ```
-$ terraform import okta_email_sender.example <sender id>
+$ terraform import okta_email_sender.example &#60;sender id&#62;
 ```

--- a/website/docs/r/event_hook.html.markdown
+++ b/website/docs/r/event_hook.html.markdown
@@ -66,5 +66,5 @@ The following arguments are supported:
 An event hook can be imported via the Okta ID.
 
 ```
-$ terraform import okta_event_hook.example <hook id>
+$ terraform import okta_event_hook.example &#60;hook id&#62;
 ```

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -67,11 +67,11 @@ The following arguments are supported:
 An Okta Group can be imported via the Okta ID.
 
 ```
-$ terraform import okta_group.example <group id>
+$ terraform import okta_group.example &#60;group id&#62;
 ```
 
 It's also possible to import group without users. In this case ID will look like this:
 
 ```
-$ terraform import okta_group.example <group id>/skip_users
+$ terraform import okta_group.example &#60;group id&#62;/skip_users
 ```

--- a/website/docs/r/group_memberships.html.markdown
+++ b/website/docs/r/group_memberships.html.markdown
@@ -47,5 +47,5 @@ N/A
 an Okta Group's memberships can be imported via the Okta group ID.
 
 ```
-$ terraform import okta_group_memberships.test <group id>
+$ terraform import okta_group_memberships.test &#60;group id&#62;
 ```

--- a/website/docs/r/group_role.html.markdown
+++ b/website/docs/r/group_role.html.markdown
@@ -56,5 +56,5 @@ The following arguments are supported:
 Individual admin role assignment can be imported by passing the group and role assignment IDs as follows:
 
 ```
-$ terraform import okta_group_role.example <group id>/<role id>
+$ terraform import okta_group_role.example &#60;group id&#62;/&#60;role id&#62;
 ```

--- a/website/docs/r/group_roles.html.markdown
+++ b/website/docs/r/group_roles.html.markdown
@@ -38,5 +38,5 @@ The following arguments are supported:
 Group Role Assignment can be imported via the Okta Group ID.
 
 ```
-$ terraform import okta_group_roles.example <group id>
+$ terraform import okta_group_roles.example &#60;group id&#62;
 ```

--- a/website/docs/r/group_rule.html.markdown
+++ b/website/docs/r/group_rule.html.markdown
@@ -54,5 +54,5 @@ The following arguments are supported:
 An Okta Group Rule can be imported via the Okta ID.
 
 ```
-$ terraform import okta_group_rule.example <group rule id>
+$ terraform import okta_group_rule.example &#60;group rule id&#62;
 ```

--- a/website/docs/r/group_schema_property.html.markdown
+++ b/website/docs/r/group_schema_property.html.markdown
@@ -84,5 +84,5 @@ The following arguments are supported:
 Group schema property can be imported via the property index.
 
 ```
-$ terraform import okta_group_schema_property.example <index>
+$ terraform import okta_group_schema_property.example &#60;index&#62;
 ```

--- a/website/docs/r/idp_oidc.html.markdown
+++ b/website/docs/r/idp_oidc.html.markdown
@@ -110,5 +110,5 @@ The following arguments are supported:
 An OIDC IdP can be imported via the Okta ID.
 
 ```
-$ terraform import okta_idp_oidc.example <idp id>
+$ terraform import okta_idp_oidc.example &#60;idp id&#62;
 ```

--- a/website/docs/r/idp_saml.html.markdown
+++ b/website/docs/r/idp_saml.html.markdown
@@ -108,5 +108,5 @@ The following arguments are supported:
 An SAML IdP can be imported via the Okta ID.
 
 ```
-$ terraform import okta_idp_saml.example <idp id>
+$ terraform import okta_idp_saml.example &#60;idp id&#62;
 ```

--- a/website/docs/r/idp_saml_key.html.markdown
+++ b/website/docs/r/idp_saml_key.html.markdown
@@ -63,5 +63,5 @@ The following arguments are supported:
 A SAML IdP Signing Key can be imported via the key id.
 
 ```
-$ terraform import okta_idp_saml_key.example <key id>
+$ terraform import okta_idp_saml_key.example &#60;key id&#62;
 ```

--- a/website/docs/r/idp_social.html.markdown
+++ b/website/docs/r/idp_social.html.markdown
@@ -114,5 +114,5 @@ and keeps the existing value if it is empty/omitted. PrivateKey isn't returned w
 A Social IdP can be imported via the Okta ID.
 
 ```
-$ terraform import okta_idp_social.example <idp id>
+$ terraform import okta_idp_social.example &#60;idp id&#62;
 ```

--- a/website/docs/r/inline_hook.html.markdown
+++ b/website/docs/r/inline_hook.html.markdown
@@ -67,5 +67,5 @@ The following arguments are supported:
 An inline hook can be imported via the Okta ID.
 
 ```
-$ terraform import okta_inline_hook.example <hook id>
+$ terraform import okta_inline_hook.example &#60;hook id&#62;
 ```

--- a/website/docs/r/link_definition.html.markdown
+++ b/website/docs/r/link_definition.html.markdown
@@ -49,5 +49,5 @@ resource "okta_link_definition" "example" {
 Okta Link Definition can be imported via the Okta Primary Link Name.
 
 ```
-$ terraform import okta_link_definition.example <primary_name>
+$ terraform import okta_link_definition.example &#60;primary_name&#62;
 ```

--- a/website/docs/r/link_value.html.markdown
+++ b/website/docs/r/link_value.html.markdown
@@ -67,5 +67,5 @@ resource "okta_link_value" "example" {
 Okta Link Value can be imported via Primary Name and Primary User ID.
 
 ```
-$ terraform import okta_link_value.example <primary_name>/<primary_user_id>
+$ terraform import okta_link_value.example &#60;primary_name&#62;/&#60;primary_user_id&#62;
 ```

--- a/website/docs/r/network_zone.html.markdown
+++ b/website/docs/r/network_zone.html.markdown
@@ -64,5 +64,5 @@ The following arguments are supported:
 Okta Network Zone can be imported via the Okta ID.
 
 ```
-$ terraform import okta_network_zone.example <zone id>
+$ terraform import okta_network_zone.example &#60;zone id&#62;
 ```

--- a/website/docs/r/policy_mfa.html.markdown
+++ b/website/docs/r/policy_mfa.html.markdown
@@ -120,5 +120,5 @@ All MFA settings above have the following structure.
 An MFA Policy can be imported via the Okta ID.
 
 ```
-$ terraform import okta_policy_mfa.example <policy id>
+$ terraform import okta_policy_mfa.example &#60;policy id&#62;
 ```

--- a/website/docs/r/policy_password.html.markdown
+++ b/website/docs/r/policy_password.html.markdown
@@ -97,5 +97,5 @@ The following arguments are supported:
 A Password Policy can be imported via the Okta ID.
 
 ```
-$ terraform import okta_policy_password.example <policy id>
+$ terraform import okta_policy_password.example &#60;policy id&#62;
 ```

--- a/website/docs/r/policy_profile_enrollment.html.markdown
+++ b/website/docs/r/policy_profile_enrollment.html.markdown
@@ -38,5 +38,5 @@ The following arguments are supported:
 A Profile Enrollment Policy can be imported via the Okta ID.
 
 ```
-$ terraform import okta_policy_profile_enrollment.example <policy id>
+$ terraform import okta_policy_profile_enrollment.example &#60;policy id&#62;
 ```

--- a/website/docs/r/policy_profile_enrollment_apps.html.markdown
+++ b/website/docs/r/policy_profile_enrollment_apps.html.markdown
@@ -54,5 +54,5 @@ The following arguments are supported:
 A Profile Enrollment Policy Apps can be imported via the Okta ID.
 
 ```
-$ terraform import okta_policy_profile_enrollment_apps.example <policy id>
+$ terraform import okta_policy_profile_enrollment_apps.example &#60;policy id&#62;
 ```

--- a/website/docs/r/policy_rule_idp_discovery.html.markdown
+++ b/website/docs/r/policy_rule_idp_discovery.html.markdown
@@ -158,5 +158,5 @@ user_identifier_patterns {
 A Policy Rule can be imported via the Policy and Rule ID.
 
 ```
-$ terraform import okta_policy_rule_idp_discovery.example <policy id>/<rule id>
+$ terraform import okta_policy_rule_idp_discovery.example &#60;policy id&#62;/&#60;rule id&#62;
 ```

--- a/website/docs/r/policy_rule_mfa.html.markdown
+++ b/website/docs/r/policy_rule_mfa.html.markdown
@@ -182,5 +182,5 @@ The following arguments are supported:
 A Policy Rule can be imported via the Policy and Rule ID.
 
 ```
-$ terraform import okta_policy_rule_mfa.example <policy id>/<rule id>
+$ terraform import okta_policy_rule_mfa.example &#60;policy id&#62;/&#60;rule id&#62;
 ```

--- a/website/docs/r/policy_rule_password.html.markdown
+++ b/website/docs/r/policy_rule_password.html.markdown
@@ -51,5 +51,5 @@ The following arguments are supported:
 A Policy Rule can be imported via the Policy and Rule ID.
 
 ```
-$ terraform import okta_policy_rule_password.example <policy id>/<rule id>
+$ terraform import okta_policy_rule_password.example &#60;policy id&#62;/&#60;rule id&#62;
 ```

--- a/website/docs/r/policy_rule_profile_enrollment.html.markdown
+++ b/website/docs/r/policy_rule_profile_enrollment.html.markdown
@@ -98,5 +98,5 @@ The following arguments are supported:
 A Policy Rule can be imported via the Policy and Rule ID.
 
 ```
-$ terraform import okta_policy_rule_profile_enrollment.example <policy id>/<rule id>
+$ terraform import okta_policy_rule_profile_enrollment.example &#60;policy id&#62;/&#60;rule id&#62;
 ```

--- a/website/docs/r/policy_rule_signon.html.markdown
+++ b/website/docs/r/policy_rule_signon.html.markdown
@@ -162,5 +162,5 @@ The following arguments are supported:
 A Policy Rule can be imported via the Policy and Rule ID.
 
 ```
-$ terraform import okta_policy_rule_signon.example <policy id>/<rule id>
+$ terraform import okta_policy_rule_signon.example &#60;policy id&#62;/&#60;rule id&#62;
 ```

--- a/website/docs/r/policy_signon.html.markdown
+++ b/website/docs/r/policy_signon.html.markdown
@@ -46,5 +46,5 @@ The following arguments are supported:
 A Sign On Policy can be imported via the Okta ID.
 
 ```
-$ terraform import okta_policy_signon.example <policy id>
+$ terraform import okta_policy_signon.example &#60;policy id&#62;
 ```

--- a/website/docs/r/resource_set.html.markdown
+++ b/website/docs/r/resource_set.html.markdown
@@ -57,5 +57,5 @@ resource "okta_resource_set" "test" {
 Okta Resource Set can be imported via the Okta ID.
 
 ```
-$ terraform import okta_resource_set.example <resource_set_id>
+$ terraform import okta_resource_set.example &#60;resource_set_id&#62;
 ```

--- a/website/docs/r/role_subscription.html.markdown
+++ b/website/docs/r/role_subscription.html.markdown
@@ -54,5 +54,5 @@ resource "okta_role_subscription" "test" {
 A role subscription can be imported via the Okta ID.
 
 ```
-$ terraform import okta_role_subscription.example <role_type>/<notification_type>
+$ terraform import okta_role_subscription.example &#60;role_type&#62;/&#60;notification_type&#62;
 ```

--- a/website/docs/r/template_email.html.markdown
+++ b/website/docs/r/template_email.html.markdown
@@ -57,5 +57,5 @@ The following arguments are supported:
 An Okta Email Template can be imported via the template type.
 
 ```
-$ terraform import okta_template_email.example <template type>
+$ terraform import okta_template_email.example &#60;template type&#62;
 ```

--- a/website/docs/r/template_sms.html.markdown
+++ b/website/docs/r/template_sms.html.markdown
@@ -51,5 +51,5 @@ The following arguments are supported:
 An Okta SMS Template can be imported via the template type.
 
 ```
-$ terraform import okta_template_sms.example <template type>
+$ terraform import okta_template_sms.example &#60;template type&#62;
 ```

--- a/website/docs/r/trusted_origin.html.markdown
+++ b/website/docs/r/trusted_origin.html.markdown
@@ -43,5 +43,5 @@ The following arguments are supported:
 A Trusted Origin can be imported via the Okta ID.
 
 ```
-$ terraform import okta_trusted_origin.example <trusted origin id>
+$ terraform import okta_trusted_origin.example &#60;trusted origin id&#62;
 ```

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -177,5 +177,5 @@ field should not be specified when using Password Import Inline Hook.
 An Okta User can be imported via the ID.
 
 ```
-$ terraform import okta_user.example <user id>
+$ terraform import okta_user.example &#60;user id&#62;
 ```

--- a/website/docs/r/user_admin_roles.html.markdown
+++ b/website/docs/r/user_admin_roles.html.markdown
@@ -57,5 +57,5 @@ N/A
 Existing user admin roles can be imported via the Okta User ID.
 
 ```
-$ terraform import okta_user_admin_roles.example <user id>
+$ terraform import okta_user_admin_roles.example &#60;user id&#62;
 ```

--- a/website/docs/r/user_base_schema.html.markdown
+++ b/website/docs/r/user_base_schema.html.markdown
@@ -53,11 +53,11 @@ The following arguments are supported:
 User schema property of default user type can be imported via the property index.
 
 ```
-$ terraform import okta_user_base_schema.example <property name>
+$ terraform import okta_user_base_schema.example &#60;property name&#62;
 ```
 
 User schema property of custom user type can be imported via user type id and property index
 
 ```
-$ terraform import okta_user_base_schema.example <user type id>.<property name>
+$ terraform import okta_user_base_schema.example &#60;user type id&#62;.&#60;property name&#62;
 ```

--- a/website/docs/r/user_base_schema_property.html.markdown
+++ b/website/docs/r/user_base_schema_property.html.markdown
@@ -62,11 +62,11 @@ The following arguments are supported:
 User schema property of default user type can be imported via the property index.
 
 ```
-$ terraform import okta_user_base_schema_property.example <property name>
+$ terraform import okta_user_base_schema_property.example &#60;property name&#62;
 ```
 
 User schema property of custom user type can be imported via user type id and property index
 
 ```
-$ terraform import okta_user_base_schema_property.example <user type id>.<property name>
+$ terraform import okta_user_base_schema_property.example &#60;user type id&#62;.&#60;property name&#62;
 ```

--- a/website/docs/r/user_factor_question.html.markdown
+++ b/website/docs/r/user_factor_question.html.markdown
@@ -63,5 +63,5 @@ The following arguments are supported:
 Security question factor for a user can be imported via the `user_id` and the `factor_id`.
 
 ```
-$ terraform import okta_user_factor_question.example <user id>/<question factor id>
+$ terraform import okta_user_factor_question.example &#60;user id&#62;/&#60;question factor id&#62;
 ```

--- a/website/docs/r/user_schema.html.markdown
+++ b/website/docs/r/user_schema.html.markdown
@@ -105,11 +105,11 @@ The following arguments are supported:
 User schema property of default user type can be imported via the property index.
 
 ```
-$ terraform import okta_user_schema.example <index>
+$ terraform import okta_user_schema.example &#60;index&#62;
 ```
 
 User schema property of custom user type can be imported via user type id and property index
 
 ```
-$ terraform import okta_user_schema.example <user type id>.<index>
+$ terraform import okta_user_schema.example &#60;user type id&#62;.&#60;index&#62;
 ```

--- a/website/docs/r/user_schema_property.html.markdown
+++ b/website/docs/r/user_schema_property.html.markdown
@@ -87,11 +87,11 @@ The following arguments are supported:
 User schema property of default user type can be imported via the property index.
 
 ```
-$ terraform import okta_user_schema_property.example <index>
+$ terraform import okta_user_schema_property.example &#60;index&#62;
 ```
 
 User schema property of custom user type can be imported via user type id and property index
 
 ```
-$ terraform import okta_user_schema_property.example <user type id>.<index>
+$ terraform import okta_user_schema_property.example &#60;user type id&#62;.&#60;index&#62;
 ```

--- a/website/docs/r/user_type.html.markdown
+++ b/website/docs/r/user_type.html.markdown
@@ -41,5 +41,5 @@ The following arguments are supported:
 A User Type can be imported via the Okta ID.
 
 ```
-$ terraform import okta_user_type.example <user type id>
+$ terraform import okta_user_type.example &#60;user type id&#62;
 ```


### PR DESCRIPTION
Markdown rendered in the TF registry has a quirk where it won't correctly render angle brackets in markdown Fenced Code Blocks. This change correctly render angle brakes in markdown Fenced Code Blocks on the TF registry.

Examples

`$ terraform import okta_app_user_base_schema.example <app id>/<property name>`

![image](https://user-images.githubusercontent.com/201/167501991-b227f91b-8eab-43b8-a63f-9be0809f44f2.png)

Example from the Terraform Registry's [Doc Preview Tool](https://registry.terraform.io/tools/doc-preview)

![image](https://user-images.githubusercontent.com/201/167502269-9ee3657a-ac92-4688-b97d-84e281ea3552.png)


These files were bulk edited with `sed`

```
sed -i '' -e '/\$ terraform .*>/s/>/\&#62;/g' website/docs/*/*.markdown
sed -i '' -e '/\$ terraform .*</s/</\&#60;/g' website/docs/*/*.markdown
```