### PR TITLE
[WIP] Adds ability to flip individual authenticator methods on/off for Authenticator type phone_number

### DIFF
--- a/okta/authenticator_methods.go
+++ b/okta/authenticator_methods.go
@@ -1,0 +1,68 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func createPhoneMethods(ctx context.Context, d *schema.ResourceData, m interface{}) error {
+	_, ok := d.GetOk("phone_methods")
+	if ok {
+		return configurePhoneMethods(ctx, d, m)
+	}
+	return nil
+}
+
+func updatePhoneMethods(ctx context.Context, d *schema.ResourceData, m interface{}) error {
+	old, new := d.GetChange("phone_methods")
+	if !old.(*schema.Set).Equal(new) {
+		// if len is 0 assume not using provider to control methods / enable both the default (UI does not allow both disabled)
+		if new.(*schema.Set).Len() == 0 {
+			for _, v := range []string{"sms", "voice"} {
+				if err := getSupplementFromMetadata(m).ActivateAuthenticatorMethod(ctx, d.Id(), v); err != nil {
+					return err
+				}
+			}
+		} else {
+			return configurePhoneMethods(ctx, d, m)
+		}
+	}
+	return nil
+}
+
+func configurePhoneMethods(ctx context.Context, d *schema.ResourceData, m interface{}) error { // diag.Diagnostics {
+	if methods := d.Get("phone_methods"); methods != nil {
+		for _, v := range []string{"sms", "voice"} {
+			if methods.(*schema.Set).Contains(v) {
+				if err := getSupplementFromMetadata(m).ActivateAuthenticatorMethod(ctx, d.Id(), v); err != nil {
+					return err
+				}
+			} else {
+				if err := getSupplementFromMetadata(m).DeactivateAuthenticatorMethod(ctx, d.Id(), v); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func readPhoneMethods(ctx context.Context, d *schema.ResourceData, m interface{}) error {
+	methods := d.Get("phone_methods")
+	if methods != nil {
+		for _, v := range []string{"sms", "voice"} {
+			status, err := getSupplementFromMetadata(m).GetAuthenticatorMethodStatus(ctx, d.Id(), v)
+			if err != nil {
+				return err
+			}
+			if status == "ACTIVE" {
+				methods.(*schema.Set).Add(v)
+			} else {
+				methods.(*schema.Set).Remove(v)
+			}
+		}
+		_ = d.Set("phone_methods", methods)
+	}
+	return nil
+}

--- a/sdk/authenticator_methods.go
+++ b/sdk/authenticator_methods.go
@@ -1,0 +1,78 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type authenticator_method struct {
+	Links  interface{} `json:"_links,omitempty"`
+	Type   string      `json:"type,omitempty"`
+	Status string      `json:"status,omitempty"`
+}
+
+// GetAppSignOnPolicyRule gets a policy rule.
+func (m *APISupplement) GetAuthenticatorMethodStatus(ctx context.Context, authenticatorID, method string) (string, error) {
+	url := fmt.Sprintf("/api/v1/authenticators/%v/methods/%v", authenticatorID, method)
+	req, err := m.RequestExecutor.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	var authenticatorMethod authenticator_method
+	_, err = m.RequestExecutor.Do(ctx, req, &authenticatorMethod)
+	if err != nil {
+		return "", err
+	}
+	return authenticatorMethod.Status, nil
+}
+
+// ActivateAuthenticatorMethod deactivates the Authenticators supplied method.
+func (m *APISupplement) ActivateAuthenticatorMethod(ctx context.Context, authenticatorID, method string) error {
+	status, err := m.GetAuthenticatorMethodStatus(ctx, authenticatorID, method)
+	if err != nil {
+		return err
+	}
+	if status != "ACTIVE" {
+		return m.lifecycleChangeAuthenticatorMethod(ctx, authenticatorID, method, "activate", 1)
+	}
+	return nil
+}
+
+// DeactivateAuthenticatorMethod deactivates the Authenticators supplied method.
+func (m *APISupplement) DeactivateAuthenticatorMethod(ctx context.Context, authenticatorID, method string) error {
+	status, err := m.GetAuthenticatorMethodStatus(ctx, authenticatorID, method)
+	if err != nil {
+		return err
+	}
+	if status != "INACTIVE" {
+		return m.lifecycleChangeAuthenticatorMethod(ctx, authenticatorID, method, "deactivate", 1)
+	}
+	return nil
+}
+
+func (m *APISupplement) lifecycleChangeAuthenticatorMethod(ctx context.Context, authenticatorID, method, action string, attempt int) error {
+	url := fmt.Sprintf("/api/v1/authenticators/%s/methods/%s/lifecycle/%s", authenticatorID, method, action)
+	req, err := m.RequestExecutor.
+		WithAccept("application/json").
+		WithContentType("application/json").
+		NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	_, err = m.RequestExecutor.Do(ctx, req, nil)
+	if err != nil {
+		// while testing received a few 501s for /api/v1/authenticators/%s/methods/%s/lifecycle/%s - could be possible lag for this endpoint
+		// to be available/consistent on backend. Retry if so
+		if err.Error() == "the API returned an error: Unsupported operation." {
+			if attempt > 5 {
+				return err
+			}
+			time.Sleep(time.Duration(attempt * 1000000000))
+			return m.lifecycleChangeAuthenticatorMethod(ctx, authenticatorID, method, action, attempt+1)
+		}
+		return err
+	}
+	return err
+}

--- a/website/docs/r/authenticator.html.markdown
+++ b/website/docs/r/authenticator.html.markdown
@@ -18,13 +18,14 @@ This resource allows you to configure different authenticators.
 
 ```hcl
 resource "okta_authenticator" "test" {
-  name     = "Security Question"
-  key      = "security_question"
+  name     = "Phone_Number"
+  key      = "phone_number"
   settings = jsonencode(
   {
     "allowedFor" : "recovery"
   }
   )
+  phone_methods  = ["sms", "voice"]
 }
 ```
 
@@ -47,6 +48,8 @@ The following arguments are supported:
 - `provider_shared_secret` - (Optional) An authentication key that must be defined when the RADIUS server is configured, and must be the same on both the RADIUS client and server. Used only for authenticators with type `"security_key"`.
 
 - `provider_user_name_template` - (Optional) Username template expected by the provider. Used only for authenticators with type `"security_key"`.
+
+- `phone_methods` - (Optional) If `key` is set to `phone_number`, specifies allowed methods. Valid values are `"sms"` and `"voice"`. Both methods will be set when this argument is absent.
 
 ## Attributes Reference
 


### PR DESCRIPTION
[WIP] - OIE
Two Authenticators (phone_number / okta_verify) allow individual methods to be enabled / disabled independent of the status of the authenticator. Currently this is exposed via the [_links](https://developer.okta.com/docs/reference/api/authenticators-admin/#error-response-example) property and is not documented in the Okta API, or any Management SDK.

This is to explore if the Terraform Provider should provide this capability which currently can only be controlled via the UI.
This [WIP] enables this feature for the okta_authenticator resource (CRUD), as well as updates the website with instructions for the phone_number Authenticator type.

If this feature should move forward tests and the data_source additions will be added along with Okta Verifier changes.