### PR TITLE
okta_auth_server_policy_rule priority

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -397,6 +397,15 @@ PASS
 ok  	github.com/okta/terraform-provider-okta/okta	55.619s
 ```
 
+#### Forced clean out of dangling acceptance test resources
+
+Sometimes the acceptance testing framework can exit leaving dangling resources.
+Run the forced sweeper test to clean them all out.
+
+```
+OKTA_ACC_TEST_FORCE_SWEEPERS=1 TF_LOG=warn make testacc TEST=./okta TESTARGS='-run=TestRunForcedSweeper'
+```
+
 #### Writing an Acceptance Test
 
 Terraform has a framework for writing acceptance tests which minimises the

--- a/okta/app_test.go
+++ b/okta/app_test.go
@@ -1,9 +1,6 @@
 package okta
 
 import (
-	"context"
-	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -33,27 +30,3 @@ func TestLogoStateFunc(t *testing.T) {
 	}
 }
 
-func deleteTestApps(client *testClient) error {
-	appList, err := listApps(context.Background(), client.oktaClient, &appFilters{LabelPrefix: testResourcePrefix}, defaultPaginationLimit)
-	if err != nil {
-		return err
-	}
-	var warnings []string
-	for _, app := range appList {
-		warn := fmt.Sprintf("failed to sweep an application, there may be dangling resources. ID %s, label %s", app.Id, app.Label)
-		_, err := client.oktaClient.Application.DeactivateApplication(context.Background(), app.Id)
-		if err != nil {
-			warnings = append(warnings, warn)
-		}
-		resp, err := client.oktaClient.Application.DeleteApplication(context.Background(), app.Id)
-		if is404(resp) {
-			warnings = append(warnings, warn)
-		} else if err != nil {
-			return err
-		}
-	}
-	if len(warnings) > 0 {
-		return fmt.Errorf("sweep failures: %s", strings.Join(warnings, ", "))
-	}
-	return nil
-}

--- a/okta/idp_test.go
+++ b/okta/idp_test.go
@@ -2,8 +2,6 @@ package okta
 
 import (
 	"context"
-
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
 
 func createDoesIdpExist() func(string) (bool, error) {
@@ -13,23 +11,3 @@ func createDoesIdpExist() func(string) (bool, error) {
 	}
 }
 
-func deleteTestIdps(client *testClient) error {
-	providers, _, err := client.oktaClient.IdentityProvider.ListIdentityProviders(context.Background(), &query.Params{Q: "testAcc_"})
-	if err != nil {
-		return err
-	}
-	for _, idp := range providers {
-		_, err := client.oktaClient.IdentityProvider.DeleteIdentityProvider(context.Background(), idp.Id)
-		if err != nil {
-			return err
-		}
-
-		if idp.Type == saml2Idp {
-			_, err := client.oktaClient.IdentityProvider.DeleteIdentityProviderKey(context.Background(), idp.Protocol.Credentials.Trust.Kid)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -432,7 +432,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		accessToken:    d.Get("access_token").(string),
 		clientID:       d.Get("client_id").(string),
 		privateKey:     d.Get("private_key").(string),
-		privateKeyId:	d.Get("private_key_id").(string),
+		privateKeyId:   d.Get("private_key_id").(string),
 		scopes:         convertInterfaceToStringSet(d.Get("scopes")),
 		retryCount:     d.Get("max_retries").(int),
 		parallelism:    d.Get("parallelism").(int),

--- a/okta/provider_sweeper_test.go
+++ b/okta/provider_sweeper_test.go
@@ -3,13 +3,35 @@ package okta
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
 	"github.com/okta/terraform-provider-okta/sdk"
 )
+
+var sweeperLogger hclog.Logger
+var sweeperLogLevel hclog.Level
+
+func init() {
+	sweeperLogLevel = hclog.Warn
+	if os.Getenv("TF_LOG") != "" {
+		sweeperLogLevel = hclog.LevelFromString(os.Getenv("TF_LOG"))
+	}
+	sweeperLogger = hclog.New(&hclog.LoggerOptions{
+		Level:      sweeperLogLevel,
+		TimeFormat: "2006/01/02 03:04:05",
+	})
+}
+
+func logSweptResource(kind, id, nameOrLabel string) {
+	sweeperLogger.Warn(fmt.Sprintf("sweeper found dangling %q %q %q", kind, id, nameOrLabel))
+}
 
 type testClient struct {
 	oktaClient    *okta.Client
@@ -21,31 +43,76 @@ var testResourcePrefix = "testAcc"
 // TestMain overridden main testing function. Package level BeforeAll and AfterAll.
 // It also delineates between acceptance tests and unit tests
 func TestMain(m *testing.M) {
-	// Acceptance test sweepers necessary to prevent dangling resources
-	setupSweeper(policyPassword, deletePasswordPolicies)
-	setupSweeper(policySignOn, deleteSignOnPolicies)
-	setupSweeper(policyRuleIdpDiscovery, deletePolicyRuleIdpDiscovery)
-	setupSweeper(policyMfa, deleteMfaPolicies)
-	setupSweeper(policyRuleSignOn, deleteSignOnPolicyRules)
-	setupSweeper(policyRulePassword, deletePolicyRulePasswords)
-	setupSweeper("okta_*_app", deleteTestApps)
-	setupSweeper("okta_*_idp", deleteTestIdps)
-	setupSweeper(policyRuleMfa, deleteMfaPolicyRules)
-	setupSweeper(authServer, deleteAuthServers)
-	setupSweeper(groupRule, sweepGroupRules)
-	setupSweeper(group, sweepGroups)
-	setupSweeper(user, sweepUsers)
-	setupSweeper(userSchemaProperty, sweepUserCustomSchema)
-	setupSweeper(groupSchemaProperty, sweepGroupCustomSchema)
-	setupSweeper(networkZone, sweepNetworkZones)
-	setupSweeper(inlineHook, sweepInlineHooks)
-	setupSweeper(userType, sweepUserTypes)
-	setupSweeper(behavior, sweepBehaviors)
-	setupSweeper(resourceSet, sweepResourceSets)
-	setupSweeper(adminRoleCustom, sweepCustomRoles)
-	setupSweeper(linkDefinition, sweepLinkDefinitions)
+	// NOTE: Acceptance test sweepers are necessary to prevent dangling
+	// resources.
+	// NOTE: Don't run sweepers if we are playing back VCR as nothing should be
+	// going over the wire
+	if os.Getenv("OKTA_VCR_TF_ACC") != "play" {
+		setupSweeper(adminRoleCustom, sweepCustomRoles)
+		setupSweeper("okta_*_app", sweepTestApps)
+		setupSweeper(authServer, sweepAuthServers)
+		setupSweeper(behavior, sweepBehaviors)
+		setupSweeper(groupRule, sweepGroupRules)
+		setupSweeper("okta_*_idp", sweepTestIdps)
+		setupSweeper(inlineHook, sweepInlineHooks)
+		setupSweeper(group, sweepGroups)
+		setupSweeper(groupSchemaProperty, sweepGroupCustomSchema)
+		setupSweeper(linkDefinition, sweepLinkDefinitions)
+		setupSweeper(networkZone, sweepNetworkZones)
+		setupSweeper(policyMfa, sweepMfaPolicies)
+		setupSweeper(policyPassword, sweepPasswordPolicies)
+		setupSweeper(policyRuleIdpDiscovery, sweepPolicyRuleIdpDiscovery)
+		setupSweeper(policyRuleMfa, sweepMfaPolicyRules)
+		setupSweeper(policyRulePassword, sweepPolicyRulePasswords)
+		setupSweeper(policyRuleSignOn, sweepSignOnPolicyRules)
+		setupSweeper(policySignOn, sweepSignOnPolicies)
+		setupSweeper(resourceSet, sweepResourceSets)
+		setupSweeper(user, sweepUsers)
+		setupSweeper(userSchemaProperty, sweepUserCustomSchema)
+		setupSweeper(userType, sweepUserTypes)
+	}
 
 	resource.TestMain(m)
+}
+
+func TestRunForcedSweeper(t *testing.T) {
+	if os.Getenv("OKTA_ACC_TEST_FORCE_SWEEPERS") == "" || os.Getenv("TF_ACC") == "" {
+		t.Skipf("ENV vars %q and %q must not be blank to force running of the sweepers", "OKTA_ACC_TEST_FORCE_SWEEPERS", "TF_ACC")
+		return
+	}
+
+	client, apiSupplement, err := sharedTestClients()
+	testClient := &testClient{
+		oktaClient:    client,
+		apiSupplement: apiSupplement,
+	}
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	sweepCustomRoles(testClient)
+	sweepTestApps(testClient)
+	sweepAuthServers(testClient)
+	sweepBehaviors(testClient)
+	sweepGroupRules(testClient)
+	sweepTestIdps(testClient)
+	sweepInlineHooks(testClient)
+	sweepGroups(testClient)
+	sweepGroupCustomSchema(testClient)
+	sweepLinkDefinitions(testClient)
+	sweepNetworkZones(testClient)
+	sweepMfaPolicies(testClient)
+	sweepPasswordPolicies(testClient)
+	sweepPolicyRuleIdpDiscovery(testClient)
+	sweepMfaPolicyRules(testClient)
+	sweepPolicyRulePasswords(testClient)
+	sweepSignOnPolicyRules(testClient)
+	sweepSignOnPolicies(testClient)
+	sweepResourceSets(testClient)
+	sweepUsers(testClient)
+	sweepUserCustomSchema(testClient)
+	sweepUserTypes(testClient)
 }
 
 // Sets up sweeper to clean up dangling resources
@@ -53,7 +120,7 @@ func setupSweeper(resourceType string, del func(*testClient) error) {
 	resource.AddTestSweepers(resourceType, &resource.Sweeper{
 		Name: resourceType,
 		F: func(_ string) error {
-			client, apiSupplement, err := sharedClient()
+			client, apiSupplement, err := sharedTestClients()
 			if err != nil {
 				return err
 			}
@@ -75,8 +142,8 @@ func buildResourceNameWithPrefix(prefix string, testID int) string {
 	return prefix + "_" + strconv.Itoa(testID)
 }
 
-// sharedClient returns a common Okta Client for sweepers, which currently requires the original SDK and the official beta SDK
-func sharedClient() (*okta.Client, *sdk.APISupplement, error) {
+// sharedTestClients returns a common Okta Client for sweepers, which currently requires the original SDK and the official beta SDK
+func sharedTestClients() (*okta.Client, *sdk.APISupplement, error) {
 	err := accPreCheck()
 	if err != nil {
 		return nil, nil, err
@@ -98,4 +165,380 @@ func sharedClient() (*okta.Client, *sdk.APISupplement, error) {
 	api := &sdk.APISupplement{RequestExecutor: client.GetRequestExecutor()}
 
 	return client, api, nil
+}
+
+func sweepCustomRoles(client *testClient) error {
+	var errorList []error
+	customRoles, _, err := client.apiSupplement.ListCustomRoles(context.Background(), &query.Params{Limit: defaultPaginationLimit})
+	if err != nil {
+		return err
+	}
+	for _, role := range customRoles.Roles {
+		if !strings.HasPrefix(role.Label, "testAcc_") {
+			_, err := client.apiSupplement.DeleteCustomRole(context.Background(), role.Id)
+			if err != nil {
+				errorList = append(errorList, err)
+				continue
+			}
+			logSweptResource("custom role", role.Id, role.Label)
+		}
+	}
+	return condenseError(errorList)
+}
+
+func sweepTestApps(client *testClient) error {
+	appList, err := listApps(context.Background(), client.oktaClient, &appFilters{LabelPrefix: testResourcePrefix}, defaultPaginationLimit)
+	if err != nil {
+		return err
+	}
+	var warnings []string
+	for _, app := range appList {
+		warn := fmt.Sprintf("failed to sweep an application, there may be dangling resources. ID %s, label %s", app.Id, app.Label)
+		_, err := client.oktaClient.Application.DeactivateApplication(context.Background(), app.Id)
+		if err != nil {
+			warnings = append(warnings, warn)
+		}
+		resp, err := client.oktaClient.Application.DeleteApplication(context.Background(), app.Id)
+		if is404(resp) {
+			warnings = append(warnings, warn)
+			continue
+		} else if err != nil {
+			return err
+		}
+		logSweptResource("app", app.Id, app.Name)
+	}
+	if len(warnings) > 0 {
+		return fmt.Errorf("sweep failures: %s", strings.Join(warnings, ", "))
+	}
+	return nil
+}
+
+func sweepAuthServers(client *testClient) error {
+	servers, _, err := client.oktaClient.AuthorizationServer.ListAuthorizationServers(context.Background(), &query.Params{Q: testResourcePrefix})
+	if err != nil {
+		return err
+	}
+	for _, s := range servers {
+		if _, err := client.oktaClient.AuthorizationServer.DeactivateAuthorizationServer(context.Background(), s.Id); err != nil {
+			return err
+		}
+		if _, err := client.oktaClient.AuthorizationServer.DeleteAuthorizationServer(context.Background(), s.Id); err != nil {
+			return err
+		}
+		logSweptResource("authorization server", s.Id, s.Name)
+	}
+	return nil
+}
+
+func sweepBehaviors(client *testClient) error {
+	var errorList []error
+	behaviors, _, err := client.apiSupplement.ListBehaviors(context.Background(), &query.Params{Q: testResourcePrefix})
+	if err != nil {
+		return err
+	}
+	for _, b := range behaviors {
+		if _, err := client.apiSupplement.DeleteBehavior(context.Background(), b.ID); err != nil {
+			errorList = append(errorList, err)
+			continue
+		}
+		logSweptResource("behavior", b.ID, b.Name)
+	}
+	return condenseError(errorList)
+}
+
+func sweepGroupRules(client *testClient) error {
+	var errorList []error
+	// Should never need to deal with pagination
+	rules, _, err := client.oktaClient.Group.ListGroupRules(context.Background(), &query.Params{Limit: defaultPaginationLimit})
+	if err != nil {
+		return err
+	}
+
+	for _, s := range rules {
+		if s.Status == statusActive {
+			if _, err := client.oktaClient.Group.DeactivateGroupRule(context.Background(), s.Id); err != nil {
+				errorList = append(errorList, err)
+				continue
+			}
+		}
+		if _, err := client.oktaClient.Group.DeleteGroupRule(context.Background(), s.Id, nil); err != nil {
+			errorList = append(errorList, err)
+			continue
+		}
+		logSweptResource("group rule", s.Id, s.Name)
+	}
+	return condenseError(errorList)
+}
+
+func sweepTestIdps(client *testClient) error {
+	providers, _, err := client.oktaClient.IdentityProvider.ListIdentityProviders(context.Background(), &query.Params{Q: "testAcc_"})
+	if err != nil {
+		return err
+	}
+	for _, idp := range providers {
+		_, err := client.oktaClient.IdentityProvider.DeleteIdentityProvider(context.Background(), idp.Id)
+		if err != nil {
+			return err
+		}
+		logSweptResource("identity provider", idp.Id, idp.Name)
+
+		if idp.Type == saml2Idp {
+			_, err := client.oktaClient.IdentityProvider.DeleteIdentityProviderKey(context.Background(), idp.Protocol.Credentials.Trust.Kid)
+			if err != nil {
+				return err
+			}
+			logSweptResource("saml identity provider key", idp.Id, idp.Protocol.Credentials.Trust.Kid)
+		}
+	}
+	return nil
+}
+
+func sweepInlineHooks(client *testClient) error {
+	var errorList []error
+	hooks, _, err := client.oktaClient.InlineHook.ListInlineHooks(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	for _, hook := range hooks {
+		if !strings.HasPrefix(hook.Name, testResourcePrefix) {
+			continue
+		}
+		if hook.Status == statusActive {
+			_, _, err = client.oktaClient.InlineHook.DeactivateInlineHook(context.Background(), hook.Id)
+			if err != nil {
+				errorList = append(errorList, err)
+			}
+		}
+		_, err = client.oktaClient.InlineHook.DeleteInlineHook(context.Background(), hook.Id)
+		if err != nil {
+			errorList = append(errorList, err)
+		}
+		logSweptResource("inline hook", hook.Id, hook.Name)
+	}
+	return condenseError(errorList)
+}
+
+func sweepGroups(client *testClient) error {
+	var errorList []error
+	// Should never need to deal with pagination, limit is 10,000 by default
+	groups, _, err := client.oktaClient.Group.ListGroups(context.Background(), &query.Params{Q: testResourcePrefix})
+	if err != nil {
+		return err
+	}
+
+	for _, s := range groups {
+		if _, err := client.oktaClient.Group.DeleteGroup(context.Background(), s.Id); err != nil {
+			errorList = append(errorList, err)
+			continue
+		}
+		logSweptResource("group", s.Id, s.Profile.Name)
+	}
+	return condenseError(errorList)
+}
+
+func sweepGroupCustomSchema(client *testClient) error {
+	schema, _, err := client.oktaClient.GroupSchema.GetGroupSchema(context.Background())
+	if err != nil {
+		return err
+	}
+	for key := range schema.Definitions.Custom.Properties {
+		if strings.HasPrefix(key, testResourcePrefix) {
+			custom := buildCustomGroupSchema(key, nil)
+			_, _, err = client.oktaClient.GroupSchema.UpdateGroupSchema(context.Background(), *custom)
+			if err != nil {
+				return err
+			}
+			logSweptResource("update group schema", key, key)
+		}
+	}
+	return nil
+}
+
+func sweepLinkDefinitions(client *testClient) error {
+	var errorList []error
+	linkedObjects, _, err := client.oktaClient.LinkedObject.ListLinkedObjectDefinitions(context.Background())
+	if err != nil {
+		return err
+	}
+	for _, object := range linkedObjects {
+		if strings.HasPrefix(object.Primary.Name, testResourcePrefix) {
+			if _, err := client.oktaClient.LinkedObject.DeleteLinkedObjectDefinition(context.Background(), object.Primary.Name); err != nil {
+				errorList = append(errorList, err)
+				continue
+			}
+			logSweptResource("linked object definition", object.Primary.Name, object.Primary.Title)
+		}
+	}
+	return condenseError(errorList)
+}
+
+func sweepNetworkZones(client *testClient) error {
+	var errorList []error
+	zones, _, err := client.oktaClient.NetworkZone.ListNetworkZones(context.Background(), &query.Params{Limit: defaultPaginationLimit})
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if strings.HasPrefix(zone.Name, testResourcePrefix) {
+			if _, err := client.oktaClient.NetworkZone.DeleteNetworkZone(context.Background(), zone.Id); err != nil {
+				errorList = append(errorList, err)
+				continue
+			}
+			logSweptResource("network zone", zone.Id, zone.Name)
+		}
+	}
+	return condenseError(errorList)
+}
+
+func sweepMfaPolicies(client *testClient) error {
+	return sweepPolicyByType(sdk.MfaPolicyType, client)
+}
+
+func sweepPasswordPolicies(client *testClient) error {
+	return sweepPolicyByType(sdk.PasswordPolicyType, client)
+}
+
+func sweepPolicyRuleIdpDiscovery(client *testClient) error {
+	return sweepPolicyRulesByType(sdk.IdpDiscoveryType, client)
+}
+
+func sweepMfaPolicyRules(client *testClient) error {
+	return sweepPolicyRulesByType(sdk.MfaPolicyType, client)
+}
+
+func sweepPolicyRulePasswords(client *testClient) error {
+	return sweepPolicyRulesByType(sdk.PasswordPolicyType, client)
+}
+
+func sweepSignOnPolicyRules(client *testClient) error {
+	return sweepPolicyRulesByType(sdk.SignOnPolicyType, client)
+}
+
+func sweepSignOnPolicies(client *testClient) error {
+	return sweepPolicyByType(sdk.SignOnPolicyType, client)
+}
+
+func sweepResourceSets(client *testClient) error {
+	var errorList []error
+	resourceSets, _, err := client.apiSupplement.ListResourceSets(context.Background())
+	if err != nil {
+		return err
+	}
+	for _, b := range resourceSets.ResourceSets {
+		if !strings.HasPrefix(b.Label, "testAcc_") {
+			if _, err := client.apiSupplement.DeleteResourceSet(context.Background(), b.Id); err != nil {
+				errorList = append(errorList, err)
+				continue
+			}
+			logSweptResource("resource set", b.Id, b.Label)
+		}
+	}
+	return condenseError(errorList)
+}
+
+func sweepUsers(client *testClient) error {
+	var errorList []error
+	users, _, err := client.oktaClient.User.ListUsers(context.Background(), &query.Params{Q: testResourcePrefix})
+	if err != nil {
+		return err
+	}
+
+	for _, u := range users {
+		if err := ensureUserDelete(context.Background(), u.Id, u.Status, client.oktaClient); err != nil {
+			errorList = append(errorList, err)
+			continue
+		}
+		var label string
+		for k, v := range *u.Profile {
+			label += fmt.Sprintf("%s:%+v, ", k, v)
+		}
+		logSweptResource("user", u.Id, label)
+	}
+	return condenseError(errorList)
+}
+
+func sweepUserCustomSchema(client *testClient) error {
+	userTypes, _, err := client.oktaClient.UserType.ListUserTypes(context.Background())
+	if err != nil {
+		return err
+	}
+	for _, userType := range userTypes {
+		typeSchemaID := userTypeSchemaID(userType)
+		schema, _, err := client.oktaClient.UserSchema.GetUserSchema(context.Background(), typeSchemaID)
+		if err != nil {
+			return err
+		}
+		for key := range schema.Definitions.Custom.Properties {
+			if strings.HasPrefix(key, testResourcePrefix) {
+				custom := buildCustomUserSchema(key, nil)
+				_, _, err = client.oktaClient.UserSchema.UpdateUserProfile(context.Background(), typeSchemaID, *custom)
+				if err != nil {
+					return err
+				}
+				logSweptResource("custom schema", typeSchemaID, "-")
+			}
+		}
+	}
+	return nil
+}
+
+func sweepUserTypes(client *testClient) error {
+	userTypeList, _, _ := client.oktaClient.UserType.ListUserTypes(context.Background())
+	var errorList []error
+	for _, ut := range userTypeList {
+		if strings.HasPrefix(ut.Name, testResourcePrefix) {
+			if _, err := client.oktaClient.UserType.DeleteUserType(context.Background(), ut.Id); err != nil {
+				errorList = append(errorList, err)
+				continue
+			}
+			logSweptResource("user type", ut.Id, ut.Name)
+		}
+	}
+	return condenseError(errorList)
+}
+
+func sweepPolicyByType(t string, client *testClient) error {
+	ctx := context.Background()
+	policies, _, err := client.oktaClient.Policy.ListPolicies(ctx, &query.Params{Type: t})
+	if err != nil {
+		return fmt.Errorf("failed to list policies in order to properly destroy: %v", err)
+	}
+	for _, _policy := range policies {
+		policy := _policy.(*okta.Policy)
+		if strings.HasPrefix(policy.Name, testResourcePrefix) {
+			_, err = client.oktaClient.Policy.DeletePolicy(ctx, policy.Id)
+			if err != nil {
+				return err
+			}
+			logSweptResource("policy: "+t, policy.Id, policy.Name)
+		}
+	}
+	return nil
+}
+
+func sweepPolicyRulesByType(ruleType string, client *testClient) error {
+	ctx := context.Background()
+	policies, _, err := client.oktaClient.Policy.ListPolicies(ctx, &query.Params{Type: ruleType})
+	if err != nil {
+		return fmt.Errorf("failed to list policies in order to properly destroy rules: %v", err)
+	}
+	for _, _policy := range policies {
+		policy := _policy.(*okta.Policy)
+		rules, _, err := client.apiSupplement.ListPolicyRules(ctx, policy.Id)
+		if err != nil {
+			return err
+		}
+		// Tests have always used default policy, I don't really think that is necessarily a good idea but
+		// leaving for now, that means we only delete the rules and not the policy, we can keep it around.
+		for i := range rules {
+			if strings.HasPrefix(rules[i].Name, testResourcePrefix) {
+				_, err = client.oktaClient.Policy.DeletePolicyRule(ctx, policy.Id, rules[i].Id)
+				if err != nil {
+					return err
+				}
+				logSweptResource("policy rule type: "+ruleType, policy.Id+"/"+rules[i].Id, rules[i].Name)
+			}
+		}
+	}
+	return nil
 }

--- a/okta/resource_okta_admin_role_custom_test.go
+++ b/okta/resource_okta_admin_role_custom_test.go
@@ -3,29 +3,11 @@ package okta
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
-
-func sweepCustomRoles(client *testClient) error {
-	var errorList []error
-	customRoles, _, err := client.apiSupplement.ListCustomRoles(context.Background(), &query.Params{Limit: defaultPaginationLimit})
-	if err != nil {
-		return err
-	}
-	for _, role := range customRoles.Roles {
-		if !strings.HasPrefix(role.Label, "testAcc_") {
-			if _, err := client.apiSupplement.DeleteCustomRole(context.Background(), role.Id); err != nil {
-				errorList = append(errorList, err)
-			}
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaAdminRoleCustom(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_auth_server_policy_rule.go
+++ b/okta/resource_okta_auth_server_policy_rule.go
@@ -106,6 +106,9 @@ func resourceAuthServerPolicyRule() *schema.Resource {
 }
 
 func resourceAuthServerPolicyRuleCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	oktaMutexKV.Lock(authServerPolicyRule)
+	defer oktaMutexKV.Unlock(authServerPolicyRule)
+
 	err := validateAuthServerPolicyRule(d)
 	if err != nil {
 		return diag.FromErr(err)
@@ -155,6 +158,9 @@ func resourceAuthServerPolicyRuleRead(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceAuthServerPolicyRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	oktaMutexKV.Lock(authServerPolicyRule)
+	defer oktaMutexKV.Unlock(authServerPolicyRule)
+
 	err := validateAuthServerPolicyRule(d)
 	if err != nil {
 		return diag.FromErr(err)
@@ -197,6 +203,9 @@ func handleAuthServerPolicyRuleLifecycle(ctx context.Context, d *schema.Resource
 }
 
 func resourceAuthServerPolicyRuleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	oktaMutexKV.Lock(authServerPolicyRule)
+	defer oktaMutexKV.Unlock(authServerPolicyRule)
+
 	_, err := getOktaClientFromMetadata(m).AuthorizationServer.DeleteAuthorizationServerPolicyRule(
 		ctx,
 		d.Get("auth_server_id").(string),

--- a/okta/resource_okta_auth_server_test.go
+++ b/okta/resource_okta_auth_server_test.go
@@ -8,24 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
-
-func deleteAuthServers(client *testClient) error {
-	servers, _, err := client.oktaClient.AuthorizationServer.ListAuthorizationServers(context.Background(), &query.Params{Q: testResourcePrefix})
-	if err != nil {
-		return err
-	}
-	for _, s := range servers {
-		if _, err := client.oktaClient.AuthorizationServer.DeactivateAuthorizationServer(context.Background(), s.Id); err != nil {
-			return err
-		}
-		if _, err := client.oktaClient.AuthorizationServer.DeleteAuthorizationServer(context.Background(), s.Id); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 func authServerExists(id string) (bool, error) {
 	server, resp, err := getOktaClientFromMetadata(testAccProvider.Meta()).AuthorizationServer.GetAuthorizationServer(context.Background(), id)

--- a/okta/resource_okta_behavior_test.go
+++ b/okta/resource_okta_behavior_test.go
@@ -7,22 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
-
-func sweepBehaviors(client *testClient) error {
-	var errorList []error
-	behaviors, _, err := client.apiSupplement.ListBehaviors(context.Background(), &query.Params{Q: testResourcePrefix})
-	if err != nil {
-		return err
-	}
-	for _, b := range behaviors {
-		if _, err := client.apiSupplement.DeleteBehavior(context.Background(), b.ID); err != nil {
-			errorList = append(errorList, err)
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaBehavior(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_group_custom_schema_property_test.go
+++ b/okta/resource_okta_group_custom_schema_property_test.go
@@ -5,30 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
-
-func sweepGroupCustomSchema(client *testClient) error {
-	schema, _, err := client.oktaClient.GroupSchema.GetGroupSchema(context.Background())
-	if err != nil {
-		return err
-	}
-	for key := range schema.Definitions.Custom.Properties {
-		if strings.HasPrefix(key, testResourcePrefix) {
-			custom := buildCustomGroupSchema(key, nil)
-			_, _, err = client.oktaClient.GroupSchema.UpdateGroupSchema(context.Background(), *custom)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
 
 func TestAccOktaGroupSchema_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_group_rule_test.go
+++ b/okta/resource_okta_group_rule_test.go
@@ -8,30 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
-
-func sweepGroupRules(client *testClient) error {
-	var errorList []error
-	// Should never need to deal with pagination
-	rules, _, err := client.oktaClient.Group.ListGroupRules(context.Background(), &query.Params{Limit: defaultPaginationLimit})
-	if err != nil {
-		return err
-	}
-
-	for _, s := range rules {
-		if s.Status == statusActive {
-			if _, err := client.oktaClient.Group.DeactivateGroupRule(context.Background(), s.Id); err != nil {
-				errorList = append(errorList, err)
-				continue
-			}
-		}
-		if _, err := client.oktaClient.Group.DeleteGroupRule(context.Background(), s.Id, nil); err != nil {
-			errorList = append(errorList, err)
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaGroupRule_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_group_test.go
+++ b/okta/resource_okta_group_test.go
@@ -8,24 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
-
-func sweepGroups(client *testClient) error {
-	var errorList []error
-	// Should never need to deal with pagination, limit is 10,000 by default
-	groups, _, err := client.oktaClient.Group.ListGroups(context.Background(), &query.Params{Q: testResourcePrefix})
-	if err != nil {
-		return err
-	}
-
-	for _, s := range groups {
-		if _, err := client.oktaClient.Group.DeleteGroup(context.Background(), s.Id); err != nil {
-			errorList = append(errorList, err)
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaGroup_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_inline_hooks_test.go
+++ b/okta/resource_okta_inline_hooks_test.go
@@ -3,36 +3,11 @@ package okta
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
-
-func sweepInlineHooks(client *testClient) error {
-	var errorList []error
-	hooks, _, err := client.oktaClient.InlineHook.ListInlineHooks(context.Background(), nil)
-	if err != nil {
-		return err
-	}
-	for _, hook := range hooks {
-		if !strings.HasPrefix(hook.Name, testResourcePrefix) {
-			continue
-		}
-		if hook.Status == statusActive {
-			_, _, err = client.oktaClient.InlineHook.DeactivateInlineHook(context.Background(), hook.Id)
-			if err != nil {
-				errorList = append(errorList, err)
-			}
-		}
-		_, err = client.oktaClient.InlineHook.DeleteInlineHook(context.Background(), hook.Id)
-		if err != nil {
-			errorList = append(errorList, err)
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaInlineHook_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_link_definition_test.go
+++ b/okta/resource_okta_link_definition_test.go
@@ -3,28 +3,11 @@ package okta
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
-
-func sweepLinkDefinitions(client *testClient) error {
-	var errorList []error
-	linkedObjects, _, err := getOktaClientFromMetadata(testAccProvider.Meta()).LinkedObject.ListLinkedObjectDefinitions(context.Background())
-	if err != nil {
-		return err
-	}
-	for _, object := range linkedObjects {
-		if strings.HasPrefix(object.Primary.Name, testResourcePrefix) {
-			if _, err := getOktaClientFromMetadata(testAccProvider.Meta()).LinkedObject.DeleteLinkedObjectDefinition(context.Background(), object.Primary.Name); err != nil {
-				errorList = append(errorList, err)
-			}
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaLinkDefinition(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_network_zone_test.go
+++ b/okta/resource_okta_network_zone_test.go
@@ -3,29 +3,11 @@ package okta
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
-
-func sweepNetworkZones(client *testClient) error {
-	var errorList []error
-	zones, _, err := client.oktaClient.NetworkZone.ListNetworkZones(context.Background(), &query.Params{Limit: defaultPaginationLimit})
-	if err != nil {
-		return err
-	}
-	for _, zone := range zones {
-		if strings.HasPrefix(zone.Name, testResourcePrefix) {
-			if _, err := client.oktaClient.NetworkZone.DeleteNetworkZone(context.Background(), zone.Id); err != nil {
-				errorList = append(errorList, err)
-			}
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaNetworkZone_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_policy_mfa_test.go
+++ b/okta/resource_okta_policy_mfa_test.go
@@ -6,12 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
-
-func deleteMfaPolicies(client *testClient) error {
-	return deletePolicyByType(sdk.MfaPolicyType, client)
-}
 
 // Note: at least one factor (e.g. `okta_otp`) should be enabled before running this test.
 func TestAccOktaMfaPolicy_crud(t *testing.T) {

--- a/okta/resource_okta_policy_password_test.go
+++ b/okta/resource_okta_policy_password_test.go
@@ -4,38 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
-
-func deletePasswordPolicies(client *testClient) error {
-	return deletePolicyByType(sdk.PasswordPolicyType, client)
-}
-
-func deletePolicyByType(t string, client *testClient) error {
-	ctx := context.Background()
-	policies, _, err := client.oktaClient.Policy.ListPolicies(ctx, &query.Params{Type: t})
-	if err != nil {
-		return fmt.Errorf("failed to list policies in order to properly destroy: %v", err)
-	}
-	for _, _policy := range policies {
-		policy := _policy.(*okta.Policy)
-		if strings.HasPrefix(policy.Name, testResourcePrefix) {
-			_, err = client.oktaClient.Policy.DeletePolicy(ctx, policy.Id)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
 
 func TestAccOktaPolicyPassword_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_policy_rule_idp_discovery_test.go
+++ b/okta/resource_okta_policy_rule_idp_discovery_test.go
@@ -6,12 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
-
-func deletePolicyRuleIdpDiscovery(client *testClient) error {
-	return deletePolicyRulesByType(sdk.IdpDiscoveryType, client)
-}
 
 func TestAccOktaPolicyRuleIdpDiscovery_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_policy_rule_mfa_test.go
+++ b/okta/resource_okta_policy_rule_mfa_test.go
@@ -6,12 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
-
-func deleteMfaPolicyRules(client *testClient) error {
-	return deletePolicyRulesByType(sdk.MfaPolicyType, client)
-}
 
 func TestAccOktaMfaPolicyRule_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_policy_rule_password_test.go
+++ b/okta/resource_okta_policy_rule_password_test.go
@@ -5,46 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 	"github.com/okta/terraform-provider-okta/sdk"
 )
-
-func deletePolicyRulePasswords(client *testClient) error {
-	return deletePolicyRulesByType(sdk.PasswordPolicyType, client)
-}
-
-func deletePolicyRulesByType(ruleType string, client *testClient) error {
-	ctx := context.Background()
-	policies, _, err := client.oktaClient.Policy.ListPolicies(ctx, &query.Params{Type: ruleType})
-	if err != nil {
-		return fmt.Errorf("failed to list policies in order to properly destroy rules: %v", err)
-	}
-	for _, _policy := range policies {
-		policy := _policy.(*okta.Policy)
-		rules, _, err := client.apiSupplement.ListPolicyRules(ctx, policy.Id)
-		if err != nil {
-			return err
-		}
-		// Tests have always used default policy, I don't really think that is necessarily a good idea but
-		// leaving for now, that means we only delete the rules and not the policy, we can keep it around.
-		for i := range rules {
-			if strings.HasPrefix(rules[i].Name, testResourcePrefix) {
-				_, err = client.oktaClient.Policy.DeletePolicyRule(ctx, policy.Id, rules[i].Id)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
 
 func TestAccOktaPolicyRulePassword_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_policy_rule_sign_on_test.go
+++ b/okta/resource_okta_policy_rule_sign_on_test.go
@@ -7,12 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
-
-func deleteSignOnPolicyRules(client *testClient) error {
-	return deletePolicyRulesByType(sdk.SignOnPolicyType, client)
-}
 
 func TestAccOktaPolicyRuleSignon_defaultErrors(t *testing.T) {
 	config := testOktaPolicyRuleSignOnDefaultErrors(acctest.RandInt())

--- a/okta/resource_okta_policy_sign_on_test.go
+++ b/okta/resource_okta_policy_sign_on_test.go
@@ -7,12 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
-
-func deleteSignOnPolicies(client *testClient) error {
-	return deletePolicyByType(sdk.SignOnPolicyType, client)
-}
 
 func TestAccOktaPolicySignOn_defaultError(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_resource_set_test.go
+++ b/okta/resource_okta_resource_set_test.go
@@ -4,28 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
-
-func sweepResourceSets(client *testClient) error {
-	var errorList []error
-	resourceSets, _, err := client.apiSupplement.ListResourceSets(context.Background())
-	if err != nil {
-		return err
-	}
-	for _, b := range resourceSets.ResourceSets {
-		if !strings.HasPrefix(b.Label, "testAcc_") {
-			if _, err := client.apiSupplement.DeleteResourceSet(context.Background(), b.Id); err != nil {
-				errorList = append(errorList, err)
-			}
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaResourceSet(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_user_custom_schema_property_test.go
+++ b/okta/resource_okta_user_custom_schema_property_test.go
@@ -5,37 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
-
-func sweepUserCustomSchema(client *testClient) error {
-	userTypes, _, err := client.oktaClient.UserType.ListUserTypes(context.Background())
-	if err != nil {
-		return err
-	}
-	for _, userType := range userTypes {
-		typeSchemaID := userTypeSchemaID(userType)
-		schema, _, err := client.oktaClient.UserSchema.GetUserSchema(context.Background(), typeSchemaID)
-		if err != nil {
-			return err
-		}
-		for key := range schema.Definitions.Custom.Properties {
-			if strings.HasPrefix(key, testResourcePrefix) {
-				custom := buildCustomUserSchema(key, nil)
-				_, _, err = client.oktaClient.UserSchema.UpdateUserProfile(context.Background(), typeSchemaID, *custom)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
 
 func TestAccResourceOktaUserSchema_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_user_test.go
+++ b/okta/resource_okta_user_test.go
@@ -13,23 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
 )
-
-func sweepUsers(client *testClient) error {
-	var errorList []error
-	users, _, err := client.oktaClient.User.ListUsers(context.Background(), &query.Params{Q: testResourcePrefix})
-	if err != nil {
-		return err
-	}
-
-	for _, u := range users {
-		if err := ensureUserDelete(context.Background(), u.Id, u.Status, client.oktaClient); err != nil {
-			errorList = append(errorList, err)
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaUser_customProfileAttributes(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/resource_okta_user_type_test.go
+++ b/okta/resource_okta_user_type_test.go
@@ -4,26 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
-
-func sweepUserTypes(client *testClient) error {
-	userTypeList, _, _ := client.oktaClient.UserType.ListUserTypes(context.Background())
-	var errorList []error
-	for _, ut := range userTypeList {
-		if strings.HasPrefix(ut.Name, testResourcePrefix) {
-			if _, err := client.oktaClient.UserType.DeleteUserType(context.Background(), ut.Id); err != nil {
-				errorList = append(errorList, err)
-			}
-		}
-	}
-	return condenseError(errorList)
-}
 
 func TestAccOktaUserType_crud(t *testing.T) {
 	ri := acctest.RandInt()

--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -12,6 +12,12 @@ Creates an Authorization Server Policy Rule.
 
 This resource allows you to create and configure an Authorization Server Policy Rule.
 
+-> This resource is concurrency safe. However, when creating/updating/deleting
+multiple rules belonging to a policy, the Terraform meta argument
+[`depends_on`](https://www.terraform.io/language/meta-arguments/depends_on)
+should be added to each rule chaining them all in sequence. Base the sequence on
+the `priority` property in ascending value.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Resolves concurrency bug with resource `okta_auth_server_policy_rule` that can cause 500s. It also resolves correctly maintaining priority order with multiple `okta_auth_server_policy_rule` so long as the meta argument `depends_on` is utilized in each resource.

TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaAuthServerPolicyRule_priority_concurrency_bug$ ./okta 
=== RUN   TestAccOktaAuthServerPolicyRule_priority_concurrency_bug
--- PASS: TestAccOktaAuthServerPolicyRule_priority_concurrency_bug (16.91s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    17.288s

Makes this kind of config operate concurrently, without 500 errors.

```terraform
data "okta_group" "all" {
  name = "Everyone"
}
resource "okta_auth_server" "test" {
  name        = "testAcc_replace_with_uuid"
  description = "test"
  audiences   = ["whatever.rise.zone"]
}
resource "okta_auth_server_policy" "test" {
  name             = "test"
  description      = "test"
  priority         = 1
  client_whitelist = ["ALL_CLIENTS"]
  auth_server_id   = okta_auth_server.test.id
}

resource "okta_auth_server_policy_rule" "test_00" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 00"
  priority             = 1 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  
}
resource "okta_auth_server_policy_rule" "test_01" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 01"
  priority             = 2 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_00]
}
resource "okta_auth_server_policy_rule" "test_02" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 02"
  priority             = 3 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_01]
}
resource "okta_auth_server_policy_rule" "test_03" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 03"
  priority             = 4 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_02]
}
resource "okta_auth_server_policy_rule" "test_04" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 04"
  priority             = 5 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_03]
}
resource "okta_auth_server_policy_rule" "test_05" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 05"
  priority             = 6 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_04]
}
resource "okta_auth_server_policy_rule" "test_06" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 06"
  priority             = 7 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_05]
}
resource "okta_auth_server_policy_rule" "test_07" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 07"
  priority             = 8 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_06]
}
resource "okta_auth_server_policy_rule" "test_08" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 08"
  priority             = 9 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_07]
}
resource "okta_auth_server_policy_rule" "test_09" {
  auth_server_id       = okta_auth_server.test.id
  policy_id            = okta_auth_server_policy.test.id
  status               = "ACTIVE"
  name                 = "Test Policy Rule 09"
  priority             = 10 
  group_whitelist      = [data.okta_group.all.id]
  grant_type_whitelist = ["implicit"]
  depends_on = [okta_auth_server_policy_rule.test_08]
}
```