### PR TITLE
New resource `okta_app_signon_policy`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -88,14 +88,14 @@ lint:
 		./$(PKG_NAME)
 
 tools:
-	@which $(GOFMT) || go install mvdan.cc/gofumpt@v0.2.1
-	@which $(TFPROVIDERLINT) || go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.27.1
-	@which $(STATICCHECK) || go install honnef.co/go/tools/cmd/staticcheck@2021.1.2
+	@which $(GOFMT) || go install mvdan.cc/gofumpt@v0.3.1
+	@which $(TFPROVIDERLINT) || go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.28.1
+	@which $(STATICCHECK) || go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
 
 tools-update:
-	@go install mvdan.cc/gofumpt@v0.2.1
-	@go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.27.1
-	@go install honnef.co/go/tools/cmd/staticcheck@2021.1.2
+	@go install mvdan.cc/gofumpt@v0.3.1
+	@go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.28.1
+	@go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))

--- a/examples/okta_app_signon_policy/basic.tf
+++ b/examples/okta_app_signon_policy/basic.tf
@@ -1,0 +1,4 @@
+resource "okta_app_signon_policy" "test" {
+  name        = "Test_App_replace_with_uuid"
+  description = "The app signon policy used by our test app."
+}

--- a/examples/okta_app_signon_policy/basic_renamed.tf
+++ b/examples/okta_app_signon_policy/basic_renamed.tf
@@ -1,0 +1,4 @@
+resource "okta_app_signon_policy" "test" {
+  name        = "Test_App_Renamed_replace_with_uuid"
+  description = "The app signon policy used by our test app."
+}

--- a/examples/okta_app_signon_policy/basic_updated.tf
+++ b/examples/okta_app_signon_policy/basic_updated.tf
@@ -1,0 +1,4 @@
+resource "okta_app_signon_policy" "test" {
+  name        = "Test_App_replace_with_uuid"
+  description = "The updated app signon policy used by our test app."
+}

--- a/okta/app_authentication_policy.go
+++ b/okta/app_authentication_policy.go
@@ -20,24 +20,24 @@ func setAuthenticationPolicy(ctx context.Context, d *schema.ResourceData, m inte
 	return err
 }
 
-func assignDefaultAuthenticationPolicy(ctx context.Context,  m interface{}, appId string) error {
+func assignDefaultAuthenticationPolicy(ctx context.Context, m interface{}, appId string) error {
 	client := getOktaClientFromMetadata(m)
 	qp := query.NewQueryParams()
 	qp.Type = "ACCESS_POLICY"
 	policies, _, err := client.Policy.ListPolicies(ctx, qp)
 	if err != nil {
-		return errors.New(fmt.Sprintf("failed delete authentication policy: %v", err))
+		return fmt.Errorf("failed delete authentication policy: %v", err)
 	}
 
 	// find the default policy
 	var defaultPolicy *okta.Policy
 	for _, p := range policies {
-		
+
 		v := p.(*okta.Policy)
-		if v.Name == "Default Policy" && *v.System == true{
+		if v.Name == "Default Policy" && *v.System {
 			defaultPolicy = v
 		}
-		
+
 	}
 	if defaultPolicy == nil {
 		return errors.New("no default policy found")

--- a/okta/app_authentication_policy.go
+++ b/okta/app_authentication_policy.go
@@ -1,0 +1,47 @@
+package okta
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func setAuthenticationPolicy(ctx context.Context, d *schema.ResourceData, m interface{}, appId string) error {
+	raw, ok := d.GetOk("authentication_policy")
+	if !ok {
+		return assignDefaultAuthenticationPolicy(ctx, m, appId)
+	}
+	policyId := raw.(string)
+	_, err := getOktaClientFromMetadata(m).Application.UpdateApplicationPolicy(ctx, appId, policyId)
+	return err
+}
+
+func assignDefaultAuthenticationPolicy(ctx context.Context,  m interface{}, appId string) error {
+	client := getOktaClientFromMetadata(m)
+	qp := query.NewQueryParams()
+	qp.Type = "ACCESS_POLICY"
+	policies, _, err := client.Policy.ListPolicies(ctx, qp)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed delete authentication policy: %v", err))
+	}
+
+	// find the default policy
+	var defaultPolicy *okta.Policy
+	for _, p := range policies {
+		
+		v := p.(*okta.Policy)
+		if v.Name == "Default Policy" && *v.System == true{
+			defaultPolicy = v
+		}
+		
+	}
+	if defaultPolicy == nil {
+		return errors.New("no default policy found")
+	}
+	_, err = client.Application.UpdateApplicationPolicy(ctx, appId, defaultPolicy.Id)
+	return err
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -257,6 +257,7 @@ func Provider() *schema.Provider {
 			appSamlAppSettings:            resourceAppSamlAppSettings(),
 			appSecurePasswordStore:        resourceAppSecurePasswordStore(),
 			appSharedCredentials:          resourceAppSharedCredentials(),
+			appSignOnPolicy:               resourceAppSignOnPolicy(),
 			appSignOnPolicyRule:           resourceAppSignOnPolicyRule(),
 			appSwa:                        resourceAppSwa(),
 			appThreeField:                 resourceAppThreeField(),

--- a/okta/provider_sweeper_test.go
+++ b/okta/provider_sweeper_test.go
@@ -71,6 +71,10 @@ func buildResourceName(testID int) string {
 	return testResourcePrefix + "_" + strconv.Itoa(testID)
 }
 
+func buildResourceNameWithPrefix(prefix string, testID int) string {
+	return prefix + "_" + strconv.Itoa(testID)
+}
+
 // sharedClient returns a common Okta Client for sweepers, which currently requires the original SDK and the official beta SDK
 func sharedClient() (*okta.Client, *sdk.APISupplement, error) {
 	err := accPreCheck()

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -361,6 +361,11 @@ func resourceAppOAuth() *schema.Resource {
 					return new == ""
 				},
 			},
+			"authentication_policy": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: "Id of this apps authentication policy",
+			},
 		}),
 	}
 }
@@ -431,6 +436,10 @@ func resourceAppOAuthCreate(ctx context.Context, d *schema.ResourceData, m inter
 	err = setAppOauthGroupsClaim(ctx, d, m)
 	if err != nil {
 		return diag.Errorf("failed to update groups claim for an OAuth application: %v", err)
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy for an OAuth application: %v", err)
 	}
 	return resourceAppOAuthRead(ctx, d, m)
 }
@@ -659,6 +668,10 @@ func resourceAppOAuthUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	err = updateAppOauthGroupsClaim(ctx, d, m)
 	if err != nil {
 		return diag.Errorf("failed to update groups claim for an OAuth application: %v", err)
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy an OAuth application: %v", err)
 	}
 	return resourceAppOAuthRead(ctx, d, m)
 }

--- a/okta/resource_okta_app_saml.go
+++ b/okta/resource_okta_app_saml.go
@@ -336,6 +336,11 @@ func resourceAppSaml() *schema.Resource {
 				Description:      "SAML version for the app's sign-on mode",
 				ValidateDiagFunc: elemInSlice([]string{saml20, saml11}),
 			},
+			"authentication_policy": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: "Id of this apps authentication policy",
+			},
 		}),
 	}
 }
@@ -376,6 +381,10 @@ func resourceAppSamlCreate(ctx context.Context, d *schema.ResourceData, m interf
 	err = handleAppLogo(ctx, d, m, app.Id, app.Links)
 	if err != nil {
 		return diag.Errorf("failed to upload logo for SAML application: %v", err)
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy for an SAML application: %v", err)
 	}
 	return resourceAppSamlRead(ctx, d, m)
 }
@@ -491,6 +500,10 @@ func resourceAppSamlUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			_ = d.Set("logo", o)
 			return diag.Errorf("failed to upload logo for SAML application: %v", err)
 		}
+	}
+	err = setAuthenticationPolicy(ctx, d, m, app.Id)
+	if err != nil {
+		return diag.Errorf("failed to set authentication policy for an SAML application: %v", err)
 	}
 	return resourceAppSamlRead(ctx, d, m)
 }

--- a/okta/resource_okta_app_signon_policy.go
+++ b/okta/resource_okta_app_signon_policy.go
@@ -14,18 +14,18 @@ import (
 func resourceAppSignOnPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAppSignOnPolicyCreate,
-		ReadContext: resourceAppSignOnPolicyRead,
+		ReadContext:   resourceAppSignOnPolicyRead,
 		UpdateContext: resourceAppSignOnPolicyUpdate,
 		DeleteContext: resourceAppSignOnPolicyDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type: schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
 				Description: "Policy Name",
 			},
 			"description": {
-				Type: schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
 				Description: "Policy Description",
 			},
 		},
@@ -34,19 +34,17 @@ func resourceAppSignOnPolicy() *schema.Resource {
 
 func buildAppSignOnPoilicy(d *schema.ResourceData) *okta.AccessPolicy {
 	return &okta.AccessPolicy{
-		Name: d.Get("name").(string),
+		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		Type: "ACCESS_POLICY",
+		Type:        "ACCESS_POLICY",
 	}
 }
 
-func  resourceAppSignOnPolicyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppSignOnPolicyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	logger(m).Info("creating authentication policy", "name", d.Get("name").(string))
 	policyToCreate := buildAppSignOnPoilicy(d)
-	
-	
-	oktaClient := getOktaClientFromMetadata(m)
 
+	oktaClient := getOktaClientFromMetadata(m)
 
 	responsePolicy, _, err := oktaClient.Policy.CreatePolicy(ctx, policyToCreate, nil)
 	if err != nil {
@@ -57,7 +55,7 @@ func  resourceAppSignOnPolicyCreate(ctx context.Context, d *schema.ResourceData,
 	return resourceAppSignOnPolicyRead(ctx, d, m)
 }
 
-func  resourceAppSignOnPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppSignOnPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	logger(m).Info("reading authentication policy", "id", d.Id(), "name", d.Get("name").(string))
 	policy := &okta.Policy{}
 	authenticationPolicy, resp, err := getOktaClientFromMetadata(m).Policy.GetPolicy(ctx, d.Id(), policy, nil)
@@ -75,7 +73,7 @@ func  resourceAppSignOnPolicyRead(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func  resourceAppSignOnPolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppSignOnPolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	logger(m).Info("updating authentication policy", "id", d.Id(), "name", d.Get("name").(string))
 	policyToUpdate := buildAppSignOnPoilicy(d)
 	_, _, err := getOktaClientFromMetadata(m).Policy.UpdatePolicy(ctx, d.Id(), policyToUpdate)
@@ -85,13 +83,13 @@ func  resourceAppSignOnPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 	return resourceAppSignOnPolicyRead(ctx, d, m)
 }
 
-func  resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	/**
 		1. find the default app policy
 		2. assign the default policy to all apps using the current policy (the one to delete)
 		3. delete the policy
 	**/
-	
+
 	client := getOktaClientFromMetadata(m)
 	qp := query.NewQueryParams()
 	qp.Type = "ACCESS_POLICY"
@@ -103,12 +101,12 @@ func  resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData,
 	// find the default policy
 	var defaultPolicy *okta.Policy
 	for _, p := range policies {
-		
+
 		v := p.(*okta.Policy)
-		if v.Name == "Default Policy" && *v.System == true{
+		if v.Name == "Default Policy" && *v.System {
 			defaultPolicy = v
 		}
-		
+
 	}
 	if defaultPolicy == nil {
 		return diag.Errorf("failed delete authentication policy: %v", errors.New("no default policy found"))
@@ -118,10 +116,10 @@ func  resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData,
 	if listErr != nil {
 		// delete the policy right away
 
-	_, err = client.Policy.DeletePolicy(ctx, d.Id())
-	if err != nil {
-		return diag.Errorf("failed delete authentication policy: %v", err)
-	}
+		_, err = client.Policy.DeletePolicy(ctx, d.Id())
+		if err != nil {
+			return diag.Errorf("failed delete authentication policy: %v", err)
+		}
 		return nil
 	} else {
 		// first unassign the policy and delete it then
@@ -143,7 +141,7 @@ func  resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData,
 						return diag.Errorf("failed to assign default policy '%v' to app %v: %v", defaultPolicy.Id, app.Id, updateErr)
 					}
 				}
-				
+
 			}
 		}
 
@@ -153,9 +151,8 @@ func  resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData,
 		}
 		return nil
 	}
-	
-}
 
+}
 
 func listApplications(ctx context.Context, client *okta.Client) ([]okta.App, error) {
 	var resClients []okta.App

--- a/okta/resource_okta_app_signon_policy.go
+++ b/okta/resource_okta_app_signon_policy.go
@@ -1,0 +1,180 @@
+package okta
+
+import (
+	"context"
+	"errors"
+	"path"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func resourceAppSignOnPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppSignOnPolicyCreate,
+		ReadContext: resourceAppSignOnPolicyRead,
+		UpdateContext: resourceAppSignOnPolicyUpdate,
+		DeleteContext: resourceAppSignOnPolicyDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type: schema.TypeString,
+				Required: true,
+				Description: "Policy Name",
+			},
+			"description": {
+				Type: schema.TypeString,
+				Required: true,
+				Description: "Policy Description",
+			},
+		},
+	}
+}
+
+func buildAppSignOnPoilicy(d *schema.ResourceData) *okta.AccessPolicy {
+	return &okta.AccessPolicy{
+		Name: d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Type: "ACCESS_POLICY",
+	}
+}
+
+func  resourceAppSignOnPolicyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("creating authentication policy", "name", d.Get("name").(string))
+	policyToCreate := buildAppSignOnPoilicy(d)
+	
+	
+	oktaClient := getOktaClientFromMetadata(m)
+
+
+	responsePolicy, _, err := oktaClient.Policy.CreatePolicy(ctx, policyToCreate, nil)
+	if err != nil {
+		return diag.Errorf("failed to create authentication policy: %v", err)
+	}
+	id := responsePolicy.(*okta.AccessPolicy).Id
+	d.SetId(id)
+	return resourceAppSignOnPolicyRead(ctx, d, m)
+}
+
+func  resourceAppSignOnPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("reading authentication policy", "id", d.Id(), "name", d.Get("name").(string))
+	policy := &okta.Policy{}
+	authenticationPolicy, resp, err := getOktaClientFromMetadata(m).Policy.GetPolicy(ctx, d.Id(), policy, nil)
+	if err := suppressErrorOn404(resp, err); err != nil {
+		return diag.Errorf("failed to get authentication policy: %v", err)
+	}
+	if authenticationPolicy == nil {
+		d.SetId("")
+		return nil
+	}
+	policyFromServer := authenticationPolicy.(*okta.Policy)
+	d.SetId(policyFromServer.Id)
+	d.Set("name", policyFromServer.Name)
+	d.Set("description", policyFromServer.Description)
+	return nil
+}
+
+func  resourceAppSignOnPolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	logger(m).Info("updating authentication policy", "id", d.Id(), "name", d.Get("name").(string))
+	policyToUpdate := buildAppSignOnPoilicy(d)
+	_, _, err := getOktaClientFromMetadata(m).Policy.UpdatePolicy(ctx, d.Id(), policyToUpdate)
+	if err != nil {
+		return diag.Errorf("failed to update authentication policy: %v", err)
+	}
+	return resourceAppSignOnPolicyRead(ctx, d, m)
+}
+
+func  resourceAppSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	/**
+		1. find the default app policy
+		2. assign the default policy to all apps using the current policy (the one to delete)
+		3. delete the policy
+	**/
+	
+	client := getOktaClientFromMetadata(m)
+	qp := query.NewQueryParams()
+	qp.Type = "ACCESS_POLICY"
+	policies, _, err := client.Policy.ListPolicies(ctx, qp)
+	if err != nil {
+		return diag.Errorf("failed delete authentication policy: %v", err)
+	}
+
+	// find the default policy
+	var defaultPolicy *okta.Policy
+	for _, p := range policies {
+		
+		v := p.(*okta.Policy)
+		if v.Name == "Default Policy" && *v.System == true{
+			defaultPolicy = v
+		}
+		
+	}
+	if defaultPolicy == nil {
+		return diag.Errorf("failed delete authentication policy: %v", errors.New("no default policy found"))
+	}
+
+	clients, listErr := listApplications(ctx, client)
+	if listErr != nil {
+		// delete the policy right away
+
+	_, err = client.Policy.DeletePolicy(ctx, d.Id())
+	if err != nil {
+		return diag.Errorf("failed delete authentication policy: %v", err)
+	}
+		return nil
+	} else {
+		// first unassign the policy and delete it then
+		// assign the default app policy to all clients using the current policy
+		for _, c := range clients {
+			app := c.(*okta.Application)
+			accessPolicy := linksValue(app.Links, "accessPolicy", "href")
+			if accessPolicy == "" {
+				return diag.Errorf("app does not support sign-on policy or this feature is not available")
+			}
+			if path.Base(accessPolicy) == d.Id() {
+				// check if client still exists
+				a := okta.NewApplication()
+				_, _, getErr := client.Application.GetApplication(ctx, app.Id, a, nil)
+				if getErr == nil {
+					// only perform the update if the app exists
+					_, updateErr := client.Application.UpdateApplicationPolicy(ctx, app.Id, defaultPolicy.Id)
+					if updateErr != nil {
+						return diag.Errorf("failed to assign default policy '%v' to app %v: %v", defaultPolicy.Id, app.Id, updateErr)
+					}
+				}
+				
+			}
+		}
+
+		_, err = client.Policy.DeletePolicy(ctx, d.Id())
+		if err != nil {
+			return diag.Errorf("failed delete authentication policy: %v", err)
+		}
+		return nil
+	}
+	
+}
+
+
+func listApplications(ctx context.Context, client *okta.Client) ([]okta.App, error) {
+	var resClients []okta.App
+
+	clients, resp, err := client.Application.ListApplications(ctx, &query.Params{Limit: defaultPaginationLimit})
+	if err != nil {
+		return nil, err
+	}
+	for {
+		resClients = append(resClients, clients...)
+		if resp.HasNextPage() {
+			resp, err = resp.Next(ctx, &clients)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		} else {
+			break
+		}
+	}
+	return resClients, nil
+}

--- a/okta/resource_okta_app_signon_policy_test.go
+++ b/okta/resource_okta_app_signon_policy_test.go
@@ -1,0 +1,52 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+
+func TestAccOktaAppSignOnPolicy_crud(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appSignOnPolicy)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
+	renamedConfig := mgr.GetFixtures("basic_renamed.tf", ri, t)
+	resourceName := fmt.Sprintf("%v.test", appSignOnPolicy)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {testAccPreCheck(t)},
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy: createPolicyCheckDestroy(appSignOnPolicy),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "description", "The updated app signon policy used by our test app."),
+				),
+			},
+			{
+				Config: renamedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("Test_App_Renamed_%d", ri)),
+					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
+				),
+			},
+		},
+	})
+
+}

--- a/okta/resource_okta_app_signon_policy_test.go
+++ b/okta/resource_okta_app_signon_policy_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-
 func TestAccOktaAppSignOnPolicy_crud(t *testing.T) {
 	ri := acctest.RandInt()
 	mgr := newFixtureManager(appSignOnPolicy)
@@ -18,15 +17,15 @@ func TestAccOktaAppSignOnPolicy_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%v.test", appSignOnPolicy)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {testAccPreCheck(t)},
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProvidersFactories,
-		CheckDestroy: createPolicyCheckDestroy(appSignOnPolicy),
+		CheckDestroy:      createPolicyCheckDestroy(appSignOnPolicy),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					ensurePolicyExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("Test_App", ri)),
 					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
 				),
 			},
@@ -34,7 +33,7 @@ func TestAccOktaAppSignOnPolicy_crud(t *testing.T) {
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
 					ensurePolicyExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("Test_App", ri)),
 					resource.TestCheckResourceAttr(resourceName, "description", "The updated app signon policy used by our test app."),
 				),
 			},
@@ -42,7 +41,7 @@ func TestAccOktaAppSignOnPolicy_crud(t *testing.T) {
 				Config: renamedConfig,
 				Check: resource.ComposeTestCheckFunc(
 					ensurePolicyExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("Test_App_Renamed_%d", ri)),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("Test_App_Renamed", ri)),
 					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
 				),
 			},

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -151,6 +151,8 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 
 - `wildcard_redirect` - (Optional) *Early Access Property*. Indicates if the client is allowed to use wildcard matching of `redirect_uris`. Valid values: `"DISABLED"`, `"SUBDOMAIN"`. Default value is `"DISABLED"`.
 
+- `authentication_policy` - (Optional) The ID of the associated `app_signon_policy`. If this property is removed from the application the `default` sign-on-policy will be associated with this application.
+
 ## Attributes Reference
 
 - `id` - ID of the application.

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -270,6 +270,8 @@ The following arguments are supported:
 - `users` - (Optional) Users associated with the application.
   - `DEPRECATED`: Please replace usage with the `okta_app_user` resource.
 
+- `authentication_policy` - (Optional) The ID of the associated `app_signon_policy`. If this property is removed from the application the `default` sign-on-policy will be associated with this application.
+
 ## Attributes Reference
 
 - `id` - id of application.

--- a/website/docs/r/app_signon_policy.html.markdown
+++ b/website/docs/r/app_signon_policy.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "okta"
+page_title: "Okta: okta_app_signon_policy"
+sidebar_current: "docs-okta-resource-okta-app-signon-policy"
+description: |-
+  Manages a sign-on policy.
+---
+
+# okta_app_signon_policy
+
+~> **WARNING:** This feature is only available as a part of the Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+
+This resource allows you to create and configure a sign-on policy for the application. (Inside the product this is referenced as an _authentication policy_)
+
+A newly create app sign-on policy will always contain a default `Catch-all Rule`.
+
+## Example Usage
+
+```hcl
+resource "okta_app_oauth" "my_app" {
+  label                     = "My App"
+  type                      = "web"
+  grant_types               = ["authorization_code"]
+  redirect_uris             = ["http://localhost:3000"]
+  post_logout_redirect_uris = ["http://localhost:3000"]
+  response_types            = ["code"]
+  // this is needed to associate the application with the policy
+  authentication_policy     = okta_app_signon_policy.my_app_policy.id
+}
+
+resource "okta_app_signon_policy" "my_app_policy" {
+  name        = "My App Sign-On Policy"
+  description = "Authentication Policy to be used on my app."
+}
+```
+
+\_The same mechanism is in place for `okta_app_oauth` and `okta_app_saml`.
+
+The created policy can be extended using `app_signon_policy_rules`.
+
+```hcl
+resource "okta_app_signon_policy" "my_app_policy" {
+  name        = "My App Sign-On Policy"
+  description = "Authentication Policy to be used on my app."
+}
+
+resource "okta_app_signon_policy_rule" "some_rule" {
+  policy_id                   = resource.okta_app_signon_policy.my_app_policy.id
+  name                        = "Some Rule"
+  factor_mode                 = "1FA"
+  re_authentication_frequency = "PT43800H"
+  constraints = [
+    jsonencode({
+      "knowledge" : {
+        "types" : ["password"]
+      }
+    })
+  ]
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) Name of the policy.
+- `description` - (Required) Description of the policy.
+
+## Attributes Reference
+
+- `id` - ID of the sign-on policy.


### PR DESCRIPTION
Bringing in #1188

--

@felixcolaci:
resolves #1025

I added the missing app_signon_policy resource to the provider and added it's reference as an additional attribute to the okta_app_oauth and okta_app_saml resource.

In order to match the naming that is already used in the provider I sticked to app_signon_policy instead of authentication_policy.

--

@monde: Additional items for this PR:

ACC tests , I'm OK with the skips, fails were from orgs with incompatible config for the resource feature.
```
for t in `grep -h "^func Test" \
okta/resource_okta_app_oauth_test.go \
okta/resource_okta_app_saml_test.go \
okta/resource_okta_app_signon_policy_test.go \
| awk '{ print $2 }' | sed -e 's/\(.*\)(t/\1/g'`; do
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^${t}$ ./okta 2>&1
done
=== RUN   TestAccResourceOktaAppOauth_basic
--- PASS: TestAccResourceOktaAppOauth_basic (10.52s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    11.029s
=== RUN   TestAccResourceOktaAppOauth_refreshToken
    resource_okta_app_oauth_test.go:91: This is an 'Early Access Feature' and needs to be enabled by Okta, skipping this test as it fails when this feature is not available
--- SKIP: TestAccResourceOktaAppOauth_refreshToken (0.00s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    0.313s
=== RUN   TestAccResourceOktaAppOauth_serviceNative
--- PASS: TestAccResourceOktaAppOauth_serviceNative (8.55s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    8.873s
=== RUN   TestAccResourceOktaAppOauth_federationBroker
    resource_okta_app_oauth_test.go:170: This is an 'Early Access Feature' and needs to be enabled by Okta, skipping this test as it fails when this feature is not available
--- SKIP: TestAccResourceOktaAppOauth_federationBroker (0.00s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    0.316s
=== RUN   TestAccResourceOktaAppOauth_customProfileAttributes
--- PASS: TestAccResourceOktaAppOauth_customProfileAttributes (11.36s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    11.669s
=== RUN   TestAccResourceOktaAppOauth_customClientID
--- PASS: TestAccResourceOktaAppOauth_customClientID (8.09s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    8.411s
=== RUN   TestAccResourceOktaAppOauth_customClientIDError
--- PASS: TestAccResourceOktaAppOauth_customClientIDError (0.18s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    0.545s
=== RUN   TestAccResourceOktaAppOauth_serviceWithJWKS
--- PASS: TestAccResourceOktaAppOauth_serviceWithJWKS (4.91s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    5.227s
=== RUN   TestAccResourceOktaAppOauth_redirect_uris
--- PASS: TestAccResourceOktaAppOauth_redirect_uris (4.33s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    4.655s
=== RUN   TestAccResourceOktaAppOauth_groups_claim
--- PASS: TestAccResourceOktaAppOauth_groups_claim (5.12s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    5.454s
=== RUN   TestAccAppSaml_conditionalRequire
--- PASS: TestAccAppSaml_conditionalRequire (1.04s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    1.355s
=== RUN   TestAccAppSaml_invalidURL
--- PASS: TestAccAppSaml_invalidURL (0.18s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    0.492s
=== RUN   TestAccAppSaml_crud
    resource_okta_app_saml_test.go:62: Step 1/6 error: Error running apply: exit status 1

        Error: failed to create SAML application: the API returned an error: You do not have permission to access the feature you are requesting

          with okta_app_saml.test,
          on terraform_plugin_test.tf line 1, in resource "okta_app_saml" "test":
           1: resource "okta_app_saml" "test" {

--- FAIL: TestAccAppSaml_crud (1.09s)
FAIL
FAIL    github.com/okta/terraform-provider-okta/okta    1.408s
FAIL


### TestAccAppSaml_crud will pass with correct org config
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccAppSaml_crud$ ./okta 2>&1
=== RUN   TestAccAppSaml_crud
--- PASS: TestAccAppSaml_crud (25.05s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)

=== RUN   TestAccAppSaml_preconfigured
    resource_okta_app_saml_test.go:160: Step 1/1 error: Error running apply: exit status 1

        Error: failed to set authentication policy for an SAML application: the API returned an error: Api validation failed: App Instance. Causes: errorSummary: Policy re-assignment for "Microsoft Office 365" application is not allowed

          with okta_app_saml.test,
          on terraform_plugin_test.tf line 1, in resource "okta_app_saml" "test":
           1: resource "okta_app_saml" "test" {

--- FAIL: TestAccAppSaml_preconfigured (6.71s)
FAIL
FAIL    github.com/okta/terraform-provider-okta/okta    7.063s
FAIL

### TestAccAppSaml_preconfigured will pass with correct org config
=== RUN   TestAccAppSaml_preconfigured
--- PASS: TestAccAppSaml_preconfigured (11.50s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    12.077s


=== RUN   TestAccAppSaml_userGroups
--- PASS: TestAccAppSaml_userGroups (14.76s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    15.077s
=== RUN   TestAccAppSaml_inlineHook
    resource_okta_app_saml_test.go:278: Step 1/1 error: Error running apply: exit status 1

        Error: failed to create SAML application: the API returned an error: You do not have permission to access the feature you are requesting

          with okta_app_saml.test,
          on terraform_plugin_test.tf line 20, in resource "okta_app_saml" "test":
          20: resource "okta_app_saml" "test" {

--- FAIL: TestAccAppSaml_inlineHook (1.98s)
FAIL
FAIL    github.com/okta/terraform-provider-okta/okta    2.314s
FAIL

### TestAccAppSaml_inlineHook will pass with correct org config
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccAppSaml_inlineHook$ ./okta 2>&1
=== RUN   TestAccAppSaml_inlineHook
--- PASS: TestAccAppSaml_inlineHook (8.94s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    9.641s

=== RUN   TestAccAppSaml_federationBroker
    resource_okta_app_saml_test.go:302: This is an 'Early Access Feature' and needs to be enabled by Okta, skipping this test as it fails when this feature is not available
--- SKIP: TestAccAppSaml_federationBroker (0.00s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    0.371s
=== RUN   TestAccOktaAppSignOnPolicy_crud
--- PASS: TestAccOktaAppSignOnPolicy_crud (8.33s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)