### PR TITLE
fix: specify client ID when using private key

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -130,7 +130,7 @@ func (c *Config) loadAndValidate(ctx context.Context) error {
 	case c.privateKey != "":
 		setters = append(
 			setters,
-			okta.WithPrivateKey(c.privateKey), okta.WithPrivateKeyId(c.privateKeyId), okta.WithScopes(c.scopes), okta.WithAuthorizationMode("PrivateKey"),
+			okta.WithPrivateKey(c.privateKey), okta.WithPrivateKeyId(c.privateKeyId), okta.WithScopes(c.scopes), okta.WithClientId(c.clientID), okta.WithAuthorizationMode("PrivateKey"),
 		)
 	}
 


### PR DESCRIPTION
Apologies, it looks like I neglected to add `WithClientID` when using a private key.