### PR TITLE
feat: add `keys` attribute to `okta_app_saml` resource

### DIFF
--- a/okta/app.go
+++ b/okta/app.go
@@ -739,15 +739,16 @@ func setAppKeys(d *schema.ResourceData, keys []*okta.JsonWebKey) error {
 
 	for i, key := range keys {
 		arr[i] = map[string]interface{}{
-			"kty":        key.Kty,
-			"kid":        key.Kid,
-			"e":          key.E,
-			"n":          key.N,
-			"created":    key.Created.String(),
-			"expires_at": key.ExpiresAt.String(),
-			"use":        key.Use,
-			"x5c":        key.X5c,
-			"x5t_s256":   key.X5tS256,
+			"kid":          key.Kid,
+			"kty":          key.Kty,
+			"use":          key.Use,
+			"created":      key.Created.String(),
+			"last_updated": key.LastUpdated.String(),
+			"expires_at":   key.ExpiresAt.String(),
+			"e":            key.E,
+			"n":            key.N,
+			"x5c":          key.X5c,
+			"x5t_s256":     key.X5tS256,
 		}
 	}
 

--- a/okta/resource_okta_app_saml.go
+++ b/okta/resource_okta_app_saml.go
@@ -85,19 +85,44 @@ func resourceAppSaml() *schema.Resource {
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"created": {
+						"kid": {
 							Type:        schema.TypeString,
-							Description: "Created Date",
+							Description: "Key ID",
 							Computed:    true,
 						},
-						"expires_at": {
+						"kty": {
 							Type:        schema.TypeString,
-							Description: "Expiration Date",
+							Description: "Key type",
 							Computed:    true,
 						},
 						"use": {
 							Type:        schema.TypeString,
 							Description: "Acceptable usage of the certificate",
+							Computed:    true,
+						},
+						"created": {
+							Type:        schema.TypeString,
+							Description: "Created date",
+							Computed:    true,
+						},
+						"last_updated": {
+							Type:        schema.TypeString,
+							Description: "Last updated date",
+							Computed:    true,
+						},
+						"expires_at": {
+							Type:        schema.TypeString,
+							Description: "Expiration date",
+							Computed:    true,
+						},
+						"e": {
+							Type:        schema.TypeString,
+							Description: "RSA exponent",
+							Computed:    true,
+						},
+						"n": {
+							Type:        schema.TypeString,
+							Description: "RSA modulus",
 							Computed:    true,
 						},
 						"x5c": {
@@ -109,26 +134,6 @@ func resourceAppSaml() *schema.Resource {
 						"x5t_s256": {
 							Type:        schema.TypeString,
 							Description: "X.509 certificate SHA-256 thumbprint",
-							Computed:    true,
-						},
-						"kid": {
-							Type:        schema.TypeString,
-							Description: "Key ID",
-							Computed:    true,
-						},
-						"kty": {
-							Type:        schema.TypeString,
-							Description: "Key type",
-							Computed:    true,
-						},
-						"e": {
-							Type:        schema.TypeString,
-							Description: "RSA Exponent",
-							Computed:    true,
-						},
-						"n": {
-							Type:        schema.TypeString,
-							Description: "RSA Modulus",
 							Computed:    true,
 						},
 					},

--- a/okta/resource_okta_app_saml_test.go
+++ b/okta/resource_okta_app_saml_test.go
@@ -261,6 +261,7 @@ func TestAccAppSaml_userGroups(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "label", buildResourceName(ri)),
 					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
 					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "keys"),
 					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "users.#", "1"),
 				),

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -282,7 +282,27 @@ The following arguments are supported:
 
 - `key_name` - Certificate name. This modulates the rotation of keys. New name == new key.
 
-- `keys` - All valid key credentials for the application.
+- `keys` - An array of all key credentials for the application. Format of each entry is as follows:
+
+  - `kid` - Key ID.
+
+  - `kty` - Identifies the cryptographic algorithm family used with the key.
+
+  - `use` - Intended use of the public key.
+
+  - `created` - Date created.
+
+  - `last_updated` - Date the key was last updated.
+
+  - `expires_at` - Date the key expires.
+
+  - `e` - RSA exponent.
+
+  - `n` - RSA modulus.
+
+  - `x5c` - X.509 certificate chain.
+
+  - `x5t_s256` - X.509 certificate SHA-256 thumbprint.
 
 - `certificate` - The raw signing certificate.
 

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -282,6 +282,8 @@ The following arguments are supported:
 
 - `key_name` - Certificate name. This modulates the rotation of keys. New name == new key.
 
+- `keys` - All valid key credentials for the application.
+
 - `certificate` - The raw signing certificate.
 
 - `metadata` - The raw SAML metadata in XML.


### PR DESCRIPTION
This pull request adds a `keys` attribute to the `okta_app_saml` resource. We've put the methods used to pull the data into `app.go`, so it could potentially be added to other `okta_app_*` resources, and also their matching data sources.

Our use case is in setting up [`org2org` with OAuth](https://developer.okta.com/docs/guides/secure-oauth-between-orgs/main/), where we'd like to create an `okta_app_saml` resource in one organization, and an `okta_app_oauth` service app in the other.

Without the `keys` attribute, we've resorted to manually calling the [`/credentials/keys`](https://developer.okta.com/docs/reference/api/apps/#list-key-credentials-for-application) endpoint and adding them as JWK blocks in `okta_app_oauth`. We'd prefer to have this process be as automated as possible, so adding the `keys` to the application resource made sense to us.
