### PR TITLE
Felixcolaci fix app enrollment policy

### DIFF
--- a/okta/resource_okta_policy_profile_enrollment_apps.go
+++ b/okta/resource_okta_policy_profile_enrollment_apps.go
@@ -47,14 +47,10 @@ func resourcePolicyProfileEnrollmentAppsCreate(ctx context.Context, d *schema.Re
 	}
 	policyID := d.Get("policy_id").(string)
 	apps := convertInterfaceToStringSetNullable(d.Get("apps"))
-	client := getSupplementFromMetadata(m)
+	client := getOktaClientFromMetadata(m)
 
 	for i := range apps {
-		body := sdk.AddAppToEnrollmentPolicyRequest{
-			ResourceType: "APP",
-			ResourceId:   apps[i],
-		}
-		_, _, err := client.AddAppToEnrollmentPolicy(ctx, policyID, body)
+		_, err := client.Application.UpdateApplicationPolicy(ctx, apps[i], policyID)
 		if err != nil {
 			return diag.Errorf("failed to add an app to the policy, %v", err)
 		}
@@ -84,15 +80,11 @@ func resourcePolicyProfileEnrollmentAppsUpdate(ctx context.Context, d *schema.Re
 	appsToAdd := convertInterfaceArrToStringArr(newSet.Difference(oldSet).List())
 	appsToRemove := convertInterfaceArrToStringArr(oldSet.Difference(newSet).List())
 
-	client := getSupplementFromMetadata(m)
+	client := getOktaClientFromMetadata(m)
 	policyID := d.Get("policy_id").(string)
 
 	for i := range appsToAdd {
-		body := sdk.AddAppToEnrollmentPolicyRequest{
-			ResourceType: "APP",
-			ResourceId:   appsToAdd[i],
-		}
-		_, _, err := client.AddAppToEnrollmentPolicy(ctx, policyID, body)
+		_, err := client.Application.UpdateApplicationPolicy(ctx, appsToAdd[i], policyID)
 		if err != nil {
 			return diag.Errorf("failed to add an app to the policy, %v", err)
 		}
@@ -101,11 +93,7 @@ func resourcePolicyProfileEnrollmentAppsUpdate(ctx context.Context, d *schema.Re
 	defaultPolicyID := d.Get("default_policy_id").(string)
 
 	for i := range appsToRemove {
-		body := sdk.AddAppToEnrollmentPolicyRequest{
-			ResourceType: "APP",
-			ResourceId:   appsToRemove[i],
-		}
-		_, _, err := client.AddAppToEnrollmentPolicy(ctx, defaultPolicyID, body)
+		_, err := client.Application.UpdateApplicationPolicy(ctx, appsToRemove[i], defaultPolicyID)
 		if err != nil {
 			return diag.Errorf("failed to add reassign app to the default policy, %v", err)
 		}
@@ -117,14 +105,10 @@ func resourcePolicyProfileEnrollmentAppsUpdate(ctx context.Context, d *schema.Re
 func resourcePolicyProfileEnrollmentAppsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	defaultPolicyID := d.Get("default_policy_id").(string)
 	apps := convertInterfaceToStringSetNullable(d.Get("apps"))
-	client := getSupplementFromMetadata(m)
+	client := getOktaClientFromMetadata(m)
 
 	for i := range apps {
-		body := sdk.AddAppToEnrollmentPolicyRequest{
-			ResourceType: "APP",
-			ResourceId:   apps[i],
-		}
-		_, _, err := client.AddAppToEnrollmentPolicy(ctx, defaultPolicyID, body)
+		_, err := client.Application.UpdateApplicationPolicy(ctx, apps[i], defaultPolicyID)
 		if err != nil {
 			return diag.Errorf("failed to add reassign app to the default policy, %v", err)
 		}

--- a/sdk/policy_enrollment_apps.go
+++ b/sdk/policy_enrollment_apps.go
@@ -29,7 +29,7 @@ func (m *APISupplement) AddAppToEnrollmentPolicy(ctx context.Context, policyID s
 	url := fmt.Sprintf("/api/v1/apps/%s/policies/%s", body.ResourceId, policyID)
 	re := m.cloneRequestExecutor()
 	requestBody := &AddEnrollmentPolicyToAppRequest{Id: body.ResourceId}
-	req, err := re.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPost, url, requestBody)
+	req, err := re.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPut, url, requestBody)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sdk/policy_enrollment_apps.go
+++ b/sdk/policy_enrollment_apps.go
@@ -10,37 +10,6 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
-type AddAppToEnrollmentPolicyRequest struct {
-	ResourceType string `json:"resourceType"`
-	ResourceId   string `json:"resourceId"`
-}
-
-type AddAppToEnrollmentPolicyResponse struct {
-	Id    string      `json:"id"`
-	Links interface{} `json:"_links,omitempty"`
-}
-
-type AddEnrollmentPolicyToAppRequest struct {
-	Id string `json:"id"`
-}
-
-// AddAppToEnrollmentPolicy adds an app to the policy
-func (m *APISupplement) AddAppToEnrollmentPolicy(ctx context.Context, policyID string, body AddAppToEnrollmentPolicyRequest) (*AddAppToEnrollmentPolicyResponse, *okta.Response, error) {
-	url := fmt.Sprintf("/api/v1/apps/%s/policies/%s", body.ResourceId, policyID)
-	re := m.cloneRequestExecutor()
-	requestBody := &AddEnrollmentPolicyToAppRequest{Id: body.ResourceId}
-	req, err := re.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPut, url, requestBody)
-	if err != nil {
-		return nil, nil, err
-	}
-	var response *AddAppToEnrollmentPolicyResponse
-	resp, err := re.Do(ctx, req, &response)
-	if err != nil {
-		return nil, resp, err
-	}
-	return response, resp, nil
-}
-
 func (m *APISupplement) ListEnrollmentPolicyApps(ctx context.Context, policyID string, qp *query.Params) ([]*okta.Application, *okta.Response, error) {
 	url := fmt.Sprintf("/api/v1/policies/%s/app", policyID)
 	if qp != nil {

--- a/sdk/policy_enrollment_apps.go
+++ b/sdk/policy_enrollment_apps.go
@@ -20,11 +20,16 @@ type AddAppToEnrollmentPolicyResponse struct {
 	Links interface{} `json:"_links,omitempty"`
 }
 
+type AddEnrollmentPolicyToAppRequest struct {
+	Id string `json:"id"`
+}
+
 // AddAppToEnrollmentPolicy adds an app to the policy
 func (m *APISupplement) AddAppToEnrollmentPolicy(ctx context.Context, policyID string, body AddAppToEnrollmentPolicyRequest) (*AddAppToEnrollmentPolicyResponse, *okta.Response, error) {
-	url := fmt.Sprintf("/api/v1/policies/%s/mappings?forceCreate=true", policyID)
+	url := fmt.Sprintf("/api/v1/apps/%s/policies/%s", body.ResourceId, policyID)
 	re := m.cloneRequestExecutor()
-	req, err := re.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPost, url, body)
+	requestBody := &AddEnrollmentPolicyToAppRequest{Id: body.ResourceId}
+	req, err := re.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPost, url, requestBody)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Bringing in @felixcolaci's #1189 
Discovered that the local sdk's implementation of `AddAppToEnrollmentPolicy` exists in okta-sdk-golang and removed the local sdk's implementation. ACC passes on my OIE test org.

```
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaPolicyProfileEnrollmentApps$ ./okta 2>&1
=== RUN   TestAccOktaPolicyProfileEnrollmentApps
--- PASS: TestAccOktaPolicyProfileEnrollmentApps (8.09s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    8.503s
```