### PR TITLE
Refine okta_group_memberships and improve documentation

### DIFF
--- a/okta/data_source_okta_group.go
+++ b/okta/data_source_okta_group.go
@@ -50,7 +50,7 @@ func dataSourceGroup() *schema.Resource {
 			"delay_read_seconds": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Force delay of the group read N seconds. Useful when eventual consistency of group information needs to be allowed for; for instance, when group rules are know to be applied.",
+				Description: "Force delay of the group read by N seconds. Useful when eventual consistency of group information needs to be allowed for; for instance, when group rules are known to have been applied.",
 			},
 		},
 	}

--- a/okta/data_source_okta_group.go
+++ b/okta/data_source_okta_group.go
@@ -3,6 +3,8 @@ package okta
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -45,11 +47,26 @@ func dataSourceGroup() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Users associated with the group. This can also be done per user.",
 			},
+			"delay_read_seconds": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Force delay of the group read N seconds. Useful when eventual consistency of group information needs to be allowed for; for instance, when group rules are know to be applied.",
+			},
 		},
 	}
 }
 
 func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if n, ok := d.GetOk("delay_read_seconds"); ok {
+		delay, err := strconv.Atoi(n.(string))
+		if err == nil {
+			logger(m).Info("delaying group read by ", delay, " seconds")
+			time.Sleep(time.Duration(delay) * time.Second)
+		} else {
+			logger(m).Warn("group read delay value ", n, " is not an integer")
+		}
+	}
+
 	return findGroup(ctx, d.Get("name").(string), d, m, false)
 }
 

--- a/okta/resource_okta_group_memberships_test.go
+++ b/okta/resource_okta_group_memberships_test.go
@@ -32,3 +32,132 @@ func TestAccOktaGroupMemberships_crud(t *testing.T) {
 		},
 	})
 }
+
+// TestAccOktaGroupMembershipsIssue1094 addresses https://github.com/okta/terraform-provider-okta/issues/1094
+func TestAccOktaGroupMembershipsIssue1094(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Before the apply the state will be:
+				//   Group A without users.
+				//   Users 1, 2 without a group association.
+				//   Group B will have users 3, 4, 5 from their creation.
+				//   There is a group memberships that will place users 1, 2 into Group A.
+				//   There is a group rule that will assign all group B users to Group A.
+				// After the apply:
+				//   Group A has users 1, 2 by okta_group_memberships resource.
+				//   The rule that okta_group_memberships.test_a_direct
+				//   describes has been run at Okta associating users 3, 4, and 5
+				//   with Group A.
+				// Upon the next plan:
+				//   The state of okta_group_memberships.test_a_direct
+				//   will appear to have drifed from having only two
+				//   users to five users becuase
+				//   okta_group_rule.group_b_to_a_rule will have run and
+				//   associated the three users from Group B to aslo be in
+				//   Group A.
+				ExpectNonEmptyPlan: true,
+
+				Config: configIssue1094,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.okta_group.test_b", "users.#", "3"),
+					resource.TestCheckResourceAttr("data.okta_group.test_a", "users.#", "5"),
+				),
+			},
+		},
+	})
+}
+
+var configIssue1094 = `
+# Given group a, b
+resource "okta_group" "test_a" {
+  name = "TestACC Group A"
+  description = "Group A"
+}
+resource "okta_group" "test_b" {
+  name = "TestACC Group B"
+  description = "Group B"
+}
+# Given users 1, 2, not assigned to any group
+resource "okta_user" "test_1" {
+  first_name = "TestAcc"
+  last_name  = "Smith1"
+  login      = "testAcc1-replace_with_uuid@example.com"
+  email      = "testAcc1-replace_with_uuid@example.com"
+}
+resource "okta_user" "test_2" {
+  first_name = "TestAcc"
+  last_name  = "Smith2"
+  login      = "testAcc2-replace_with_uuid@example.com"
+  email      = "testAcc2-replace_with_uuid@example.com"
+}
+# Given users 3, 4, 5 assigned to group B
+resource "okta_user" "test_3" {
+  first_name        = "TestAcc"
+  last_name         = "Smith3"
+  login             = "testAcc3-replace_with_uuid@example.com"
+  email             = "testAcc3-replace_with_uuid@example.com"
+  group_memberships = [okta_group.test_b.id]
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+resource "okta_user" "test_4" {
+  first_name        = "TestAcc"
+  last_name         = "Smith4"
+  login             = "testAcc4-replace_with_uuid@example.com"
+  email             = "testAcc4-replace_with_uuid@example.com"
+  group_memberships = [okta_group.test_b.id]
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+resource "okta_user" "test_5" {
+  first_name        = "TestAcc"
+  last_name         = "Smith5"
+  login             = "testAcc5-replace_with_uuid@example.com"
+  email             = "testAcc5-replace_with_uuid@example.com"
+  group_memberships = [okta_group.test_b.id]
+  lifecycle {
+    ignore_changes = [group_memberships]
+  }
+}
+# Group A should have users 1, 2 assigned via okta_group_memberships
+resource "okta_group_memberships" "test_a_direct" {
+  group_id = okta_group.test_a.id
+  users = [okta_user.test_1.id, okta_user.test_2.id]
+  depends_on = [okta_user.test_1, okta_user.test_2, okta_group.test_a]
+
+  # Ignore changes on users if group members will be changed outside of it
+  # lifecycle {
+  #   ignore_changes = [users]
+  # }
+}
+# Group A should have users 3, 4, 5 assigned via okta_group_rule
+resource "okta_group_rule" "group_b_to_a_rule" {
+  name                  = "Group B -> A rule"
+  status                = "ACTIVE"
+  group_assignments     = [okta_group.test_a.id]
+  expression_type       = "urn:okta:expression:1.0"
+  expression_value      = "isMemberOfAnyGroup(\"${okta_group.test_b.id}\")"
+  remove_assigned_users = true
+  depends_on = [okta_user.test_3, okta_user.test_4, okta_user.test_5, okta_group.test_a, okta_group.test_b, okta_group_memberships.test_a_direct]
+}
+# Use a data source to read back in the state of each gorup for testing
+# After the group rules run, users 3, 4, 5 should now be in Group A in addition to users 1, 2
+data "okta_group" "test_a" {
+  id = okta_group.test_a.id
+  # There can be eventual consistency issues running a group rule so let's give ours chance to catch up adding group B users to group A
+  delay_read_seconds = 5
+  include_users = true
+  depends_on = [okta_group_memberships.test_a_direct, okta_group_rule.group_b_to_a_rule]
+}
+data "okta_group" "test_b" {
+  id = okta_group.test_b.id
+  include_users = true
+  depends_on = [okta_group_memberships.test_a_direct, okta_group_rule.group_b_to_a_rule]
+}
+`

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -28,6 +28,8 @@ data "okta_group" "example" {
 
 - `include_users` - (Optional) whether to retrieve all member ids.
 
+- `delay_read_seconds` - (Optional) Force delay of the group read N seconds. Useful when eventual consistency of group information needs to be allowed for; for instance, when group rules are know to be applied.
+
 ## Attributes Reference
 
 - `id` - ID of group.

--- a/website/docs/d/group.html.markdown
+++ b/website/docs/d/group.html.markdown
@@ -28,7 +28,7 @@ data "okta_group" "example" {
 
 - `include_users` - (Optional) whether to retrieve all member ids.
 
-- `delay_read_seconds` - (Optional) Force delay of the group read N seconds. Useful when eventual consistency of group information needs to be allowed for; for instance, when group rules are know to be applied.
+- `delay_read_seconds` - (Optional) Force delay of the group read by N seconds. Useful when eventual consistency of group information needs to be allowed for; for instance, when group rules are known to have been applied.
 
 ## Attributes Reference
 

--- a/website/docs/r/group_memberships.html.markdown
+++ b/website/docs/r/group_memberships.html.markdown
@@ -10,9 +10,17 @@ description: |-
 
 Resource to manage a set of memberships for a specific group.
 
-This resource will allow you to bulk manage group membership in Okta for a given group. This offers an interface to pass multiple users into a single resource call, for better API resource usage. Effectively this is the same as using the `okta_group_membership` resource several times with a single group and different users. If you need a relationship of a single user to many groups, please use the `okta_user_group_memberships` resource.
+This resource will allow you to bulk manage group membership in Okta for a given
+group. This offers an interface to pass multiple users into a single resource
+call, for better API resource usage. Effectively this is the same as using the
+`okta_group_membership` resource several times with a single group and different
+users. If you need a relationship of a single user to many groups, please use
+the `okta_user_group_memberships` resource.
 
-When using this with a `okta_user` resource, you should add a lifecycle ignore for group memberships to avoid conflicts in desired state.
+**Important**: When the group memberships resource is used in an environment
+where other resources or services can add users to the group it will make this
+resource appear to drift. If that is the case make use of a lifecycle ignore for
+the `users` argument to avoid conflicts in desired state.
 
 ## Example Usage
 
@@ -28,6 +36,10 @@ resource "okta_group_memberships" "test" {
     okta_user.test1.id,
     okta_user.test2.id,
   ]
+
+  # lifecycle {
+  #   ignore_changes = [users]
+  # }
 }
 ```
 


### PR DESCRIPTION
- Adds new argument to data source `okta_group` allowing for a delay before the it does its API read
- Refines and fully documents the behavior of `checkIfGroupHasUsers` in the `okta_group_memberships` resource
- Improves the public documentation of `okta_group_memberships` resource
- Includes an acceptance test that demonstrates how/where drift may occur with the `okta_group_memberships` resource