### PR TITLE
Reverting 0ebeae7c5e062a084809397ca93b194cdef17a94 on okta/resource_okta_policy_rule_sign_on.go

### DIFF
--- a/okta/resource_okta_policy_rule_sign_on.go
+++ b/okta/resource_okta_policy_rule_sign_on.go
@@ -79,8 +79,7 @@ func resourcePolicySignOnRule() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: elemInSlice([]string{"", "ANY", "LOW", "MEDIUM", "HIGH"}),
 				Description:      "Risc level: ANY, LOW, MEDIUM or HIGH",
-				// On reads the Okta API can return a default value of "ANY" when not present in local TF config
-				DiffSuppressFunc: valueDiffDefaultAPIValueToLocalValue("ANY", ""),
+				Default:          "ANY",
 			},
 			"behaviors": {
 				Type:        schema.TypeSet,
@@ -136,8 +135,7 @@ func resourcePolicySignOnRule() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: elemInSlice([]string{"ANY", "OKTA", "SPECIFIC_IDP"}),
 				Description:      "Apply rule based on the IdP used: ANY, OKTA or SPECIFIC_IDP.",
-				// On reads the Okta API can return a default value of "ANY" when not present in local TF config
-				DiffSuppressFunc: valueDiffDefaultAPIValueToLocalValue("ANY", ""),
+				Default:          "ANY",
 			},
 			"identity_provider_ids": { // identity_provider must be SPECIFIC_IDP
 				Type:        schema.TypeList,
@@ -196,6 +194,12 @@ func resourcePolicySignOnRuleRead(ctx context.Context, d *schema.ResourceData, m
 			if err != nil {
 				return diag.Errorf("failed to set sign-on policy rule behaviors: %v", err)
 			}
+		}
+	}
+	if rule.Conditions.IdentityProvider != nil {
+		_ = d.Set("identity_provider", rule.Conditions.IdentityProvider.Provider)
+		if rule.Conditions.IdentityProvider.Provider == "SPECIFIC_IDP" {
+			_ = d.Set("identity_provider_ids", convertStringSliceToInterfaceSlice(rule.Conditions.IdentityProvider.IdpIds))
 		}
 	}
 
@@ -265,6 +269,14 @@ func buildSignOnPolicyRule(d *schema.ResourceData) sdk.PolicyRule {
 		},
 		Network: buildPolicyNetworkCondition(d),
 		People:  getUsers(d),
+	}
+
+	provider, ok := d.GetOk("identity_provider")
+	if ok {
+		template.Conditions.IdentityProvider = &okta.IdentityProviderPolicyRuleCondition{
+			Provider: provider.(string),
+			IdpIds:   convertInterfaceToStringArr(d.Get("identity_provider_ids")),
+		}
 	}
 
 	bi, ok := d.GetOk("behaviors")

--- a/okta/resource_okta_policy_rule_sign_on_test.go
+++ b/okta/resource_okta_policy_rule_sign_on_test.go
@@ -93,6 +93,7 @@ func TestAccOktaPolicyRuleSignon_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc_%d", ri)),
 					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
 					resource.TestCheckResourceAttr(resourceName, "mfa_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider", "SPECIFIC_IDP"),
 				),
 			},
 

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -219,16 +219,6 @@ func createValueDiffSuppression(newValueToIgnore string) schema.SchemaDiffSuppre
 	}
 }
 
-// ignore schema diff change if value changes from default value (TF old) to local value (TF new)
-func valueDiffDefaultAPIValueToLocalValue(defaultAPIValue, localValue string) schema.SchemaDiffSuppressFunc {
-	return func(k, old, new string, d *schema.ResourceData) bool {
-		if old == defaultAPIValue && new == localValue {
-			return true
-		}
-		return false
-	}
-}
-
 func ensureNotDefault(d *schema.ResourceData, t string) error {
 	thing := fmt.Sprintf("Default %s", t)
 


### PR DESCRIPTION
Reverting 0ebeae7c5e062a084809397ca93b194cdef17a94 which incorrectly removed setup around SPECIFIC_IDP.

Passing ACC tests:
- TestAccOktaPolicyRuleSignon_crud
- TestAccOktaPolicySignOn_defaultError
- TestAccOktaPolicySignOn_crud

Closes #1126
Reopens #1079