### PR TITLE
Prep for 3.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.30.0 (June 22, 2022)
+
+BUG FIXES:
+
+* Correct issuer mode value in embedded `groups_claim` of an `okta_app_oauth` resource [#1167](https://github.com/okta/terraform-provider-okta/pull/1167). Thanks, [@monde](https://github.com/monde)!
+* Resource `okta_app_oauth` property`redirect_uris` is a list, not a set, and needs to maintain order. [#1171](https://github.com/okta/terraform-provider-okta/pull/1171). Thanks, [@monde](https://github.com/monde)!
+* Fix JSON serialization errors that group and user schemas experience when `enum` and `one_of` properties are utilized with a `type` value other than `string` [#1178](https://github.com/okta/terraform-provider-okta/pull/1178). Thanks, [@monde](https://github.com/monde)!
+
+ENHANCEMENTS:
+
+* Add `no-stalebot` label exemption for GH stalebot action [#1180](https://github.com/okta/terraform-provider-okta/pull/1180). Thanks, [@monde](https://github.com/monde)!
+
+
 ## 3.29.0 (June 09, 2022)
 
 ENHANCEMENTS:

--- a/okta/config.go
+++ b/okta/config.go
@@ -112,7 +112,7 @@ func (c *Config) loadAndValidate(ctx context.Context) error {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.29.0"),
+		okta.WithUserAgentExtra("okta-terraform/3.30.0"),
 	}
 	if c.apiToken == "" {
 		setters = append(setters, okta.WithAuthorizationMode("PrivateKey"))


### PR DESCRIPTION
BUG FIXES:

* Correct issuer mode value in embedded `groups_claim` of an `okta_app_oauth` resource [#1167](https://github.com/okta/terraform-provider-okta/pull/1167). Thanks, [@monde](https://github.com/monde)!
* Resource `okta_app_oauth` property`redirect_uris` is a list, not a set, and needs to maintain order. [#1171](https://github.com/okta/terraform-provider-okta/pull/1171). Thanks, [@monde](https://github.com/monde)!
* Fix JSON serialization errors that group and user schemas experience when `enum` and `one_of` properties are utilized with a `type` value other than `string` [#1178](https://github.com/okta/terraform-provider-okta/pull/1178). Thanks, [@mond>

ENHANCEMENTS:

* Add `no-stalebot` label exemption for GH stalebot action [#1180](https://github.com/okta/terraform-provider-okta/pull/1180). Thanks, [@monde](https://github.com/monde)!