### PR TITLE
`com.okta.telephony.provider` is valid hook type

### DIFF
--- a/examples/okta_inline_hook/basic.tf
+++ b/examples/okta_inline_hook/basic.tf
@@ -16,3 +16,21 @@ resource "okta_inline_hook" "test" {
     value = "123"
   }
 }
+
+resource "okta_inline_hook" "twilio" {
+  name = "twillio"
+  version = "1.0.0"
+  type = "com.okta.telephony.provider"
+
+  channel = {
+    version = "1.0.0"
+    uri = "https://example.com/test"
+    method = "POST"
+  }
+
+  auth = {
+    key = "Authorization"
+    type = "HEADER"
+    value = "secret"
+  }
+}

--- a/okta/resource_okta_inline_hooks.go
+++ b/okta/resource_okta_inline_hooks.go
@@ -45,9 +45,10 @@ func resourceInlineHook() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateDiagFunc: elemInSlice([]string{
-					"com.okta.oauth2.tokens.transform",
 					"com.okta.import.transform",
+					"com.okta.oauth2.tokens.transform",
 					"com.okta.saml.tokens.transform",
+					"com.okta.telephony.provider",
 					"com.okta.user.pre-registration",
 					"com.okta.user.credential.password.import",
 				}),

--- a/okta/resource_okta_inline_hooks_test.go
+++ b/okta/resource_okta_inline_hooks_test.go
@@ -63,6 +63,8 @@ func TestAccOktaInlineHook_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "channel.method", "POST"),
 					resource.TestCheckResourceAttr(resourceName, "auth.type", "HEADER"),
 					resource.TestCheckResourceAttr(resourceName, "auth.key", "Authorization"),
+
+					resource.TestCheckResourceAttr("okta_inline_hook.twilio", "type", "com.okta.telephony.provider"),
 				),
 			},
 			{


### PR DESCRIPTION
- `com.okta.telephony.provider` is valid hook type
- Alphabetize hook types for easier reading
- Test ACC coverage
- Closes #1128