### PR TITLE
Support multiple identity providers on the `okta_policy_rule_idp_discovery` resource

### DIFF
--- a/examples/okta_policy_rule_idp_discovery/multiple_idp.tf
+++ b/examples/okta_policy_rule_idp_discovery/multiple_idp.tf
@@ -1,0 +1,37 @@
+data "okta_policy" "test" {
+  type = "IDP_DISCOVERY"
+  name = "Idp Discovery Policy"
+
+}
+
+resource "okta_policy_rule_idp_discovery" "test" {
+  name      = "Test Rule"
+  policy_id = data.okta_policy.test.id
+
+  idp {
+    id   = okta_idp_social.google.id
+    type = "GOOGLE"
+  }
+  idp {
+    id   = okta_idp_social.facebook.id
+    type = "FACEBOOK"
+  }
+}
+
+resource "okta_idp_social" "facebook" {
+  name          = "Facebook"
+  type          = "FACEBOOK"
+  protocol_type = "OAUTH2"
+  client_id     = "var.idp_social_facebook_client_id"
+  client_secret = "var.idp_social_facebook_client_secret"
+  scopes        = ["public_profile", "email"]
+
+}
+resource "okta_idp_social" "google" {
+  name          = "Google"
+  type          = "GOOGLE"
+  protocol_type = "OIDC"
+  client_id     = "var.idp_social_google_client_id"
+  client_secret = "var.idp_social_google_client_secret"
+  scopes        = ["openid", "profile", "email"]
+}

--- a/okta/resource_okta_policy_rule_idp_discovery_test.go
+++ b/okta/resource_okta_policy_rule_idp_discovery_test.go
@@ -23,6 +23,7 @@ func TestAccOktaPolicyRuleIdpDiscovery_crud(t *testing.T) {
 	appIncludeConfig := mgr.GetFixtures("app_include.tf", ri2, t)
 	appExcludeConfig := mgr.GetFixtures("app_exclude_platform.tf", ri2, t)
 	resourceName := fmt.Sprintf("%s.test", policyRuleIdpDiscovery)
+	multipleIdp := mgr.GetFixtures("multiple_idp.tf", ri2, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -78,6 +79,13 @@ func TestAccOktaPolicyRuleIdpDiscovery_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "app_exclude.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "idp_type", "OKTA"),
 					resource.TestCheckResourceAttr(resourceName, "platform_include.#", "1"),
+				),
+			},			
+			{
+				Config: multipleIdp,
+				Check: resource.ComposeTestCheckFunc(
+					ensureRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "idp.#", "2"),
 				),
 			},
 		},

--- a/website/docs/r/policy_rule_idp_discovery.html.markdown
+++ b/website/docs/r/policy_rule_idp_discovery.html.markdown
@@ -1,7 +1,7 @@
 ---
-layout: 'okta'
-page_title: 'Okta: okta_policy_rule_idp_discovery'
-sidebar_current: 'docs-okta-resource-policy-rule-idp-discovery'
+layout: "okta"
+page_title: "Okta: okta_policy_rule_idp_discovery"
+sidebar_current: "docs-okta-resource-policy-rule-idp-discovery"
 description: |-
   Creates an IdP Discovery Policy Rule.
 ---
@@ -62,6 +62,40 @@ resource "okta_policy_rule_idp_discovery" "example" {
 }
 ```
 
+```hcl
+resource "okta_policy_rule_idp_discovery" "my_rule" {
+  name      = "My Rule"
+  policy_id = "some-policy-id"
+
+  idp {
+    id   = okta_idp_social.google.id
+    type = "GOOGLE"
+  }
+  idp {
+    id   = okta_idp_social.facebook.id
+    type = "FACEBOOK"
+  }
+}
+
+resource "okta_idp_social" "facebook" {
+  name          = "Facebook"
+  type          = "FACEBOOK"
+  protocol_type = "OAUTH2"
+  client_id     = "xxx"
+  client_secret = "xxx"
+  scopes        = ["public_profile", "email"]
+
+}
+resource "okta_idp_social" "google" {
+  name          = "Google"
+  type          = "GOOGLE"
+  protocol_type = "OIDC"
+  client_id     = "xxx"
+  client_secret = "xxx"
+  scopes        = ["openid", "profile", "email"]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -75,6 +109,17 @@ The following arguments are supported:
 - `idp_id` - (Optional) The identifier for the Idp the rule should route to if all conditions are met.
 
 - `idp_type` - (Optional) Type of Idp. One of: `"SAML2"`, `"IWA"`, `"AgentlessDSSO"`, `"X509"`, `"FACEBOOK"`, `"GOOGLE"`, `"LINKEDIN"`, `"MICROSOFT"`, `"OIDC"`
+
+- `idp` - (Optional) List of multiple Idp associated with this resource. If set this will overwrite the `idp_id` and `idp_type` attributes.
+
+  - `id` - (Required) The identifier for the Idp this rule should route to.
+  - `type` - (Optional) Type of Idp. One of: `"SAML2"`, `"IWA"`, `"AgentlessDSSO"`, `"X509"`, `"FACEBOOK"`, `"GOOGLE"`, `"LINKEDIN"`, `"MICROSOFT"`, `"OIDC"`
+
+````hcl
+idp {
+  id = string
+  type = string
+}
 
 - `network_connection` - (Optional) The network selection mode. One of `"ANYWEHRE"` or `"ZONE"`.
 
@@ -104,7 +149,7 @@ app_include {
   type = string
   name = string
 }
-```
+````
 
 - `app_exclude` - (Optional) Applications to exclude in discovery. See `app_include` for details.
 
@@ -132,7 +177,7 @@ platform_include {
 }
 ```
 
-- `user_identifier_patterns` - (Optional) Specifies a User Identifier pattern condition to match against. If `match_type` of `"EXPRESSION"` is used, only a *single* element can be set, otherwise multiple elements of matching patterns may be provided.
+- `user_identifier_patterns` - (Optional) Specifies a User Identifier pattern condition to match against. If `match_type` of `"EXPRESSION"` is used, only a _single_ element can be set, otherwise multiple elements of matching patterns may be provided.
 
   - `match_type` - (Optional) The kind of pattern. For regex, use `"EXPRESSION"`. For simple string matches, use one of the following: `"SUFFIX"`, `"EQUALS"`, `"STARTS_WITH"`, `"CONTAINS"`
 
@@ -150,7 +195,6 @@ user_identifier_patterns {
 - `id` - ID of the Rule.
 
 - `policyid` - (Deprecated) Policy ID.
-  
 - `policy_id` - Policy ID.
 
 ## Import


### PR DESCRIPTION
Hi.
I noticed a shortcoming between the management ui and the `okta_policy_rule_idp_disvovery`. While it is possible to configure multiple identity providers for a given rule through the ui this is not possible through terraform yet.

### UI
![Bildschirmfoto 2022-07-21 um 10 47 48](https://user-images.githubusercontent.com/34742348/180176452-8fef6e0c-88fc-457a-bbad-f94cb32b705b.png)

### Terraform
```hcl
resource "okta_policy_rule_idp_discovery" "my_rule" {
  name      = "My Rule"
  policy_id = "some-policy-id"
  idp_id    = "some-idp-id"
  idp_type = "idp-type"
}

```
## Changes
I suggest to add the possibility to configure multiple idps per discovery rule and use it in terraform like this:
```hcl
resource "okta_policy_rule_idp_discovery" "my_rule" {
  name      = "My Rule"
  policy_id = "some-policy-id"

  idp {
    id   = okta_idp_social.google.id
    type = "GOOGLE"
  }
  idp {
    id   = okta_idp_social.facebook.id
    type = "FACEBOOK"
  }
}

```
I implemented this change in a backwards compatible way. If the legacy attributes `idp_id` and `idp_type` are set they will be used as before. However if the newly added `idp {}` list is used the list will take advantage over the legacy attributes.
Let me know what you think! 
Cheers, Felix
