### PR TITLE
Add support for `authentication_policy` / `app_signon_policy`

### DIFF
--- a/examples/okta_app_signon_policy/basic.tf
+++ b/examples/okta_app_signon_policy/basic.tf
@@ -1,0 +1,4 @@
+resource "okta_app_signon_policy" "test" {
+  name        = "Test_App_replace_with_uuid"
+  description = "The app signon policy used by our test app."
+}

--- a/examples/okta_app_signon_policy/basic_renamed.tf
+++ b/examples/okta_app_signon_policy/basic_renamed.tf
@@ -1,0 +1,4 @@
+resource "okta_app_signon_policy" "test" {
+  name        = "Test_App_Renamed_replace_with_uuid"
+  description = "The app signon policy used by our test app."
+}

--- a/examples/okta_app_signon_policy/basic_updated.tf
+++ b/examples/okta_app_signon_policy/basic_updated.tf
@@ -1,0 +1,4 @@
+resource "okta_app_signon_policy" "test" {
+  name        = "Test_App_replace_with_uuid"
+  description = "The updated app signon policy used by our test app."
+}

--- a/okta/app_authentication_policy.go
+++ b/okta/app_authentication_policy.go
@@ -1,0 +1,47 @@
+package okta
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func setAuthenticationPolicy(ctx context.Context, d *schema.ResourceData, m interface{}, appId string) error {
+	raw, ok := d.GetOk("authentication_policy")
+	if !ok {
+		return assignDefaultAuthenticationPolicy(ctx, m, appId)
+	}
+	policyId := raw.(string)
+	_, err := getOktaClientFromMetadata(m).Application.UpdateApplicationPolicy(ctx, appId, policyId)
+	return err
+}
+
+func assignDefaultAuthenticationPolicy(ctx context.Context,  m interface{}, appId string) error {
+	client := getOktaClientFromMetadata(m)
+	qp := query.NewQueryParams()
+	qp.Type = "ACCESS_POLICY"
+	policies, _, err := client.Policy.ListPolicies(ctx, qp)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed delete authentication policy: %v", err))
+	}
+
+	// find the default policy
+	var defaultPolicy *okta.Policy
+	for _, p := range policies {
+		
+		v := p.(*okta.Policy)
+		if v.Name == "Default Policy" && *v.System == true{
+			defaultPolicy = v
+		}
+		
+	}
+	if defaultPolicy == nil {
+		return errors.New("no default policy found")
+	}
+	_, err = client.Application.UpdateApplicationPolicy(ctx, appId, defaultPolicy.Id)
+	return err
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -257,6 +257,7 @@ func Provider() *schema.Provider {
 			appSamlAppSettings:            resourceAppSamlAppSettings(),
 			appSecurePasswordStore:        resourceAppSecurePasswordStore(),
 			appSharedCredentials:          resourceAppSharedCredentials(),
+			appSignOnPolicy:               resourceAppSignOnPolicy(),
 			appSignOnPolicyRule:           resourceAppSignOnPolicyRule(),
 			appSwa:                        resourceAppSwa(),
 			appThreeField:                 resourceAppThreeField(),

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -361,6 +361,11 @@ func resourceAppOAuth() *schema.Resource {
 					return new == ""
 				},
 			},
+			"authentication_policy": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: "Id of this apps authentication policy",
+			},
 		}),
 	}
 }
@@ -431,6 +436,10 @@ func resourceAppOAuthCreate(ctx context.Context, d *schema.ResourceData, m inter
 	err = setAppOauthGroupsClaim(ctx, d, m)
 	if err != nil {
 		return diag.Errorf("failed to update groups claim for an OAuth application: %v", err)
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy for an OAuth application: %v", err)
 	}
 	return resourceAppOAuthRead(ctx, d, m)
 }
@@ -659,6 +668,10 @@ func resourceAppOAuthUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	err = updateAppOauthGroupsClaim(ctx, d, m)
 	if err != nil {
 		return diag.Errorf("failed to update groups claim for an OAuth application: %v", err)
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy an OAuth application: %v", err)
 	}
 	return resourceAppOAuthRead(ctx, d, m)
 }

--- a/okta/resource_okta_app_saml.go
+++ b/okta/resource_okta_app_saml.go
@@ -336,6 +336,11 @@ func resourceAppSaml() *schema.Resource {
 				Description:      "SAML version for the app's sign-on mode",
 				ValidateDiagFunc: elemInSlice([]string{saml20, saml11}),
 			},
+			"authentication_policy": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: "Id of this apps authentication policy",
+			},
 		}),
 	}
 }
@@ -376,6 +381,10 @@ func resourceAppSamlCreate(ctx context.Context, d *schema.ResourceData, m interf
 	err = handleAppLogo(ctx, d, m, app.Id, app.Links)
 	if err != nil {
 		return diag.Errorf("failed to upload logo for SAML application: %v", err)
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy for an SAML application: %v", err)
 	}
 	return resourceAppSamlRead(ctx, d, m)
 }
@@ -491,6 +500,10 @@ func resourceAppSamlUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			_ = d.Set("logo", o)
 			return diag.Errorf("failed to upload logo for SAML application: %v", err)
 		}
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy for an SAML application: %v", err)
 	}
 	return resourceAppSamlRead(ctx, d, m)
 }

--- a/okta/resource_okta_app_signon_policy.go
+++ b/okta/resource_okta_app_signon_policy.go
@@ -1,0 +1,180 @@
+package okta
+
+import (
+	"context"
+	"errors"
+	"path"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func resourceAppSignOnPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppSignOnPolicyCreate,
+		ReadContext: resourceAppSignOnPolicyRead,
+		UpdateContext: resourceAppSignOnPolicyUpdate,
+		DeleteContext: resourceAppSignOnPolicyDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type: schema.TypeString,
+				Required: true,
+				Description: "Policy Name",
+			},
+			"description": {
+				Type: schema.TypeString,
+				Required: true,
+				Description: "Policy Description",
+			},
+		},
+	}
+}
+
+func buildAppSignOnPoilicy(d *schema.ResourceData) *okta.AccessPolicy {
+	return &okta.AccessPolicy{
+		Name: d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Type: "ACCESS_POLICY",
+	}
+}
+
+func  resourceAppSignOnPolicyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("creating authentication policy", "name", d.Get("name").(string))
+	policyToCreate := buildAppSignOnPoilicy(d)
+	
+	
+	oktaClient := getOktaClientFromMetadata(m)
+
+
+	responsePolicy, _, err := oktaClient.Policy.CreatePolicy(ctx, policyToCreate, nil)
+	if err != nil {
+		return diag.Errorf("failed to create authentication policy: %v", err)
+	}
+	id := responsePolicy.(*okta.AccessPolicy).Id
+	d.SetId(id)
+	return resourceAppSignOnPolicyRead(ctx, d, m)
+}
+
+func  resourceAppSignOnPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("reading authentication policy", "id", d.Id(), "name", d.Get("name").(string))
+	policy := &okta.Policy{}
+	authenticationPolicy, resp, err := getOktaClientFromMetadata(m).Policy.GetPolicy(ctx, d.Id(), policy, nil)
+	if err := suppressErrorOn404(resp, err); err != nil {
+		return diag.Errorf("failed to get authentication policy: %v", err)
+	}
+	if authenticationPolicy == nil {
+		d.SetId("")
+		return nil
+	}
+	policyFromServer := authenticationPolicy.(*okta.Policy)
+	d.SetId(policyFromServer.Id)
+	d.Set("name", policyFromServer.Name)
+	d.Set("description", policyFromServer.Description)
+	return nil
+}
+
+func  resourceAppSignOnPolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("updating authentication policy", "id", d.Id(), "name", d.Get("name").(string))
+	policyToUpdate := buildAppSignOnPoilicy(d)
+	_, _, err := getOktaClientFromMetadata(m).Policy.UpdatePolicy(ctx, d.Id(), policyToUpdate)
+	if err != nil {
+		return diag.Errorf("failed to update authentication policy: %v", err)
+	}
+	return resourceAppSignOnPolicyRead(ctx, d, m)
+}
+
+func  resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	/**
+		1. find the default app policy
+		2. assign the default policy to all apps using the current policy (the one to delete)
+		3. delete the policy
+	**/
+	
+	client := getOktaClientFromMetadata(m)
+	qp := query.NewQueryParams()
+	qp.Type = "ACCESS_POLICY"
+	policies, _, err := client.Policy.ListPolicies(ctx, qp)
+	if err != nil {
+		return diag.Errorf("failed delete authentication policy: %v", err)
+	}
+
+	// find the default policy
+	var defaultPolicy *okta.Policy
+	for _, p := range policies {
+		
+		v := p.(*okta.Policy)
+		if v.Name == "Default Policy" && *v.System == true{
+			defaultPolicy = v
+		}
+		
+	}
+	if defaultPolicy == nil {
+		return diag.Errorf("failed delete authentication policy: %v", errors.New("no default policy found"))
+	}
+
+	clients, listErr := listApplications(ctx, client)
+	if listErr != nil {
+		// delete the policy right away
+
+	_, err = client.Policy.DeletePolicy(ctx, d.Id())
+	if err != nil {
+		return diag.Errorf("failed delete authentication policy: %v", err)
+	}
+		return nil
+	} else {
+		// first unassign the policy and delete it then
+		// assign the default app policy to all clients using the current policy
+		for _, c := range clients {
+			app := c.(*okta.Application)
+			accessPolicy := linksValue(app.Links, "accessPolicy", "href")
+			if accessPolicy == "" {
+				return diag.Errorf("app does not support sign-on policy or this feature is not available")
+			}
+			if path.Base(accessPolicy) == d.Id() {
+				// check if client still exists
+				a := okta.NewApplication()
+				_, _, getErr := client.Application.GetApplication(ctx, app.Id, a, nil)
+				if getErr == nil {
+					// only perform the update if the app exists
+					_, updateErr := client.Application.UpdateApplicationPolicy(ctx, app.Id, defaultPolicy.Id)
+					if updateErr != nil {
+						return diag.Errorf("failed to assign default policy '%v' to app %v: %v", defaultPolicy.Id, app.Id, updateErr)
+					}
+				}
+				
+			}
+		}
+
+		_, err = client.Policy.DeletePolicy(ctx, d.Id())
+		if err != nil {
+			return diag.Errorf("failed delete authentication policy: %v", err)
+		}
+		return nil
+	}
+	
+}
+
+
+func listApplications(ctx context.Context, client *okta.Client) ([]okta.App, error) {
+	var resClients []okta.App
+
+	clients, resp, err := client.Application.ListApplications(ctx, &query.Params{Limit: defaultPaginationLimit})
+	if err != nil {
+		return nil, err
+	}
+	for {
+		resClients = append(resClients, clients...)
+		if resp.HasNextPage() {
+			resp, err = resp.Next(ctx, &clients)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		} else {
+			break
+		}
+	}
+	return resClients, nil
+}

--- a/okta/resource_okta_app_signon_policy_test.go
+++ b/okta/resource_okta_app_signon_policy_test.go
@@ -1,0 +1,52 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+
+func TestAccOktaAppSignOnPolicy_crud(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appSignOnPolicy)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
+	renamedConfig := mgr.GetFixtures("basic_renamed.tf", ri, t)
+	resourceName := fmt.Sprintf("%v.test", appSignOnPolicy)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {testAccPreCheck(t)},
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy: createPolicyCheckDestroy(appSignOnPolicy),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "description", "The updated app signon policy used by our test app."),
+				),
+			},
+			{
+				Config: renamedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("Test_App_Renamed_%d", ri)),
+					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
+				),
+			},
+		},
+	})
+
+}

--- a/sdk/policy_enrollment_apps.go
+++ b/sdk/policy_enrollment_apps.go
@@ -20,11 +20,16 @@ type AddAppToEnrollmentPolicyResponse struct {
 	Links interface{} `json:"_links,omitempty"`
 }
 
+type AddEnrollmentPolicyToAppRequest struct {
+	Id string `json:"id"`
+}
+
 // AddAppToEnrollmentPolicy adds an app to the policy
 func (m *APISupplement) AddAppToEnrollmentPolicy(ctx context.Context, policyID string, body AddAppToEnrollmentPolicyRequest) (*AddAppToEnrollmentPolicyResponse, *okta.Response, error) {
-	url := fmt.Sprintf("/api/v1/policies/%s/mappings?forceCreate=true", policyID)
+	url := fmt.Sprintf("/api/v1/apps/%s/policies/%s", body.ResourceId, policyID)
 	re := m.cloneRequestExecutor()
-	req, err := re.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPost, url, body)
+	requestBody := &AddEnrollmentPolicyToAppRequest{Id: body.ResourceId}
+	req, err := re.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPost, url, requestBody)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -151,6 +151,8 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 
 - `wildcard_redirect` - (Optional) *Early Access Property*. Indicates if the client is allowed to use wildcard matching of `redirect_uris`. Valid values: `"DISABLED"`, `"SUBDOMAIN"`. Default value is `"DISABLED"`.
 
+- `authentication_policy` - (Optional) The ID of the associated `app_signon_policy`. If this property is removed from the application the `default` sign-on-policy will be associated with this application.
+
 ## Attributes Reference
 
 - `id` - ID of the application.

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -270,6 +270,8 @@ The following arguments are supported:
 - `users` - (Optional) Users associated with the application.
   - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
+- `authentication_policy` - (Optional) The ID of the associated `app_signon_policy`. If this property is removed from the application the `default` sign-on-policy will be associated with this application.
+
 ## Attributes Reference
 
 - `id` - id of application.

--- a/website/docs/r/app_signon_policy.html.markdown
+++ b/website/docs/r/app_signon_policy.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "okta"
+page_title: "Okta: okta_app_signon_policy"
+sidebar_current: "docs-okta-resource-okta-app-signon-policy"
+description: |-
+  Manages a sign-on policy.
+---
+
+# okta_app_signon_policy
+
+~> **WARNING:** This feature is only available as a part of the Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+
+This resource allows you to create and configure a sign-on policy for the application. (Inside the product this is referenced as an _authentication policy_)
+
+A newly create app sign-on policy will always contain a default `Catch-all Rule`.
+
+## Example Usage
+
+```hcl
+resource "okta_app_oauth" "my_app" {
+  label                     = "My App"
+  type                      = "web"
+  grant_types               = ["authorization_code"]
+  redirect_uris             = ["http://localhost:3000"]
+  post_logout_redirect_uris = ["http://localhost:3000"]
+  response_types            = ["code"]
+  // this is needed to associate the application with the policy
+  authentication_policy     = okta_app_signon_policy.my_app_policy.id
+}
+
+resource "okta_app_signon_policy" "my_app_policy" {
+  name        = "My App Sign-On Policy"
+  description = "Authentication Policy to be used on my app."
+}
+```
+
+\_The same mechanism is in place for `okta_app_oauth` and `okta_app_saml`.
+
+The created policy can be extended using `app_signon_policy_rules`.
+
+```hcl
+resource "okta_app_signon_policy" "my_app_policy" {
+  name        = "My App Sign-On Policy"
+  description = "Authentication Policy to be used on my app."
+}
+
+resource "okta_app_signon_policy_rule" "some_rule" {
+  policy_id                   = resource.okta_app_signon_policy.my_app_policy.id
+  name                        = "Some Rule"
+  factor_mode                 = "1FA"
+  re_authentication_frequency = "PT43800H"
+  constraints = [
+    jsonencode({
+      "knowledge" : {
+        "types" : ["password"]
+      }
+    })
+  ]
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) Name of the policy.
+- `description` - (Required) Description of the policy.
+
+## Attributes Reference
+
+- `id` - ID of the sign-on policy.


### PR DESCRIPTION
resolves #1025 

I added the missing `app_signon_policy` resource to the provider and added it's reference as an additional attribute to the `okta_app_oauth` and `okta_app_saml` resource.

In order to match the naming that is already used in the provider I sticked to app_signon_policy instead of authentication_policy.

I also fixed the API url used to add an app to a profile enrollment policy. Sorry - screwed up putting this in a seperate PR.