### PR TITLE
Deal with regressions v3 25 0

### DIFF
--- a/examples/okta_policy_password/basic_updated.tf
+++ b/examples/okta_policy_password/basic_updated.tf
@@ -18,7 +18,7 @@ resource "okta_policy_password" "test" {
   password_expire_warn_days              = 15
   password_min_age_minutes               = 60
   password_history_count                 = 5
-  password_max_lockout_attempts          = 0
+  password_max_lockout_attempts          = 10
   password_auto_unlock_minutes           = 2
   password_show_lockout_failures         = true
   password_lockout_notification_channels = ["EMAIL"]

--- a/okta/resource_okta_policy_password.go
+++ b/okta/resource_okta_policy_password.go
@@ -111,7 +111,6 @@ func resourcePolicyPassword() *schema.Resource {
 				Optional:         true,
 				Description:      "Number of unsuccessful login attempts allowed before lockout: 0 = no limit.",
 				Default:          10,
-				DiffSuppressFunc: createValueDiffSuppression("0"), // default from Okta can be set to other than 10
 			},
 			"password_auto_unlock_minutes": {
 				Type:        schema.TypeInt,

--- a/okta/resource_okta_policy_password_default.go
+++ b/okta/resource_okta_policy_password_default.go
@@ -106,10 +106,12 @@ func resourcePolicyPasswordDefault() *schema.Resource {
 				Default:     0,
 			},
 			"password_history_count": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Description:      "Number of distinct passwords that must be created before they can be reused: 0 = none.",
-				Default:          0,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Number of distinct passwords that must be created before they can be reused: 0 = none.",
+				Default:     4,
+				// API documentation says default is 0 but it appears in acceptance testing on different orgs to now be 4 by default
+				// historyCount -> https://developer.okta.com/docs/reference/api/policy/#age-object
 			},
 			"password_max_lockout_attempts": {
 				Type:        schema.TypeInt,

--- a/okta/resource_okta_policy_password_default.go
+++ b/okta/resource_okta_policy_password_default.go
@@ -110,7 +110,6 @@ func resourcePolicyPasswordDefault() *schema.Resource {
 				Optional:         true,
 				Description:      "Number of distinct passwords that must be created before they can be reused: 0 = none.",
 				Default:          0,
-				DiffSuppressFunc: createValueDiffSuppression("0"), // default from Okta can be set to other than 0
 			},
 			"password_max_lockout_attempts": {
 				Type:        schema.TypeInt,

--- a/okta/resource_okta_policy_password_test.go
+++ b/okta/resource_okta_policy_password_test.go
@@ -77,7 +77,7 @@ func TestAccOktaPolicyPassword_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password_expire_warn_days", "15"),
 					resource.TestCheckResourceAttr(resourceName, "password_min_age_minutes", "60"),
 					resource.TestCheckResourceAttr(resourceName, "password_history_count", "5"),
-					// resource.TestCheckResourceAttr(resourceName, "password_max_lockout_attempts", "0"), // this default value can be overwritten on the org, don't test the default
+					resource.TestCheckResourceAttr(resourceName, "password_max_lockout_attempts", "10"),
 					resource.TestCheckResourceAttr(resourceName, "password_auto_unlock_minutes", "2"),
 					resource.TestCheckResourceAttr(resourceName, "password_show_lockout_failures", "true"),
 					resource.TestCheckResourceAttr(resourceName, "password_lockout_notification_channels.#", "1"),


### PR DESCRIPTION
Soft revert of defaults on `password_max_lockout_attempts` in `okta_policy_password` resource and `password_history_count` in `okta_policy_password_default`