### PR TITLE
Fixes variable type with enum and one_of in user and group schemas (old JSON serialization errors)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-hclog v1.2.1
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/okta/okta-sdk-golang/v2 v2.12.2-0.20220602195034-d7ea6917663f
+	github.com/okta/okta-sdk-golang/v2 v2.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/okta/okta-sdk-golang/v2 v2.12.2-0.20220602195034-d7ea6917663f h1:6zPIZb9jjYbKfCdkpjERA6tpQKIiX+4+d4WJ8kEJJ8g=
-github.com/okta/okta-sdk-golang/v2 v2.12.2-0.20220602195034-d7ea6917663f/go.mod h1:aL3K0likfyLVapi33OsegX+KJf4c6SDapDhlUcXFEvk=
+github.com/okta/okta-sdk-golang/v2 v2.13.0 h1:Z5fmqKcFqJCJ1GCRVezElYqUgeL+8jrPybO7nVJjAm0=
+github.com/okta/okta-sdk-golang/v2 v2.13.0/go.mod h1:aL3K0likfyLVapi33OsegX+KJf4c6SDapDhlUcXFEvk=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/okta/fixtures_test.go
+++ b/okta/fixtures_test.go
@@ -42,5 +42,9 @@ func (manager *fixtureManager) GetFixtures(fixtureName string, rInt int, t *test
 		return tfConfig
 	}
 
+	return manager.ConfigReplace(tfConfig, rInt)
+}
+
+func (manager *fixtureManager) ConfigReplace(tfConfig string, rInt int) string {
 	return strings.ReplaceAll(tfConfig, uuidPattern, fmt.Sprintf("%d", rInt))
 }

--- a/okta/resource_okta_group_custom_schema_property.go
+++ b/okta/resource_okta_group_custom_schema_property.go
@@ -118,7 +118,15 @@ func alterCustomGroupSchema(ctx context.Context, m interface{}, index string, sc
 	bc := backoff.WithContext(bOff, ctx)
 
 	err := backoff.Retry(func() error {
+
+		// NOTE: Enums on the schema can be typed other than string but the
+		// Terraform SDK is staticly defined at runtime for string so we need to
+		// juggle types on the fly.
+
+		retypeGroupSchemaPropertyEnums(schema)
 		updated, resp, err := getOktaClientFromMetadata(m).GroupSchema.UpdateGroupSchema(ctx, *schema)
+		stringifyGroupSchemaPropertyEnums(schema)
+
 		if err != nil {
 			logger(m).Error(err.Error())
 			if resp != nil && resp.StatusCode == 500 {
@@ -177,14 +185,26 @@ func syncCustomGroupSchema(d *schema.ResourceData, subschema *okta.GroupSchemaAt
 	_ = d.Set("external_name", subschema.ExternalName)
 	_ = d.Set("external_namespace", subschema.ExternalNamespace)
 	_ = d.Set("unique", subschema.Unique)
+
+	// NOTE: Enums on the schema can be typed other than string but the
+	// Terraform SDK is staticly defined at runtime for string so we need to
+	// juggle types on the fly.
+
 	if subschema.Items != nil {
+		stringifyOneOfSlice(subschema.Items.Type, &subschema.Items.OneOf)
+		stringifyEnumSlice(subschema.Items.Type, &subschema.Items.Enum)
 		_ = d.Set("array_type", subschema.Items.Type)
 		_ = d.Set("array_one_of", flattenOneOf(subschema.Items.OneOf))
-		_ = d.Set("array_enum", strToInterfaceSlice(subschema.Items.Enum))
+		_ = d.Set("array_enum", subschema.Items.Enum)
 	}
+
+	stringifyOneOfSlice(subschema.Type, &subschema.OneOf)
+	stringifyEnumSlice(subschema.Type, &subschema.Enum)
+
 	if len(subschema.Enum) > 0 {
-		_ = d.Set("enum", strToInterfaceSlice(subschema.Enum))
+		_ = d.Set("enum", subschema.Enum)
 	}
+
 	return setNonPrimitives(d, map[string]interface{}{
 		"one_of": flattenOneOf(subschema.OneOf),
 	})
@@ -224,9 +244,9 @@ func buildGroupCustomSchemaAttribute(d *schema.ResourceData) (*okta.GroupSchemaA
 			return nil, err
 		}
 	}
-	var enum []string
+	var enum []interface{}
 	if rawEnum, ok := d.GetOk("enum"); ok {
-		enum = buildStringSlice(rawEnum.([]interface{}))
+		enum = rawEnum.([]interface{})
 	}
 	return &okta.GroupSchemaAttribute{
 		Title:       d.Get("title").(string),
@@ -257,4 +277,63 @@ func groupSchemaCustomAttribute(s *okta.GroupSchema, index string) *okta.GroupSc
 		return nil
 	}
 	return s.Definitions.Custom.Properties[index]
+}
+
+// retypeGroupSchemaPropertyEnums takes a schema and ensures the enums in its
+// GroupSchemaAttribute(s) have the correct golang type values instead of the
+// strings limitation due to the TF SDK.
+func retypeGroupSchemaPropertyEnums(schema *okta.GroupSchema) {
+	if schema.Definitions != nil && schema.Definitions.Base != nil {
+		retypeGroupPropertiesEnum(schema.Definitions.Base.Properties)
+	}
+	if schema.Definitions != nil && schema.Definitions.Custom != nil {
+		retypeGroupPropertiesEnum(schema.Definitions.Custom.Properties)
+	}
+}
+
+// stringifyGroupSchemaPropertyEnums takes a schema and ensures the enums in its
+// GroupSchemaAttribute(s) have string values to satisfy the TF schema
+func stringifyGroupSchemaPropertyEnums(schema *okta.GroupSchema) {
+	if schema.Definitions != nil && schema.Definitions.Base != nil {
+		stringifyGroupPropertiesEnum(schema.Definitions.Base.Properties)
+	}
+	if schema.Definitions != nil && schema.Definitions.Custom != nil {
+		stringifyGroupPropertiesEnum(schema.Definitions.Custom.Properties)
+	}
+}
+
+func retypeGroupPropertiesEnum(properties map[string]*okta.GroupSchemaAttribute) {
+	for _, val := range properties {
+		if val == nil {
+			continue
+		}
+		enum := retypeEnumSlice(val.Type, val.Enum)
+		val.Enum = enum
+		attributeEnum := retypeOneOfSlice(val.Type, val.OneOf)
+		val.OneOf = attributeEnum
+		if val.Items != nil {
+			enum := retypeEnumSlice(val.Items.Type, val.Items.Enum)
+			val.Items.Enum = enum
+			retypeOneOfSlice(val.Type, val.OneOf)
+			attributeEnum := retypeOneOfSlice(val.Items.Type, val.Items.OneOf)
+			val.Items.OneOf = attributeEnum
+		}
+
+	}
+}
+
+func stringifyGroupPropertiesEnum(properties map[string]*okta.GroupSchemaAttribute) {
+	for _, val := range properties {
+		if val != nil && val.Enum != nil {
+			stringifyEnumSlice(val.Type, &val.Enum)
+		}
+		if val != nil && val.OneOf != nil {
+			stringifyOneOfSlice(val.Type, &val.OneOf)
+		}
+		if val != nil && val.Items != nil {
+			stringifyEnumSlice(val.Items.Type, &val.Items.Enum)
+			stringifyOneOfSlice(val.Items.Type, &val.Items.OneOf)
+		}
+
+	}
 }

--- a/okta/resource_okta_group_custom_schema_property_test.go
+++ b/okta/resource_okta_group_custom_schema_property_test.go
@@ -217,3 +217,691 @@ func testOktaGroupSchemasExists(name string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+func TestAccResourceOktaGroupSchema_array_enum_number(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "number"
+			  array_enum  = ["0.01", "0.02", "0.03"]
+			  array_one_of {
+			    title = "number point oh one"
+			    const = "0.01"
+			  }
+			  array_one_of {
+			    title = "number point oh two"
+			    const = "0.02"
+			  }
+			  array_one_of {
+			    title = "number point oh three"
+			    const = "0.03"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "0.03"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "number point oh one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "number point oh two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "number point oh three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "0.03"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "number"
+			  array_enum  = ["0.011", "0.022", "0.033"]
+			  array_one_of {
+			    title = "number point oh one one"
+			    const = "0.011"
+			  }
+			  array_one_of {
+			    title = "number point oh two two"
+			    const = "0.022"
+			  }
+			  array_one_of {
+			    title = "number point oh three three"
+			    const = "0.033"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "0.033"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "number point oh one one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "number point oh two two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "number point oh three three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "0.033"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupSchema_enum_number(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "number"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["0.01", "0.02", "0.03"]
+			  one_of {
+			    title = "number point oh one"
+			    const = "0.01"
+			  }
+			  one_of {
+			    title = "number point oh two"
+			    const = "0.02"
+			  }
+			  one_of {
+			    title = "number point oh three"
+			    const = "0.03"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "0.03"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "number point oh one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "number point oh two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "number point oh three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "0.03"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "number"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["0.011", "0.022", "0.033"]
+			  one_of {
+			    title = "number point oh one one"
+			    const = "0.011"
+			  }
+			  one_of {
+			    title = "number point oh two two"
+			    const = "0.022"
+			  }
+			  one_of {
+			    title = "number point oh three three"
+			    const = "0.033"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "0.033"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "number point oh one one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "number point oh two two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "number point oh three three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "0.033"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupSchema_array_enum_integer(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "integer"
+			  array_enum  = ["1", "2", "3"]
+			  array_one_of {
+			    title = "integer one"
+			    const = "1"
+			  }
+			  array_one_of {
+			    title = "integer two"
+			    const = "2"
+			  }
+			  array_one_of {
+			    title = "integer three"
+			    const = "3"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "1"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "integer one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "1"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "integer two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "integer three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "3"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "integer"
+			  array_enum  = ["4", "5", "6"]
+			  array_one_of {
+			    title = "integer four"
+			    const = "4"
+			  }
+			  array_one_of {
+			    title = "integer five"
+			    const = "5"
+			  }
+			  array_one_of {
+			    title = "integer six"
+			    const = "6"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "4"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "5"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "6"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "integer four"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "4"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "integer five"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "5"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "integer six"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupSchema_enum_integer(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "integer"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["1", "2", "3"]
+			  one_of {
+			    title = "integer one"
+			    const = "1"
+			  }
+			  one_of {
+			    title = "integer two"
+			    const = "2"
+			  }
+			  one_of {
+			    title = "integer three"
+			    const = "3"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "integer one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "1"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "integer two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "2"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "integer three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "3"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "integer"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["4", "5", "6"]
+			  one_of {
+			    title = "integer four"
+			    const = "4"
+			  }
+			  one_of {
+			    title = "integer five"
+			    const = "5"
+			  }
+			  one_of {
+			    title = "integer six"
+			    const = "6"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "4"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "5"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "6"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "integer four"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "4"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "integer five"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "5"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "integer six"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupSchema_array_enum_boolean(t *testing.T) {
+	// TODO deal with apparent monolith bug:
+	// "the API returned an error: Array specified in enum field must match const values specified in oneOf field."
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "boolean"
+			  array_enum  = ["true", "false"]
+			  array_one_of {
+			    title = "boolean True"
+			    const = "true"
+			  }
+			  array_one_of {
+			    title = "boolean False"
+			    const = "false"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "true"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "false"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "boolean True"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "true"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "boolean False"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "false"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "boolean"
+			  array_enum  = ["false", "true"]
+			  array_one_of {
+			    title = "boolean FALSE"
+			    const = "false"
+			  }
+			  array_one_of {
+			    title = "boolean TRUE"
+			    const = "true"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "false"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "true"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "boolean FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "false"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "boolean TRUE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupSchema_enum_boolean(t *testing.T) {
+	// TODO deal with apparent monolith bug:
+	// "the API returned an error: Array specified in enum field must match const values specified in oneOf field."
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "boolean"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["true", "false"]
+			  one_of {
+			    title = "boolean True"
+			    const = "true"
+			  }
+			  one_of {
+			    title = "boolean False"
+			    const = "false"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "false"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "boolean True"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "true"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "boolean False"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "false"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "boolean"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["false", "true"]
+			  one_of {
+			    title = "boolean FALSE"
+			    const = "false"
+			  }
+			  one_of {
+			    title = "boolean TRUE"
+			    const = "true"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "true"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "boolean FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "false"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "boolean TRUE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupSchema_array_enum_string(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "string"
+			  array_enum  = ["one", "two", "three"]
+			  array_one_of {
+			    title = "string One"
+			    const = "one"
+			  }
+			  array_one_of {
+			    title = "string Two"
+			    const = "two"
+			  }
+			  array_one_of {
+			    title = "string Three"
+			    const = "three"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "one"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "two"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "string One"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "string Two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "string Three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "three"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "string"
+			  array_enum  = ["ONE", "TWO", "THREE"]
+			  array_one_of {
+			    title = "STRING ONE"
+			    const = "ONE"
+			  }
+			  array_one_of {
+			    title = "STRING TWO"
+			    const = "TWO"
+			  }
+			  array_one_of {
+			    title = "STRING THREE"
+			    const = "THREE"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "THREE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "STRING ONE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "STRING TWO"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "STRING THREE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "THREE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupSchema_enum_string(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(groupSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaGroupSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  type  = "string"
+			  enum  = ["one", "two", "three"]
+			  one_of {
+			    title = "string One"
+			    const = "one"
+			  }
+			  one_of {
+			    title = "string Two"
+			    const = "two"
+			  }
+			  one_of {
+			    title = "string Three"
+			    const = "three"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "one"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "two"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "string One"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "string Two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "string Three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "three"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_group_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  type  = "string"
+			  enum  = ["ONE", "TWO", "THREE"]
+			  one_of {
+			    title = "STRING ONE"
+			    const = "ONE"
+			  }
+			  one_of {
+			    title = "STRING TWO"
+			    const = "TWO"
+			  }
+			  one_of {
+			    title = "STRING THREE"
+			    const = "THREE"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "THREE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "STRING ONE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "STRING TWO"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "STRING THREE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "THREE"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_user_custom_schema_property.go
+++ b/okta/resource_okta_user_custom_schema_property.go
@@ -162,9 +162,9 @@ func alterCustomUserSchema(ctx context.Context, m interface{}, userType, index s
 		// Terraform SDK is staticly defined at runtime for string so we need to
 		// juggle types on the fly.
 
-		retypeSchemaPropertyEnums(schema)
+		retypeUserSchemaPropertyEnums(schema)
 		updated, resp, err := getOktaClientFromMetadata(m).UserSchema.UpdateUserProfile(ctx, typeSchemaID, *schema)
-		stringifySchemaPropertyEnums(schema)
+		stringifyUserSchemaPropertyEnums(schema)
 
 		if err != nil {
 			logger(m).Error(err.Error())

--- a/okta/resource_okta_user_custom_schema_property.go
+++ b/okta/resource_okta_user_custom_schema_property.go
@@ -100,9 +100,6 @@ func resourceUserSchemaResourceV0() *schema.Resource {
 	})}
 }
 
-// Sometime Okta API does not update or create custom property on the first try, thus that require running
-// `terraform apply` several times. This simple retry resolves that issue. (If) After  this issue will be resolved,
-// this retry logic will be demolished.
 func resourceUserSchemaCreateOrUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	logger(m).Info("creating user custom schema property", "name", d.Get("index").(string))
 	err := validateUserSchema(d)
@@ -161,7 +158,14 @@ func alterCustomUserSchema(ctx context.Context, m interface{}, userType, index s
 	bc := backoff.WithContext(bOff, ctx)
 
 	err = backoff.Retry(func() error {
+		// NOTE: Enums on the schema can be typed other than string but the
+		// Terraform SDK is staticly defined at runtime for string so we need to
+		// juggle types on the fly.
+
+		retypeSchemaPropertyEnums(schema)
 		updated, resp, err := getOktaClientFromMetadata(m).UserSchema.UpdateUserProfile(ctx, typeSchemaID, *schema)
+		stringifySchemaPropertyEnums(schema)
+
 		if err != nil {
 			logger(m).Error(err.Error())
 			if resp != nil && resp.StatusCode == 500 {

--- a/okta/resource_okta_user_custom_schema_property_test.go
+++ b/okta/resource_okta_user_custom_schema_property_test.go
@@ -37,7 +37,7 @@ func sweepUserCustomSchema(client *testClient) error {
 	return nil
 }
 
-func TestAccOktaUserSchema_crud(t *testing.T) {
+func TestAccResourceOktaUserSchema_crud(t *testing.T) {
 	ri := acctest.RandInt()
 	mgr := newFixtureManager(userSchemaProperty)
 	config := mgr.GetFixtures("basic.tf", ri, t)
@@ -135,7 +135,7 @@ func TestAccOktaUserSchema_crud(t *testing.T) {
 	})
 }
 
-func TestAccOktaUserSchema_arrayString(t *testing.T) {
+func TestAccResourceOktaUserSchema_array_enum(t *testing.T) {
 	ri := acctest.RandInt()
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	mgr := newFixtureManager(userSchemaProperty)
@@ -242,6 +242,694 @@ func checkOktaUserSchemasDestroy() resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+func TestAccResourceOktaUserSchema_array_enum_number(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "number"
+			  array_enum  = ["0.01", "0.02", "0.03"]
+			  array_one_of {
+			    title = "number point oh one"
+			    const = "0.01"
+			  }
+			  array_one_of {
+			    title = "number point oh two"
+			    const = "0.02"
+			  }
+			  array_one_of {
+			    title = "number point oh three"
+			    const = "0.03"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "0.03"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "number point oh one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "number point oh two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "number point oh three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "0.03"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "number"
+			  array_enum  = ["0.011", "0.022", "0.033"]
+			  array_one_of {
+			    title = "number point oh one one"
+			    const = "0.011"
+			  }
+			  array_one_of {
+			    title = "number point oh two two"
+			    const = "0.022"
+			  }
+			  array_one_of {
+			    title = "number point oh three three"
+			    const = "0.033"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "0.033"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "number point oh one one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "number point oh two two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "number point oh three three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "0.033"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaUserSchema_enum_number(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "number"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["0.01", "0.02", "0.03"]
+			  one_of {
+			    title = "number point oh one"
+			    const = "0.01"
+			  }
+			  one_of {
+			    title = "number point oh two"
+			    const = "0.02"
+			  }
+			  one_of {
+			    title = "number point oh three"
+			    const = "0.03"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "0.03"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "number point oh one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "number point oh two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "0.02"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "number point oh three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "0.03"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "number"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["0.011", "0.022", "0.033"]
+			  one_of {
+			    title = "number point oh one one"
+			    const = "0.011"
+			  }
+			  one_of {
+			    title = "number point oh two two"
+			    const = "0.022"
+			  }
+			  one_of {
+			    title = "number point oh three three"
+			    const = "0.033"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "number"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "0.033"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "number point oh one one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "0.011"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "number point oh two two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "0.022"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "number point oh three three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "0.033"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaUserSchema_array_enum_integer(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "integer"
+			  array_enum  = ["1", "2", "3"]
+			  array_one_of {
+			    title = "integer one"
+			    const = "1"
+			  }
+			  array_one_of {
+			    title = "integer two"
+			    const = "2"
+			  }
+			  array_one_of {
+			    title = "integer three"
+			    const = "3"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "1"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "integer one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "1"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "integer two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "integer three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "3"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "integer"
+			  array_enum  = ["4", "5", "6"]
+			  array_one_of {
+			    title = "integer four"
+			    const = "4"
+			  }
+			  array_one_of {
+			    title = "integer five"
+			    const = "5"
+			  }
+			  array_one_of {
+			    title = "integer six"
+			    const = "6"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "4"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "5"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "6"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "integer four"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "4"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "integer five"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "5"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "integer six"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaUserSchema_enum_integer(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "integer"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["1", "2", "3"]
+			  one_of {
+			    title = "integer one"
+			    const = "1"
+			  }
+			  one_of {
+			    title = "integer two"
+			    const = "2"
+			  }
+			  one_of {
+			    title = "integer three"
+			    const = "3"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "2"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "integer one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "1"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "integer two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "2"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "integer three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "3"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "integer"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["4", "5", "6"]
+			  one_of {
+			    title = "integer four"
+			    const = "4"
+			  }
+			  one_of {
+			    title = "integer five"
+			    const = "5"
+			  }
+			  one_of {
+			    title = "integer six"
+			    const = "6"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "4"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "5"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "6"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "integer four"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "4"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "integer five"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "5"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "integer six"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaUserSchema_array_enum_boolean(t *testing.T) {
+	// TODO deal with apparent monolith bug:
+	// "the API returned an error: Array specified in enum field must match const values specified in oneOf field."
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "boolean"
+			  array_enum  = ["true", "false"]
+			  array_one_of {
+			    title = "boolean True"
+			    const = "true"
+			  }
+			  array_one_of {
+			    title = "boolean False"
+			    const = "false"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "true"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "false"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "boolean True"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "true"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "boolean False"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "false"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "boolean"
+			  array_enum  = ["false", "true"]
+			  array_one_of {
+			    title = "boolean FALSE"
+			    const = "false"
+			  }
+			  array_one_of {
+			    title = "boolean TRUE"
+			    const = "true"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "false"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "true"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "boolean FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "false"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "boolean TRUE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaUserSchema_enum_boolean(t *testing.T) {
+	// TODO deal with apparent monolith bug:
+	// "the API returned an error: Array specified in enum field must match const values specified in oneOf field."
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "boolean"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["true", "false"]
+			  one_of {
+			    title = "boolean True"
+			    const = "true"
+			  }
+			  one_of {
+			    title = "boolean False"
+			    const = "false"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "false"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "boolean True"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "true"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "boolean False"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "false"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "boolean"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  enum  = ["false", "true"]
+			  one_of {
+			    title = "boolean FALSE"
+			    const = "false"
+			  }
+			  one_of {
+			    title = "boolean TRUE"
+			    const = "true"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "boolean"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "true"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "boolean FALSE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "false"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "boolean TRUE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaUserSchema_array_enum_string(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "string"
+			  array_enum  = ["one", "two", "three"]
+			  array_one_of {
+			    title = "string One"
+			    const = "one"
+			  }
+			  array_one_of {
+			    title = "string Two"
+			    const = "two"
+			  }
+			  array_one_of {
+			    title = "string Three"
+			    const = "three"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "one"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "two"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "string One"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "one"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "string Two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "two"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "string Three"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "three"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  type        = "array"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  array_type  = "string"
+			  array_enum  = ["ONE", "TWO", "THREE"]
+			  array_one_of {
+			    title = "STRING ONE"
+			    const = "ONE"
+			  }
+			  array_one_of {
+			    title = "STRING TWO"
+			    const = "TWO"
+			  }
+			  array_one_of {
+			    title = "STRING THREE"
+			    const = "THREE"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "array"),
+					resource.TestCheckResourceAttr(resourceName, "array_type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.0", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.1", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "array_enum.2", "THREE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.title", "STRING ONE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.0.const", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.title", "STRING TWO"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.1.const", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.title", "STRING THREE"),
+					resource.TestCheckResourceAttr(resourceName, "array_one_of.2.const", "THREE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaUserSchema_enum_string(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userSchemaProperty)
+	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      checkOktaUserSchemasDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  type  = "string"
+			  enum  = ["one", "two", "three"]
+			  one_of {
+			    title = "string One"
+			    const = "one"
+			  }
+			  one_of {
+			    title = "string Two"
+			    const = "two"
+			  }
+			  one_of {
+			    title = "string Three"
+			    const = "three"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "one"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "two"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "string One"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "one"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "string Two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "two"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "string Three"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "three"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(`
+			resource "okta_user_schema_property" "test" {
+			  index       = "testAcc_replace_with_uuid"
+			  title       = "terraform acceptance test"
+			  description = "testing"
+			  master      = "OKTA"
+			  scope       = "SELF"
+			  type  = "string"
+			  enum  = ["ONE", "TWO", "THREE"]
+			  one_of {
+			    title = "STRING ONE"
+			    const = "ONE"
+			  }
+			  one_of {
+			    title = "STRING TWO"
+			    const = "TWO"
+			  }
+			  one_of {
+			    title = "STRING THREE"
+			    const = "THREE"
+			  }
+			}`, ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "enum.0", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "enum.1", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "enum.2", "THREE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.title", "STRING ONE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.0.const", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.title", "STRING TWO"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.1.const", "TWO"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.title", "STRING THREE"),
+					resource.TestCheckResourceAttr(resourceName, "one_of.2.const", "THREE"),
+				),
+			},
+		},
+	})
 }
 
 func testOktaUserSchemasExists(name string) resource.TestCheckFunc {

--- a/okta/user_schema_property.go
+++ b/okta/user_schema_property.go
@@ -433,30 +433,30 @@ func userSchemaBaseAttribute(s *okta.UserSchema, index string) *okta.UserSchemaA
 	return s.Definitions.Base.Properties[index]
 }
 
-// retypeSchemaPropertyEnums takes a schema and ensures the enums in its
+// retypeUserSchemaPropertyEnums takes a schema and ensures the enums in its
 // UserSchemaAttribute(s) have the correct golang type values instead of the
 // strings limitation due to the TF SDK.
-func retypeSchemaPropertyEnums(schema *okta.UserSchema) {
+func retypeUserSchemaPropertyEnums(schema *okta.UserSchema) {
 	if schema.Definitions != nil && schema.Definitions.Base != nil {
-		retypePropertiesEnum(schema.Definitions.Base.Properties)
+		retypeUserPropertiesEnum(schema.Definitions.Base.Properties)
 	}
 	if schema.Definitions != nil && schema.Definitions.Custom != nil {
-		retypePropertiesEnum(schema.Definitions.Custom.Properties)
+		retypeUserPropertiesEnum(schema.Definitions.Custom.Properties)
 	}
 }
 
-// stringifySchemaPropertyEnums takes a schema and ensures the enums in its
+// stringifyUserSchemaPropertyEnums takes a schema and ensures the enums in its
 // UserSchemaAttribute(s) have string values to satisfy the TF schema
-func stringifySchemaPropertyEnums(schema *okta.UserSchema) {
+func stringifyUserSchemaPropertyEnums(schema *okta.UserSchema) {
 	if schema.Definitions != nil && schema.Definitions.Base != nil {
-		stringifyPropertiesEnum(schema.Definitions.Base.Properties)
+		stringifyUserPropertiesEnum(schema.Definitions.Base.Properties)
 	}
 	if schema.Definitions != nil && schema.Definitions.Custom != nil {
-		stringifyPropertiesEnum(schema.Definitions.Custom.Properties)
+		stringifyUserPropertiesEnum(schema.Definitions.Custom.Properties)
 	}
 }
 
-func retypePropertiesEnum(properties map[string]*okta.UserSchemaAttribute) {
+func retypeUserPropertiesEnum(properties map[string]*okta.UserSchemaAttribute) {
 	for _, val := range properties {
 		if val == nil {
 			continue
@@ -476,7 +476,7 @@ func retypePropertiesEnum(properties map[string]*okta.UserSchemaAttribute) {
 	}
 }
 
-func stringifyPropertiesEnum(properties map[string]*okta.UserSchemaAttribute) {
+func stringifyUserPropertiesEnum(properties map[string]*okta.UserSchemaAttribute) {
 	for _, val := range properties {
 		if val != nil && val.Enum != nil {
 			stringifyEnumSlice(val.Type, &val.Enum)

--- a/okta/user_schema_property.go
+++ b/okta/user_schema_property.go
@@ -261,7 +261,6 @@ func buildNullableItems(d *schema.ResourceData) (*okta.UserSchemaAttributeItems,
 		return u, nil
 	}
 	if okArrayEnum {
-		//enum := buildStringSlice(arrayEnum.([]interface{}))
 		u.Enum = arrayEnum.([]interface{})
 	}
 	if okArrayOneOf {
@@ -285,23 +284,6 @@ func buildOneOf(ae []interface{}, elemType string) ([]*okta.UserSchemaAttributeE
 		oneOf[i].Const = c
 	}
 	return oneOf, nil
-}
-
-func buildStringSlice(enum []interface{}) []string {
-	result := make([]string, len(enum))
-	for i := range enum {
-		result[i] = enum[i].(string)
-	}
-	return result
-}
-
-func strToInterfaceSlice(enum []string) []interface{} {
-	result := make([]interface{}, len(enum))
-	for i := range enum {
-		result[i] = enum[i]
-	}
-
-	return result
 }
 
 func flattenOneOf(oneOf []*okta.UserSchemaAttributeEnum) []interface{} {

--- a/website/docs/r/app_user_schema.html.markdown
+++ b/website/docs/r/app_user_schema.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # okta_app_user_schema
 
-~> **DEPRECATED** use `okta_app_user_schema_property` instead.
+~> **DEPRECATED** use `okta_app_user_schema_property` instead. To reiterate, development updates to `okta_app_user_schema` are no longer occuring and this resource may exhibit unknown or unstable behavior.
 
 Creates an Application User Schema property.
 

--- a/website/docs/r/app_user_schema_property.html.markdown
+++ b/website/docs/r/app_user_schema_property.html.markdown
@@ -11,6 +11,12 @@ description: |-
 This resource allows you to create and configure a custom user schema property and associate it with an application.
 Make sure that the app instance is `active` before creating the schema property, because in some cases API might return `404` error.
 
+**IMPORTANT:** With `enum`, list its values as strings even though the `type`
+may be something other than string. This is a limitation of the schema defintion
+in the Terraform Plugin SDK runtime and we juggle the type correctly when making
+Okta API calls. Same holds for the `const` value of `one_of` as well as the
+`array_*` variation of `enum` and `one_of`.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/group_schema_property.html.markdown
+++ b/website/docs/r/group_schema_property.html.markdown
@@ -12,6 +12,12 @@ Creates a Group Schema property.
 
 This resource allows you to create and configure a custom group schema property.
 
+**IMPORTANT:** With `enum`, list its values as strings even though the `type`
+may be something other than string. This is a limitation of the schema defintion
+in the Terraform Plugin SDK runtime and we juggle the type correctly when making
+Okta API calls. Same holds for the `const` value of `one_of` as well as the
+`array_*` variation of `enum` and `one_of`.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/user_schema.html.markdown
+++ b/website/docs/r/user_schema.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # okta_user_schema
 
-~> **DEPRECATED** use `okta_user_schema_property` instead.
+~> **DEPRECATED** use `okta_user_schema_property` instead. To reiterate, development updates to `okta_user_schema` are no longer occuring and this resource may exhibit unknown or unstable behavior.
 
 Creates a User Schema property.
 

--- a/website/docs/r/user_schema_property.html.markdown
+++ b/website/docs/r/user_schema_property.html.markdown
@@ -12,6 +12,12 @@ Creates a User Schema property.
 
 This resource allows you to create and configure a custom user schema property.
 
+**IMPORTANT:** With `enum`, list its values as strings even though the `type`
+may be something other than string. This is a limitation of the schema defintion
+in the Terraform Plugin SDK runtime and we juggle the type correctly when making
+Okta API calls. Same holds for the `const` value of `one_of` as well as the
+`array_*` variation of `enum` and `one_of`.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Fixes the JSON serialization errors that group and user schema properties could experience when they make use of an enum that was typed with values other than string.