### PR TITLE
"no default policy found" bug

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -53,6 +53,7 @@ type (
 		supplementClient *sdk.APISupplement
 		client           *http.Client
 		logger           hclog.Logger
+		classicOrg       bool
 	}
 )
 

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -454,6 +454,12 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if err := config.loadAndValidate(ctx); err != nil {
 		return nil, diag.Errorf("[ERROR] invalid configuration: %v", err)
 	}
+
+	// Discover if the Okta Org is Classic or OIE
+	if org, _, err := config.supplementClient.GetWellKnownOktaOrganization(ctx); err == nil {
+		config.classicOrg = (org.Pipeline == "v1") // v1 == Classic, idx == OIE
+	}
+
 	return &config, nil
 }
 

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -362,8 +362,8 @@ func resourceAppOAuth() *schema.Resource {
 				},
 			},
 			"authentication_policy": {
-				Type: schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "Id of this apps authentication policy",
 			},
 		}),

--- a/sdk/org.go
+++ b/sdk/org.go
@@ -1,0 +1,38 @@
+package sdk
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+type OktaOrganization struct {
+	Id       string      `json:"id"`
+	Pipeline string      `json:"pipeline"`
+	Links    interface{} `json:"_links,omitempty"`
+	Settings interface{} `json:"settings,omitempty"`
+}
+
+// GetWellKnownOktaOrganization calls GET /.well-known/okta-organization that
+// surfaces information about the org including if it is OIE or Classic
+// (pipeline=v1 is Classic, pipeline=idx is OIE)
+//
+// NOTE: Devs at Okta are negotiating internally to recognize the endpoint as
+// public and will be in a coming release of okta-sdk-golang and documented at
+// developer.okta.com .
+//
+// TODO: remove this custom code with well known okta organization is in okta-sdk-golang
+func (m *APISupplement) GetWellKnownOktaOrganization(ctx context.Context) (*OktaOrganization, *okta.Response, error) {
+	url := "/.well-known/okta-organization"
+	req, err := m.RequestExecutor.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var oktaOrganization *OktaOrganization
+	resp, err := m.RequestExecutor.Do(ctx, req, &oktaOrganization)
+	if err != nil {
+		return nil, resp, err
+	}
+	return oktaOrganization, resp, nil
+}


### PR DESCRIPTION
Fixes "no default policy found" bug.

Uses `GET /.well-known/okta-organization` to help discover if an org is Classic or OIE. Fix bug in assign policy for apps.

ACC tests pass for:

* classic org
* OIE org with "Default Policy" ACCESS_POLICY
* OIE org without "Default Policy" ACCESS_POLICY

```
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaDataSourceAppOauth_read$ ./okta 2>&1
START TEST MAIN
=== RUN   TestAccOktaDataSourceAppOauth_read
--- PASS: TestAccOktaDataSourceAppOauth_read (8.14s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    8.712s
```