### PR TITLE
Correctly handle label handling in ds okta_app

### DIFF
--- a/website/docs/d/app.html.markdown
+++ b/website/docs/d/app.html.markdown
@@ -21,8 +21,10 @@ data "okta_app" "example" {
 ## Arguments Reference
 
 - `label` - (Optional) The label of the app to retrieve, conflicts with `label_prefix` and `id`. Label uses
-  the `?q=<label>` query parameter exposed by Okta's API. It should be noted that at this time this searches both `name`
-  and `label`. This is used to avoid paginating through all applications.
+  the `?q=<label>` query parameter exposed by Okta's API. It should be noted that at this time the API searches both `name`
+  and `label` with a [starts with query](https://developer.okta.com/docs/reference/api/apps/#list-applications) which
+  may result in multiple apps being returned for the query. The data source further inspects the lables looking for
+  an exact match.
 
 - `label_prefix` - (Optional) Label prefix of the app to retrieve, conflicts with `label` and `id`. This will tell the
   provider to do a `starts with` query as opposed to an `equals` query.


### PR DESCRIPTION
Correctly handle starts with behavior in Okta API for listing applications that was affecting the original implementation of the `okta_app` data source. Closes #1111