### PR TITLE
Adding `CHROMEOS` to `os_type` in `platform_include`

### DIFF
--- a/examples/okta_app_signon_policy_rule/basic_updated.tf
+++ b/examples/okta_app_signon_policy_rule/basic_updated.tf
@@ -107,6 +107,10 @@ resource "okta_app_signon_policy_rule" "test" {
     os_type = "WINDOWS"
     type    = "DESKTOP"
   }
+  platform_include {
+    os_type = "CHROMEOS"
+    type    = "DESKTOP"
+  }
   priority                    = 98
   re_authentication_frequency = "PT43800H"
   inactivity_period           = "PT2H"

--- a/okta/resource_okta_app_signon_policy_rule_test.go
+++ b/okta/resource_okta_app_signon_policy_rule_test.go
@@ -62,7 +62,7 @@ func TestAccOktaAppSignOnPolicyRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network_includes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_excludes.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_connection", "ZONE"),
-					resource.TestCheckResourceAttr(resourceName, "platform_include.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "platform_include.#", "5"),
 					resource.TestCheckResourceAttr(resourceName, "re_authentication_frequency", "PT43800H"),
 					resource.TestCheckResourceAttr(resourceName, "inactivity_period", "PT2H"),
 					resource.TestCheckResourceAttr(resourceName, "type", "ASSURANCE"),

--- a/okta/resource_okta_policy_rule_idp_discovery.go
+++ b/okta/resource_okta_policy_rule_idp_discovery.go
@@ -241,7 +241,7 @@ var (
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "ANY",
-				ValidateDiagFunc: elemInSlice([]string{"ANY", "IOS", "WINDOWS", "ANDROID", "OTHER", "OSX", "MACOS"}),
+				ValidateDiagFunc: elemInSlice([]string{"ANY", "IOS", "WINDOWS", "ANDROID", "OTHER", "OSX", "MACOS", "CHROMEOS"}),
 			},
 			"os_expression": {
 				Type:        schema.TypeString,

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 This resource allows you to create and configure a SAML Application.
 
+-> If you receive the error `You do not have permission to access the feature
+you are requesting` [contact support](mailto:dev-inquiries@okta.com) and
+request feature flag `ADVANCED_SSO` be applied to your org.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/policy_rule_idp_discovery.html.markdown
+++ b/website/docs/r/policy_rule_idp_discovery.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 This resource allows you to create and configure an IdP Discovery Policy Rule.
 
+-> If you receive the error `You do not have permission to access the feature
+you are requesting` [contact support](mailto:dev-inquiries@okta.com) and
+request feature flag `ADVANCED_SSO` be applied to your org.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Adding `CHROMEOS` to `os_type` in `platform_include` used by resources `okta_app_signon_policy_rule` and `okta_policy_rule_idp_discovery`. Added note about missing FF causing an error with these resources in their documentation.

Closes #1236