### PR TITLE
Remove incorrect attributes `response_signature_algorithm`, and `response_signature_scope` from resource `okta_idp_oidc`

### DIFF
--- a/okta/idp.go
+++ b/okta/idp.go
@@ -249,19 +249,6 @@ func syncGroupActions(d *schema.ResourceData, groups *okta.ProvisioningGroups) e
 	})
 }
 
-func syncAlgo(d *schema.ResourceData, alg *okta.ProtocolAlgorithms) {
-	if alg != nil {
-		if alg.Request != nil && alg.Request.Signature != nil {
-			_ = d.Set("request_signature_algorithm", alg.Request.Signature.Algorithm)
-			_ = d.Set("request_signature_scope", alg.Request.Signature.Scope)
-		}
-		if alg.Response != nil && alg.Response.Signature != nil {
-			_ = d.Set("response_signature_algorithm", alg.Response.Signature.Algorithm)
-			_ = d.Set("response_signature_scope", alg.Response.Signature.Scope)
-		}
-	}
-}
-
 func buildPolicyAccountLink(d *schema.ResourceData) *okta.PolicyAccountLink {
 	link := convertInterfaceToStringSet(d.Get("account_link_group_include"))
 	var filter *okta.PolicyAccountLinkFilter

--- a/okta/resource_okta_idp_oidc.go
+++ b/okta/resource_okta_idp_oidc.go
@@ -120,7 +120,7 @@ func resourceIdpRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	syncEndpoint("token", idp.Protocol.Endpoints.Token, d)
 	syncEndpoint("user_info", idp.Protocol.Endpoints.UserInfo, d)
 	syncEndpoint("jwks", idp.Protocol.Endpoints.Jwks, d)
-	syncAlgo(d, idp.Protocol.Algorithms)
+	syncIdpOidcAlgo(d, idp.Protocol.Algorithms)
 	err = syncGroupActions(d, idp.Policy.Provisioning.Groups)
 	if err != nil {
 		return diag.Errorf("failed to set OIDC identity provider properties: %v", err)
@@ -204,4 +204,13 @@ func buildIdPOidc(d *schema.ResourceData) (okta.IdentityProvider, error) {
 			},
 		},
 	}, nil
+}
+
+func syncIdpOidcAlgo(d *schema.ResourceData, alg *okta.ProtocolAlgorithms) {
+	if alg != nil {
+		if alg.Request != nil && alg.Request.Signature != nil {
+			_ = d.Set("request_signature_algorithm", alg.Request.Signature.Algorithm)
+			_ = d.Set("request_signature_scope", alg.Request.Signature.Scope)
+		}
+	}
 }

--- a/okta/resource_okta_idp_saml.go
+++ b/okta/resource_okta_idp_saml.go
@@ -136,7 +136,7 @@ func resourceIdpSamlRead(ctx context.Context, d *schema.ResourceData, m interfac
 	_ = d.Set("issuer", idp.Protocol.Credentials.Trust.Issuer)
 	_ = d.Set("audience", idp.Protocol.Credentials.Trust.Audience)
 	_ = d.Set("kid", idp.Protocol.Credentials.Trust.Kid)
-	syncAlgo(d, idp.Protocol.Algorithms)
+	syncIdpSamlAlgo(d, idp.Protocol.Algorithms)
 	err = syncGroupActions(d, idp.Policy.Provisioning.Groups)
 	if err != nil {
 		return diag.Errorf("failed to set SAML identity provider properties: %v", err)
@@ -231,4 +231,17 @@ func buildIdPSaml(d *schema.ResourceData) (okta.IdentityProvider, error) {
 			},
 		},
 	}, nil
+}
+
+func syncIdpSamlAlgo(d *schema.ResourceData, alg *okta.ProtocolAlgorithms) {
+	if alg != nil {
+		if alg.Request != nil && alg.Request.Signature != nil {
+			_ = d.Set("request_signature_algorithm", alg.Request.Signature.Algorithm)
+			_ = d.Set("request_signature_scope", alg.Request.Signature.Scope)
+		}
+		if alg.Response != nil && alg.Response.Signature != nil {
+			_ = d.Set("response_signature_algorithm", alg.Response.Signature.Algorithm)
+			_ = d.Set("response_signature_scope", alg.Response.Signature.Scope)
+		}
+	}
 }


### PR DESCRIPTION
DRY'd up `syncAlgo` was too loose, idp oidc does not have attributes `response_signature_algorithm`, and `response_signature_scope`.