### PR TITLE
Resource `okta_auth_server_default` property `issuer_mode` can be set to

### DIFF
--- a/okta/resource_okta_default_auth_server.go
+++ b/okta/resource_okta_default_auth_server.go
@@ -65,7 +65,7 @@ func resourceAuthServerDefault() *schema.Resource {
 				Optional:         true,
 				Description:      "*Early Access Property*. Indicates which value is specified in the issuer of the tokens that a Custom Authorization Server returns: the original Okta org domain URL or a custom domain URL",
 				Default:          "ORG_URL",
-				ValidateDiagFunc: elemInSlice([]string{"CUSTOM_URL", "ORG_URL"}),
+				ValidateDiagFunc: elemInSlice([]string{"CUSTOM_URL", "ORG_URL", "DYNAMIC"}),
 			},
 		},
 	}

--- a/website/docs/r/auth_server_default.html.markdown
+++ b/website/docs/r/auth_server_default.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 - `description` - (Optional) The description of the authorization server.
 
-- `issuer_mode` - (Optional) Allows you to use a custom issuer URL. It can be set to `"CUSTOM_URL"` or `"ORG_URL"`
+- `issuer_mode` - (Optional) Allows you to use a custom issuer URL. It can be set to `"CUSTOM_URL"`, `"ORG_URL"`, or `"DYNAMIC"`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Resource `okta_auth_server_default` property `issuer_mode` can be set to `"CUSTOM_URL"`, `"ORG_URL"`, or `"DYNAMIC"`.
https://developer.okta.com/docs/reference/api/authorization-servers/#property-details

```
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaAuthServerDefault_crud$ ./okta 2>&1
=== RUN   TestAccOktaAuthServerDefault_crud
--- PASS: TestAccOktaAuthServerDefault_crud (16.85s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    17.421s
```