### PR TITLE
Add `privateKeyId` support.

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -38,6 +38,7 @@ type (
 		apiToken         string
 		clientID         string
 		privateKey       string
+		privateKeyId     string
 		scopes           []string
 		retryCount       int
 		parallelism      int
@@ -106,6 +107,7 @@ func (c *Config) loadAndValidate(ctx context.Context) error {
 		okta.WithToken(c.apiToken),
 		okta.WithClientId(c.clientID),
 		okta.WithPrivateKey(c.privateKey),
+		okta.WithPrivateKeyId(c.privateKeyId),
 		okta.WithScopes(c.scopes),
 		okta.WithCache(false),
 		okta.WithHttpClientPtr(httpClient),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -173,6 +173,13 @@ func Provider() *schema.Provider {
 				Description:   "API Token granting privileges to Okta API.",
 				ConflictsWith: []string{"api_token"},
 			},
+			"private_key_id": {
+				Optional:      true,
+				Type:          schema.TypeString,
+				DefaultFunc:   schema.EnvDefaultFunc("OKTA_API_PRIVATE_KEY_ID", nil),
+				Description:   "API Token Id granting privileges to Okta API.",
+				ConflictsWith: []string{"api_token"},
+			},
 			"base_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -417,6 +424,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		apiToken:       d.Get("api_token").(string),
 		clientID:       d.Get("client_id").(string),
 		privateKey:     d.Get("private_key").(string),
+		privateKeyId:	d.Get("private_key_id").(string),
 		scopes:         convertInterfaceToStringSet(d.Get("scopes")),
 		retryCount:     d.Get("max_retries").(int),
 		parallelism:    d.Get("parallelism").(int),

--- a/okta/provider_test.go
+++ b/okta/provider_test.go
@@ -47,6 +47,7 @@ func oktaConfig() (*Config, error) {
 		httpProxy:      os.Getenv("OKTA_HTTP_PROXY"),
 		clientID:       os.Getenv("OKTA_API_CLIENT_ID"),
 		privateKey:     os.Getenv("OKTA_API_PRIVATE_KEY"),
+		privateKeyId: 	os.Getenv("OKTA_API_PRIVATE_KEY_ID"),
 		scopes:         strings.Split(os.Getenv("OKTA_API_SCOPES"), ","),
 		domain:         os.Getenv("OKTA_BASE_URL"),
 		parallelism:    1,
@@ -75,8 +76,9 @@ func accPreCheck() error {
 	token := os.Getenv("OKTA_API_TOKEN")
 	clientID := os.Getenv("OKTA_API_CLIENT_ID")
 	privateKey := os.Getenv("OKTA_API_PRIVATE_KEY")
+	privateKeyId := os.Getenv("OKTA_API_PRIVATE_KEY_IE")
 	scopes := os.Getenv("OKTA_API_SCOPES")
-	if token == "" && (clientID == "" || scopes == "" || privateKey == "") {
+	if token == "" && (clientID == "" || scopes == "" || privateKey == "" || privateKeyId == "") {
 		return errors.New("either OKTA_API_TOKEN or OKTA_API_CLIENT_ID, OKTA_API_SCOPES and OKTA_API_PRIVATE_KEY must be set for acceptance tests")
 	}
 	return nil

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -89,6 +89,8 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 - `private_key` - (Optional) This is the private key for obtaining the API token (can be represented by a filepath, or the key itself). It can also be sourced from the `OKTA_API_PRIVATE_KEY` environment variable. `private_key` conflicts with `api_token`.
 
+- `private_key_id` - (Optional) This is the private key ID (kid) for obtaining the API token. It can also be sourced from `OKTA_API_PRIVATE_KEY_ID` environmental variable. `private_key_id` conflicts with `api_token`.
+
 - `backoff` - (Optional) Whether to use exponential back off strategy for rate limits, the default is `true`.
 
 - `min_wait_seconds` - (Optional) Minimum seconds to wait when rate limit is hit, the default is `30`.


### PR DESCRIPTION
Currently, if you have an application configured with Public key / Private key Client authentication and you have multiple keys configured, the provider will throw the following error:

`Error: failed <insert action>: the API returned an error: The client_assertion JWT kid is invalid.`

This PR allows the `KID` to be set to use the correct key.