### PR TITLE
prep 3.35.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 3.35.0 (August 25, 2022)
+
+NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:
+
+* Adds customizable Timeouts to resources/data that rely on syncing users and groups to avoid context.DeadlineExceeded
+ [#1207](https://github.com/okta/terraform-provider-okta/pull/1207). Thanks, [@emanor-okta](https://github.com/emanor-okta)!
+  * [Terraform documentation: Resources - Retries and Customizable Timeouts](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts)
+  * Resources: `okta_app_auto_login`, `okta_app_basic_auth`, `okta_app_bookmark`, `okta_app_group_assignment`, `okta_app_oauth`, `okta_app_saml`, `okta_app_secure_password_store`, `okta_app_shared_credentials`, `okta_app_swa`
+
+BUG FIXES:
+
+* Correctly collect network zones in datasource `okta_network_zone` [#1239](https://github.com/okta/terraform-provider-okta/pull/1239). Thanks, [@natmariam](https://github.com/natmariam)!
+* Adding `CHROMEOS` to `os_type` in `platform_include` [#1261](https://github.com/okta/terraform-provider-okta/pull/1261). Thanks, [@monde](https://github.com/monde)!
+* Update okta-sdk-golang that correctly caches OAuth2 access tokens [#1262](https://github.com/okta/terraform-provider-okta/pull/1262). Thanks, [@monde](https://github.com/monde)!
+* Update role types validation on resource `okta_role_subscription` [#1265](https://github.com/okta/terraform-provider-okta/pull/1265). Thanks, [@monde](https://github.com/monde)!
+* Correct pagination to list all email templates on data source `okta_email_templates` [#1266](https://github.com/okta/terraform-provider-okta/pull/1266). Thanks, [@monde](https://github.com/monde)!
+
+PROJECT IMPROVEMENTS:
+
+* Show current version for provider config in documentation [#1256](https://github.com/okta/terraform-provider-okta/pull/1256). Thanks, [@ErelAdoni](https://github.com/ErelAdoni)!
+* Code clean up from go vet and format [#1264](https://github.com/okta/terraform-provider-okta/pull/1264). Thanks, [@monde](https://github.com/monde)!
+
 ## 3.34.0 (August 12, 2022)
 
 BUG FIXES:

--- a/okta/config.go
+++ b/okta/config.go
@@ -111,7 +111,7 @@ func (c *Config) loadAndValidate(ctx context.Context) error {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.34.0"),
+		okta.WithUserAgentExtra("okta-terraform/3.35.0"),
 	}
 
 	switch {

--- a/okta/data_source_okta_app.go
+++ b/okta/data_source_okta_app.go
@@ -90,6 +90,8 @@ func dataSourceAppRead(ctx context.Context, d *schema.ResourceData, m interface{
 		// which could result in multiple matches on the data source's "label"
 		// property.  We need to further inspect for an exact label match.
 		if filters.Label != "" {
+			// guard on nils, an app is always set
+			app = appList[0]
 			for i, _app := range appList {
 				if _app.Label == filters.Label {
 					app = appList[i]

--- a/okta/data_source_okta_app_group_assignments_test.go
+++ b/okta/data_source_okta_app_group_assignments_test.go
@@ -13,7 +13,8 @@ func TestAccOktaDataSourceAppGroupAssignments_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_app_oauth_test.go
+++ b/okta/data_source_okta_app_oauth_test.go
@@ -15,7 +15,8 @@ func TestAccOktaDataSourceAppOauth_read(t *testing.T) {
 	appCreate := buildTestAppOauth(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_app_saml_metadata_test.go
+++ b/okta/data_source_okta_app_saml_metadata_test.go
@@ -14,9 +14,8 @@ func TestAccOktaDataSourceAppMetadataSaml_read(t *testing.T) {
 	resourceName := "data.okta_app_metadata_saml.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_app_saml_test.go
+++ b/okta/data_source_okta_app_saml_test.go
@@ -15,9 +15,8 @@ func TestAccOktaDataSourceAppSaml_read(t *testing.T) {
 	appCreate := buildTestAppSaml(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_app_test.go
+++ b/okta/data_source_okta_app_test.go
@@ -15,9 +15,8 @@ func TestAccOktaDataSourceApp_read(t *testing.T) {
 	appCreate := buildTestApp(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -57,9 +56,8 @@ func TestAccOktaDataSourceAppLabelTest_read(t *testing.T) {
 	config := testLabelConfig(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_app_user_assignments_test.go
+++ b/okta/data_source_okta_app_user_assignments_test.go
@@ -13,7 +13,8 @@ func TestAccOktaDataSourceAppUserAssignments_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_auth_server_claim_test.go
+++ b/okta/data_source_okta_auth_server_claim_test.go
@@ -15,9 +15,8 @@ func TestAccOktaDataSourceAuthServerClaim(t *testing.T) {
 	createUser := mgr.GetFixtures("datasource_create_auth_server.tf", ri, t)
 	resourceName := fmt.Sprintf("data.%s.test", authServerClaim)
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_auth_server_policy_test.go
+++ b/okta/data_source_okta_auth_server_policy_test.go
@@ -14,7 +14,8 @@ func TestAccOktaDataSourceAuthServerPolicy_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 	createServerWithPolicy := buildTestAuthServerWithPolicy(ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_auth_server_scopes_test.go
+++ b/okta/data_source_okta_auth_server_scopes_test.go
@@ -13,7 +13,8 @@ func TestAccOktaDataSourceAuthServerScopes(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_auth_server_test.go
+++ b/okta/data_source_okta_auth_server_test.go
@@ -14,7 +14,8 @@ func TestAccOktaDataSourceAuthServer_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 	authServer := buildTestAuthServer(ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_authenticator_test.go
+++ b/okta/data_source_okta_authenticator_test.go
@@ -16,9 +16,8 @@ func TestAccOktaDataSourceAuthenticator_read(t *testing.T) {
 	resourceName1 := fmt.Sprintf("data.%s.test_1", authenticator)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_brand_test.go
+++ b/okta/data_source_okta_brand_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaBrand_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_brands_test.go
+++ b/okta/data_source_okta_brands_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaBrands_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_default_policy_test.go
+++ b/okta/data_source_okta_default_policy_test.go
@@ -15,9 +15,8 @@ func TestAccOktaDataSourceDefaultPolicy_readPasswordPolicy(t *testing.T) {
 	config := testAccDataSourceDefaultPolicy(ri, sdk.PasswordPolicyType)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -35,9 +34,8 @@ func TestAccOktaDataSourceDefaultPolicy_readIdpPolicy(t *testing.T) {
 	config := testAccDataSourceDefaultPolicy(ri, sdk.IdpDiscoveryType)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_email_customization_test.go
+++ b/okta/data_source_okta_email_customization_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaEmailCustomization_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_email_customizations_test.go
+++ b/okta/data_source_okta_email_customizations_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaEmailCustomizations_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_email_template_test.go
+++ b/okta/data_source_okta_email_template_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaEmailTemplate_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_email_templates_test.go
+++ b/okta/data_source_okta_email_templates_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaEmailTemplates_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_everyone_group_test.go
+++ b/okta/data_source_okta_everyone_group_test.go
@@ -14,9 +14,8 @@ func TestAccOktaDataSourceEveryoneGroup_read(t *testing.T) {
 	config := testAccDataSourceEveryoneGroupConfig(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_group_test.go
+++ b/okta/data_source_okta_group_test.go
@@ -16,9 +16,8 @@ func TestAccOktaDataSourceGroup_read(t *testing.T) {
 	configInvalid := mgr.GetFixtures("datasource_not_found.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_groups_test.go
+++ b/okta/data_source_okta_groups_test.go
@@ -13,7 +13,8 @@ func TestAccOktaDataSourceGroups_read(t *testing.T) {
 	groups := mgr.GetFixtures("okta_groups.tf", ri, t)
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_idp_metadata_saml_test.go
+++ b/okta/data_source_okta_idp_metadata_saml_test.go
@@ -14,9 +14,8 @@ func TestAccOktaDataSourceIdpMetadataSaml_read(t *testing.T) {
 	resourceName := "data.okta_idp_metadata_saml.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_idp_oidc_test.go
+++ b/okta/data_source_okta_idp_oidc_test.go
@@ -13,7 +13,8 @@ func TestAccOktaDataSourceIdpOidc_read(t *testing.T) {
 	idpOidcConfig := mgr.GetFixtures("generic_oidc.tf", ri, t)
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_idp_saml_test.go
+++ b/okta/data_source_okta_idp_saml_test.go
@@ -15,9 +15,8 @@ func TestAccOktaDataSourceIdpSaml_read(t *testing.T) {
 	idpSaml := mgr.GetFixtures("basic.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_idp_social_test.go
+++ b/okta/data_source_okta_idp_social_test.go
@@ -13,9 +13,8 @@ func TestAccOktaDataSourceIdpSocial_read(t *testing.T) {
 	preConfig := mgr.GetFixtures("basic.tf", ri, t)
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_policy_test.go
+++ b/okta/data_source_okta_policy_test.go
@@ -12,9 +12,8 @@ func TestAccOktaDataSourcePolicy_read(t *testing.T) {
 	config := testAccDataSourcePolicyConfig()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_theme_test.go
+++ b/okta/data_source_okta_theme_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaTheme_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_themes_test.go
+++ b/okta/data_source_okta_themes_test.go
@@ -13,7 +13,8 @@ func TestAccDataSourceOktaThemes_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_user_test.go
+++ b/okta/data_source_okta_user_test.go
@@ -18,9 +18,8 @@ func TestAccDataSourceOktaUser_read(t *testing.T) {
 	// NOTE: eliminated previous flapping issues when delay_read_seconds was added to okta_user
 	// TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaDataSourceUser_read$
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -66,9 +65,8 @@ func TestAccDataSourceOktaUser_read(t *testing.T) {
 // TestAccDataSourceOktaUser_SkipAdminRoles pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -85,9 +83,8 @@ func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
 // TestAccDataSourceOktaUser_SkipGroups pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipGroups(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -104,9 +101,8 @@ func TestAccDataSourceOktaUser_SkipGroups(t *testing.T) {
 // TestAccDataSourceOktaUser_SkipGroupsSkipRoles pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipGroupsSkipRoles(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -125,9 +121,8 @@ func TestAccDataSourceOktaUser_NoSkips(t *testing.T) {
 	allAdminRolesRegexp, _ := regexp.Compile("APP_ADMIN, SUPER_ADMIN")
 	allGroupMembershipsRegexp, _ := regexp.Compile("00g[a-z,A-Z,0-9]{17}, 00g[a-z,A-Z,0-9]{17}")
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_user_test.go
+++ b/okta/data_source_okta_user_test.go
@@ -64,13 +64,15 @@ func TestAccDataSourceOktaUser_read(t *testing.T) {
 
 // TestAccDataSourceOktaUser_SkipAdminRoles pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUserRolesGroupsConfig(false, true),
+				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(false, true), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "0"),       // skipped
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "2"), // Everyone, A Group
@@ -82,13 +84,15 @@ func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
 
 // TestAccDataSourceOktaUser_SkipGroups pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipGroups(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUserRolesGroupsConfig(true, false),
+				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(true, false), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "2"),       // SUPER_ADMIN, APP_ADMIN
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "0"), // skipped
@@ -100,13 +104,15 @@ func TestAccDataSourceOktaUser_SkipGroups(t *testing.T) {
 
 // TestAccDataSourceOktaUser_SkipGroupsSkipRoles pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipGroupsSkipRoles(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUserRolesGroupsConfig(true, true),
+				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(true, true), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "0"),       // skipped
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "0"), // skipped
@@ -118,6 +124,8 @@ func TestAccDataSourceOktaUser_SkipGroupsSkipRoles(t *testing.T) {
 
 // TestAccDataSourceOktaUser_NoSkips pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_NoSkips(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	allAdminRolesRegexp, _ := regexp.Compile("APP_ADMIN, SUPER_ADMIN")
 	allGroupMembershipsRegexp, _ := regexp.Compile("00g[a-z,A-Z,0-9]{17}, 00g[a-z,A-Z,0-9]{17}")
 	resource.Test(t, resource.TestCase{
@@ -126,7 +134,7 @@ func TestAccDataSourceOktaUser_NoSkips(t *testing.T) {
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUserRolesGroupsConfig(false, false),
+				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(false, false), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "2"),       // SUPER_ADMIN, APP_ADMIN
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "2"), // Everyone, A Group
@@ -141,11 +149,11 @@ func TestAccDataSourceOktaUser_NoSkips(t *testing.T) {
 func testOktaUserRolesGroupsConfig(skipGroups, skipRoles bool) string {
 	prepend := `
 
-resource "okta_group" "test" {
-  name        = "Example"
+resource "okta_group" "testAcc-replace_with_uuid" {
+  name        = "testAcc-replace_with_uuid"
   description = "A Group"
 }
-resource "okta_user" "test" {
+resource "okta_user" "testAcc-replace_with_uuid" {
   first_name = "TestAcc"
   last_name  = "Smith"
   login      = "testAcc-replace_with_uuid@example.com"
@@ -155,20 +163,20 @@ resource "okta_user" "test" {
   }
 }
 resource "okta_user_admin_roles" "test" {
-  user_id     = okta_user.test.id
+  user_id     = okta_user.testAcc-replace_with_uuid.id
   admin_roles = [
     "SUPER_ADMIN",
     "APP_ADMIN",
   ]
 }
 resource "okta_user_group_memberships" "test" {
-  user_id = okta_user.test.id
+  user_id = okta_user.testAcc-replace_with_uuid.id
   groups = [
-    okta_group.test.id,
+    okta_group.testAcc-replace_with_uuid.id,
   ]
 }
 data "okta_user" "test" {
-  user_id = okta_user.test.id
+  user_id = okta_user.testAcc-replace_with_uuid.id
 `
 
 	var clause string

--- a/okta/data_source_okta_user_type_test.go
+++ b/okta/data_source_okta_user_type_test.go
@@ -16,9 +16,8 @@ func TestAccOktaDataSourceUserType_read(t *testing.T) {
 	config := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/data_source_okta_users_test.go
+++ b/okta/data_source_okta_users_test.go
@@ -126,13 +126,15 @@ func TestAccOktaDataSourceUsers_readWithGroupIdIncludingGroups(t *testing.T) {
 
 // TestAccDataSourceOktaUsers_IncludeNone pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeNone(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUsersRolesGroupsConfig(false, false),
+				Config: mgr.ConfigReplace(testOktaUsersRolesGroupsConfig(false, false), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.#", "1"),
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.0.admin_roles.#", "0"),       // skipped
@@ -147,13 +149,15 @@ func TestAccDataSourceOktaUsers_IncludeNone(t *testing.T) {
 
 // TestAccDataSourceOktaUsers_IncludeGroups pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeGroups(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUsersRolesGroupsConfig(true, false),
+				Config: mgr.ConfigReplace(testOktaUsersRolesGroupsConfig(true, false), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.#", "1"),
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.0.admin_roles.#", "0"),       // skipped
@@ -168,13 +172,15 @@ func TestAccDataSourceOktaUsers_IncludeGroups(t *testing.T) {
 
 // TestAccDataSourceOktaUsers_IncludeRoles pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeRoles(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUsersRolesGroupsConfig(false, true),
+				Config: mgr.ConfigReplace(testOktaUsersRolesGroupsConfig(false, true), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.#", "1"),
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.0.admin_roles.#", "2"),       // SUPER_ADMIN, APP_ADMIN
@@ -189,13 +195,15 @@ func TestAccDataSourceOktaUsers_IncludeRoles(t *testing.T) {
 
 // TestAccDataSourceOktaUsers_IncludeAll pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeAll(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(user)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testOktaUsersRolesGroupsConfig(true, true),
+				Config: mgr.ConfigReplace(testOktaUsersRolesGroupsConfig(true, true), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.#", "1"),
 					resource.TestCheckResourceAttr("data.okta_users.test", "users.0.admin_roles.#", "2"),       // SUPER_ADMIN, APP_ADMIN
@@ -210,11 +218,11 @@ func TestAccDataSourceOktaUsers_IncludeAll(t *testing.T) {
 
 func testOktaUsersRolesGroupsConfig(includeGroups, includeRoles bool) string {
 	prepend := `
-resource "okta_group" "test" {
-  name        = "Example"
+resource "okta_group" "testAcc-replace_with_uuid" {
+  name        = "testAcc-replace_with_uuid"
   description = "A Group"
 }
-resource "okta_user" "test" {
+resource "okta_user" "testAcc-replace_with_uuid" {
   first_name = "TestAcc"
   last_name  = "Smith"
   login      = "testAcc-replace_with_uuid@example.com"
@@ -224,23 +232,23 @@ resource "okta_user" "test" {
   }
 }
 resource "okta_user_admin_roles" "test" {
-  user_id     = okta_user.test.id
+  user_id     = okta_user.testAcc-replace_with_uuid.id
   admin_roles = [
     "SUPER_ADMIN",
     "APP_ADMIN",
   ]
 }
 resource "okta_user_group_memberships" "test" {
-  user_id = okta_user.test.id
+  user_id     = okta_user.testAcc-replace_with_uuid.id
   groups = [
-    okta_group.test.id,
+    okta_group.testAcc-replace_with_uuid.id,
   ]
 }
 data "okta_users" "test" {
   search {
     name = "profile.email"
     comparison = "eq"
-    value = okta_user.test.email
+    value = okta_user.testAcc-replace_with_uuid.email
   }
   
   delay_read_seconds = 2
@@ -256,7 +264,7 @@ data "okta_users" "test" {
 
 	append := `
   depends_on = [
-    okta_user.test,
+    okta_user.testAcc-replace_with_uuid,
     okta_user_admin_roles.test,
     okta_user_group_memberships.test
   ]
@@ -264,7 +272,7 @@ data "okta_users" "test" {
 output "output_admin_roles" {
   value = join(", ", data.okta_users.test.users.0.admin_roles)
   depends_on = [
-    okta_user.test,
+    okta_user.testAcc-replace_with_uuid,
     okta_user_admin_roles.test,
     okta_user_group_memberships.test
   ]
@@ -272,7 +280,7 @@ output "output_admin_roles" {
 output "output_group_memberships" {
   value = join(", ", data.okta_users.test.users.0.group_memberships)
   depends_on = [
-    okta_user.test,
+    okta_user.testAcc-replace_with_uuid,
     okta_user_admin_roles.test,
     okta_user_group_memberships.test
   ]

--- a/okta/data_source_okta_users_test.go
+++ b/okta/data_source_okta_users_test.go
@@ -22,9 +22,8 @@ func TestAccOktaDataSourceUsers_read(t *testing.T) {
 	dataSource := mgr.GetFixtures("datasource.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -64,9 +63,8 @@ func TestAccOktaDataSourceUsers_readWithGroupId(t *testing.T) {
 	config := mgr.GetFixtures("group.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -99,9 +97,8 @@ func TestAccOktaDataSourceUsers_readWithGroupIdIncludingGroups(t *testing.T) {
 	config := mgr.GetFixtures("group_with_groups.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -130,9 +127,8 @@ func TestAccOktaDataSourceUsers_readWithGroupIdIncludingGroups(t *testing.T) {
 // TestAccDataSourceOktaUsers_IncludeNone pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeNone(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -152,9 +148,8 @@ func TestAccDataSourceOktaUsers_IncludeNone(t *testing.T) {
 // TestAccDataSourceOktaUsers_IncludeGroups pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeGroups(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -174,9 +169,8 @@ func TestAccDataSourceOktaUsers_IncludeGroups(t *testing.T) {
 // TestAccDataSourceOktaUsers_IncludeRoles pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeRoles(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
@@ -196,9 +190,8 @@ func TestAccDataSourceOktaUsers_IncludeRoles(t *testing.T) {
 // TestAccDataSourceOktaUsers_IncludeAll pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUsers_IncludeAll(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{

--- a/okta/max_api_capacity_test.go
+++ b/okta/max_api_capacity_test.go
@@ -20,7 +20,8 @@ func TestMaxApiCapacity(t *testing.T) {
 	// hack max api capacity value is enabled by env var
 	os.Setenv("MAX_API_CAPACITY", "50")
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/provider_test.go
+++ b/okta/provider_test.go
@@ -63,10 +63,12 @@ func oktaConfig() (*Config, error) {
 	return config, nil
 }
 
-func testAccPreCheck(t *testing.T) {
-	err := accPreCheck()
-	if err != nil {
-		t.Fatalf("%v", err)
+func testAccPreCheck(t *testing.T) func() {
+	return func() {
+		err := accPreCheck()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	}
 }
 

--- a/okta/resource_okta_admin_role_custom_assignments_test.go
+++ b/okta/resource_okta_admin_role_custom_assignments_test.go
@@ -18,7 +18,8 @@ func TestAccOktaAdminRoleCustomAssignments(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", adminRoleCustomAssignments)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(adminRoleCustomAssignments, doesAdminRoleCustomAssignmentExist),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_admin_role_custom_test.go
+++ b/okta/resource_okta_admin_role_custom_test.go
@@ -17,7 +17,8 @@ func TestAccOktaAdminRoleCustom(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", adminRoleCustom)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(adminRoleCustom, doesAdminRoleCustomExist),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_admin_role_targets_test.go
+++ b/okta/resource_okta_admin_role_targets_test.go
@@ -18,7 +18,8 @@ func TestAccAdminRoleTargets(t *testing.T) {
 	resourceAppName := fmt.Sprintf("%s.test_app", adminRoleTargets)
 	resourceGroupName := fmt.Sprintf("%s.test_group", adminRoleTargets)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(idpOidc, doesTargetExists()),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_auto_login_test.go
+++ b/okta/resource_okta_app_auto_login_test.go
@@ -17,7 +17,8 @@ func TestAccAppAutoLoginApplication_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appAutoLogin)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appAutoLogin, createDoesAppExist(okta.NewAutoLoginApplication())),
 		Steps: []resource.TestStep{
@@ -77,7 +78,8 @@ resource "okta_app_auto_login" "test" {
   }
 }`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appAutoLogin, createDoesAppExist(okta.NewAutoLoginApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_basic_auth_test.go
+++ b/okta/resource_okta_app_basic_auth_test.go
@@ -17,7 +17,8 @@ func TestAccAppBasicAuthApplication_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appBasicAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appBasicAuth, createDoesAppExist(okta.NewBasicAuthApplication())),
 		Steps: []resource.TestStep{
@@ -65,7 +66,8 @@ resource "okta_app_basic_auth" "test" {
   }
 }`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appBasicAuth, createDoesAppExist(okta.NewBasicAuthApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_bookmark_test.go
+++ b/okta/resource_okta_app_bookmark_test.go
@@ -17,7 +17,8 @@ func TestAccAppBookmarkApplication_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appBookmark)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appBookmark, createDoesAppExist(okta.NewBookmarkApplication())),
 		Steps: []resource.TestStep{
@@ -62,7 +63,8 @@ resource "okta_app_bookmark" "test" {
   }
 }`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appBookmark, createDoesAppExist(okta.NewBookmarkApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_group_assignment_test.go
+++ b/okta/resource_okta_app_group_assignment_test.go
@@ -21,7 +21,8 @@ func TestAccAppGroupAssignment_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -104,7 +105,8 @@ func TestAccAppGroupAssignment_retain(t *testing.T) {
 	retainAssignmentDestroy := mgr.GetFixtures("retain_assignment_destroy.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -170,7 +172,8 @@ resource "okta_app_group_assignment" "test" {
 }
 `
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_group_assignments_test.go
+++ b/okta/resource_okta_app_group_assignments_test.go
@@ -22,7 +22,8 @@ func TestAccAppGroupAssignments_crud(t *testing.T) {
 	group3 := fmt.Sprintf("%s.test3", group)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_oauth_api_scope_test.go
+++ b/okta/resource_okta_app_oauth_api_scope_test.go
@@ -23,7 +23,8 @@ func TestAccAppOAuthApplication_apiScope(t *testing.T) {
 	updatedConfig := strings.ReplaceAll(plainUpdatedConfig, "https://your.okta.org", getOktaDomainName())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_oauth_post_logout_redirect_uri_test.go
+++ b/okta/resource_okta_app_oauth_post_logout_redirect_uri_test.go
@@ -44,7 +44,8 @@ func TestAccAppOAuthApplication_postLogoutRedirectCrud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuthPostLogoutRedirectURI)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_oauth_redirect_uri_test.go
+++ b/okta/resource_okta_app_oauth_redirect_uri_test.go
@@ -44,7 +44,8 @@ func TestAccAppOAuthApplication_redirectCrud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuthRedirectURI)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_oauth_test.go
+++ b/okta/resource_okta_app_oauth_test.go
@@ -24,7 +24,8 @@ func TestAccResourceOktaAppOauth_basic(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -96,7 +97,8 @@ func TestAccResourceOktaAppOauth_refreshToken(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -135,7 +137,8 @@ func TestAccResourceOktaAppOauth_serviceNative(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -176,7 +179,8 @@ func TestAccResourceOktaAppOauth_federationBroker(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -214,7 +218,8 @@ func TestAccResourceOktaAppOauth_customProfileAttributes(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -256,7 +261,8 @@ func TestAccResourceOktaAppOauth_customClientID(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -287,7 +293,8 @@ func TestAccResourceOktaAppOauth_customClientIDError(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -307,7 +314,8 @@ func TestAccResourceOktaAppOauth_serviceWithJWKS(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -394,7 +402,8 @@ resource "%s" "test" {
 func TestAccResourceOktaAppOauth_redirect_uris(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -430,7 +439,8 @@ func TestAccResourceOktaAppOauth_groups_claim(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appOAuth)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -487,7 +497,8 @@ resource "okta_app_oauth" "test" {
 }
 `
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_saml_app_settings_test.go
+++ b/okta/resource_okta_app_saml_app_settings_test.go
@@ -21,7 +21,8 @@ func TestAccAppSamlAppSettings_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSamlAppSettings)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_saml_test.go
+++ b/okta/resource_okta_app_saml_test.go
@@ -20,7 +20,8 @@ func TestAccAppSaml_conditionalRequire(t *testing.T) {
 	config := buildTestSamlConfigMissingFields(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{
@@ -38,7 +39,8 @@ func TestAccAppSaml_invalidURL(t *testing.T) {
 	config := buildTestSamlConfigInvalidURL(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{
@@ -60,7 +62,8 @@ func TestAccAppSaml_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSaml)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{
@@ -158,7 +161,8 @@ func TestAccAppSaml_preconfigured(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSaml)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{
@@ -239,7 +243,8 @@ func TestAccAppSaml_userGroups(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSaml)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{
@@ -277,7 +282,8 @@ func TestAccAppSaml_inlineHook(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSaml)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{
@@ -309,7 +315,8 @@ func TestAccAppSaml_federationBroker(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSaml)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
 		Steps: []resource.TestStep{
@@ -395,7 +402,8 @@ resource "okta_app_saml" "test" {
 }
 `
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_secure_password_store_test.go
+++ b/okta/resource_okta_app_secure_password_store_test.go
@@ -17,7 +17,8 @@ func TestAccAppSecurePasswordStoreApplication_credsSchemes(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSecurePasswordStore)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSecurePasswordStore, createDoesAppExist(okta.NewSecurePasswordStoreApplication())),
 		Steps: []resource.TestStep{
@@ -66,7 +67,8 @@ resource "okta_app_secure_password_store" "test" {
   }
 }`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSecurePasswordStore, createDoesAppExist(okta.NewSecurePasswordStoreApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_shared_credentials_test.go
+++ b/okta/resource_okta_app_shared_credentials_test.go
@@ -17,7 +17,8 @@ func TestAccAppSharedCredentials_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSharedCredentials)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSharedCredentials, createDoesAppExist(okta.NewBrowserPluginApplication())),
 		Steps: []resource.TestStep{
@@ -95,7 +96,8 @@ resource "okta_app_shared_credentials" "test" {
   }
 }`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSharedCredentials, createDoesAppExist(okta.NewBrowserPluginApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_signon_policy_rule_test.go
+++ b/okta/resource_okta_app_signon_policy_rule_test.go
@@ -19,7 +19,8 @@ func TestAccOktaAppSignOnPolicyRule(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      appSignOnPolicyRuleExists,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_signon_policy_test.go
+++ b/okta/resource_okta_app_signon_policy_test.go
@@ -17,7 +17,8 @@ func TestAccOktaAppSignOnPolicy_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%v.test", appSignOnPolicy)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createPolicyCheckDestroy(appSignOnPolicy),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_swa_test.go
+++ b/okta/resource_okta_app_swa_test.go
@@ -18,7 +18,8 @@ func TestAccAppSwaApplication_preconfig(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSwa)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSwa, createDoesAppExist(okta.NewSwaApplication())),
 		Steps: []resource.TestStep{
@@ -53,7 +54,8 @@ func TestAccAppSwaApplication_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSwa)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSwa, createDoesAppExist(okta.NewSwaApplication())),
 		Steps: []resource.TestStep{
@@ -102,7 +104,8 @@ resource "okta_app_swa" "test" {
   }
 }`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appSwa, createDoesAppExist(okta.NewSwaApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_three_field_test.go
+++ b/okta/resource_okta_app_three_field_test.go
@@ -18,7 +18,8 @@ func TestAccAppThreeFieldApplication_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appThreeField)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appThreeField, createDoesAppExist(okta.NewSwaThreeFieldApplication())),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_user_base_schema_property_test.go
+++ b/okta/resource_okta_app_user_base_schema_property_test.go
@@ -17,7 +17,8 @@ func TestAccAppUserBaseSchema_change(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appUserBaseSchemaProperty)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		// Just need to make sure the app gets cleaned up
 		CheckDestroy: createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),

--- a/okta/resource_okta_app_user_custom_schema_property_test.go
+++ b/okta/resource_okta_app_user_custom_schema_property_test.go
@@ -20,7 +20,8 @@ func TestAccAppUserSchemas_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appUserSchemaProperty)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(appUserSchemaProperty, testAppUserSchemaExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_app_user_test.go
+++ b/okta/resource_okta_app_user_test.go
@@ -20,7 +20,8 @@ func TestAccOktaAppUser_crud(t *testing.T) {
 	basicProfile := mgr.GetFixtures("basic_profile.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkAppUserDestroy,
 		Steps: []resource.TestStep{
@@ -88,7 +89,8 @@ func TestAccOktaAppUser_retain(t *testing.T) {
 	retainDestroy := mgr.GetFixtures("retain_destroy.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkAppUserDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_auth_server_claim_default_test.go
+++ b/okta/resource_okta_auth_server_claim_default_test.go
@@ -15,7 +15,8 @@ func TestAccOktaAuthServerClaimDefault(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	updated := mgr.GetFixtures("updated.tf", ri, t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_auth_server_claim_test.go
+++ b/okta/resource_okta_auth_server_claim_test.go
@@ -16,7 +16,8 @@ func TestAccOktaAuthServerClaim_create(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{
@@ -52,7 +53,8 @@ func TestAccOktaAuthServerClaim_groupType(t *testing.T) {
 	config := mgr.GetFixtures("basic_group.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_auth_server_policy_rule_test.go
+++ b/okta/resource_okta_auth_server_policy_rule_test.go
@@ -17,7 +17,8 @@ func TestAccOktaAuthServerPolicyRule_create(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{
@@ -73,7 +74,8 @@ resource "okta_auth_server_policy" "test" {
 	mgr := newFixtureManager(authServerPolicyRule)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_auth_server_policy_test.go
+++ b/okta/resource_okta_auth_server_policy_test.go
@@ -16,7 +16,8 @@ func TestAccOktaAuthServerPolicy_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_auth_server_scope_test.go
+++ b/okta/resource_okta_auth_server_scope_test.go
@@ -20,7 +20,8 @@ func TestAccOktaAuthServerScope_crud(t *testing.T) {
 	importConfig := mgr.GetFixtures("import.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_auth_server_test.go
+++ b/okta/resource_okta_auth_server_test.go
@@ -27,7 +27,8 @@ func TestAccOktaAuthServer_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{
@@ -68,7 +69,8 @@ func TestAccOktaAuthServer_fullStack(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("full_stack_with_client.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{
@@ -116,7 +118,8 @@ func TestAccOktaAuthServer_gh299(t *testing.T) {
 	config := mgr.GetFixtures("dependency.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(authServer, authServerExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_authenticator_test.go
+++ b/okta/resource_okta_authenticator_test.go
@@ -17,7 +17,8 @@ func TestAccOktaAuthenticator_crud(t *testing.T) {
 	configUpdated := mgr.GetFixtures("security_question_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_behavior_test.go
+++ b/okta/resource_okta_behavior_test.go
@@ -18,7 +18,8 @@ func TestAccOktaBehavior(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", behavior)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(behavior, doesBehaviorExist),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_brand_test.go
+++ b/okta/resource_okta_brand_test.go
@@ -19,7 +19,8 @@ func TestAccResourceOktaBrand_import_update(t *testing.T) {
 
 	// okta_brand is read and update only, so set up the test by importing the brand first
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy: func(s *terraform.State) error {
 			// brand api doens't have real delete for a brand

--- a/okta/resource_okta_capcha_org_wide_settings_test.go
+++ b/okta/resource_okta_capcha_org_wide_settings_test.go
@@ -18,7 +18,8 @@ func TestAccOktaCaptchaOrgWideSettings(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", captchaOrgWideSettings)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(captchaOrgWideSettings, doesCaptchaOrgWideSettingsExist),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_capcha_test.go
+++ b/okta/resource_okta_capcha_test.go
@@ -17,7 +17,8 @@ func TestAccOktaCaptcha(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", captcha)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(captcha, doesCaptchaExist),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_default_auth_server_test.go
+++ b/okta/resource_okta_default_auth_server_test.go
@@ -16,7 +16,8 @@ func TestAccOktaAuthServerDefault_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_domain_test.go
+++ b/okta/resource_okta_domain_test.go
@@ -16,7 +16,8 @@ func TestAccOktaDomain(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", domain)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(domain, domainExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_email_customization_test.go
+++ b/okta/resource_okta_email_customization_test.go
@@ -18,7 +18,8 @@ func TestAccResourceOktaEmailCustomization_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceEmailCustomizationDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_email_sender_test.go
+++ b/okta/resource_okta_email_sender_test.go
@@ -17,7 +17,8 @@ func TestAccOktaEmailSender(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", emailSender)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(emailSender, emailSenderExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_event_hook_test.go
+++ b/okta/resource_okta_event_hook_test.go
@@ -22,7 +22,8 @@ func TestAccOktaEventHook_crud(t *testing.T) {
 	activatedConfig := mgr.GetFixtures("basic_activated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(eventHook, eventHookExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_factor_totp_test.go
+++ b/okta/resource_okta_factor_totp_test.go
@@ -15,7 +15,8 @@ func TestAccOktaFactorTOTP(t *testing.T) {
 	mgr := newFixtureManager(factorTotp)
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(factorTotp, doesFactorTOTPExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_group_custom_schema_property_test.go
+++ b/okta/resource_okta_group_custom_schema_property_test.go
@@ -21,7 +21,8 @@ func TestAccOktaGroupSchema_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -96,7 +97,8 @@ func TestAccOktaGroupSchema_arrayString(t *testing.T) {
 	arrayEnum := mgr.GetFixtures("array_enum.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -205,7 +207,8 @@ func TestAccResourceOktaGroupSchema_array_enum_number(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -296,7 +299,8 @@ func TestAccResourceOktaGroupSchema_enum_number(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -383,7 +387,8 @@ func TestAccResourceOktaGroupSchema_array_enum_integer(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -474,7 +479,8 @@ func TestAccResourceOktaGroupSchema_enum_integer(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -563,7 +569,8 @@ func TestAccResourceOktaGroupSchema_array_enum_boolean(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -642,7 +649,8 @@ func TestAccResourceOktaGroupSchema_enum_boolean(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -715,7 +723,8 @@ func TestAccResourceOktaGroupSchema_array_enum_string(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -806,7 +815,8 @@ func TestAccResourceOktaGroupSchema_enum_string(t *testing.T) {
 	mgr := newFixtureManager(groupSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", groupSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaGroupSchemasDestroy(),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_group_membership_test.go
+++ b/okta/resource_okta_group_membership_test.go
@@ -19,7 +19,8 @@ func TestAccOktaGroupMembership_crud(t *testing.T) {
 	removedConfig := mgr.GetFixtures("okta_group_membership_removed.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(groupMembership, checkMembershipState),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_group_memberships_test.go
+++ b/okta/resource_okta_group_memberships_test.go
@@ -19,7 +19,8 @@ func TestAccResourceOktaGroupMemberships_crud(t *testing.T) {
 	remove := mgr.GetFixtures("basic_removal.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -39,7 +40,8 @@ func TestAccResourceOktaGroupMemberships_crud(t *testing.T) {
 // TestAccResourceOktaGroupMemberships_Issue1072 addresses https://github.com/okta/terraform-provider-okta/issues/1072
 func TestAccResourceOktaGroupMemberships_Issue1072(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -69,7 +71,8 @@ resource "okta_group_memberships" "test" {
 // https://github.com/okta/terraform-provider-okta/issues/1155
 func TestAccResourceOktaGroupMemberships_ClassicBehavior(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +111,8 @@ func TestAccResourceOktaGroupMemberships_ClassicBehavior(t *testing.T) {
 // https://github.com/okta/terraform-provider-okta/issues/1155
 func TestAccResourceOktaGroupMemberships_TrackAllUsersBehavior(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -269,7 +273,8 @@ resource "okta_group" "test" {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_group_role_test.go
+++ b/okta/resource_okta_group_role_test.go
@@ -19,7 +19,8 @@ func TestAccOktaGroupAdminRole_crud(t *testing.T) {
 	groupTargetsRemoved := mgr.GetFixtures("group_targets_removed.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(group, doesGroupExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_group_roles_test.go
+++ b/okta/resource_okta_group_roles_test.go
@@ -16,7 +16,8 @@ func TestAccOktaGroupAdminRoles_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("all_roles.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(group, doesGroupExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_group_rule_test.go
+++ b/okta/resource_okta_group_rule_test.go
@@ -23,7 +23,8 @@ func TestAccOktaGroupRule_crud(t *testing.T) {
 	name2 := buildResourceName(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(groupRule, doesGroupRuleExist),
 		Steps: []resource.TestStep{
@@ -73,9 +74,8 @@ func TestAccOktaGroupRule_invalidHandle(t *testing.T) {
 	testUpdate := buildInvalidUpdate(testName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(groupRule, doesGroupRuleExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_group_test.go
+++ b/okta/resource_okta_group_test.go
@@ -19,7 +19,8 @@ func TestAccOktaGroup_crud(t *testing.T) {
 	addUsersConfig := mgr.GetFixtures("okta_group_with_users.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(group, doesGroupExist),
 		Steps: []resource.TestStep{
@@ -53,7 +54,8 @@ func TestAccOktaGroup_customschema(t *testing.T) {
 	removal := mgr.GetFixtures("okta_group_custom_removal.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(group, doesGroupExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_idp_oidc_test.go
+++ b/okta/resource_okta_idp_oidc_test.go
@@ -16,7 +16,8 @@ func TestAccOktaIdpOidc_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", idpOidc)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(idpOidc, createDoesIdpExist()),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_idp_saml_test.go
+++ b/okta/resource_okta_idp_saml_test.go
@@ -16,7 +16,8 @@ func TestAccOktaIdpSaml_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", idpSaml)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(idpSaml, createDoesIdpExist()),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_idp_social_test.go
+++ b/okta/resource_okta_idp_social_test.go
@@ -18,7 +18,8 @@ func TestAccOktaIdpSocial_crud(t *testing.T) {
 	googleName := fmt.Sprintf("%s.google", idpSocial)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(idpSocial, createDoesIdpExist()),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_inline_hooks_test.go
+++ b/okta/resource_okta_inline_hooks_test.go
@@ -20,7 +20,8 @@ func TestAccOktaInlineHook_crud(t *testing.T) {
 	passwordImport := mgr.GetFixtures("password_import.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(inlineHook, inlineHookExists),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_link_definition_test.go
+++ b/okta/resource_okta_link_definition_test.go
@@ -15,7 +15,8 @@ func TestAccOktaLinkDefinition(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", linkDefinition)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(linkDefinition, doesLinkDefinitionExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_link_value_test.go
+++ b/okta/resource_okta_link_value_test.go
@@ -18,7 +18,8 @@ func TestAccOktaLinkValue(t *testing.T) {
 	updated := mgr.GetFixtures("updated.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", linkValue)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkLinkValueDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_network_zone_test.go
+++ b/okta/resource_okta_network_zone_test.go
@@ -18,7 +18,8 @@ func TestAccOktaNetworkZone_crud(t *testing.T) {
 	dynamicResourceName := fmt.Sprintf("%s.dynamic_network_zone_example", networkZone)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(networkZone, doesNetworkZoneExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_org_configuration_test.go
+++ b/okta/resource_okta_org_configuration_test.go
@@ -17,7 +17,8 @@ func TestAccOktaOrgConfiguration(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("standard_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_org_support_test.go
+++ b/okta/resource_okta_org_support_test.go
@@ -19,7 +19,8 @@ func TestAccOktaOrgSupport(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("extended.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkSupportDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_mfa_default_test.go
+++ b/okta/resource_okta_policy_mfa_default_test.go
@@ -16,7 +16,8 @@ func TestAccOktaDefaultMFAPolicy(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyMfaDefault)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_mfa_test.go
+++ b/okta/resource_okta_policy_mfa_test.go
@@ -17,7 +17,8 @@ func TestAccOktaMfaPolicy_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyMfa)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createPolicyCheckDestroy(policyMfa),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_password_default_test.go
+++ b/okta/resource_okta_policy_password_default_test.go
@@ -16,7 +16,8 @@ func TestAccOktaDefaultPasswordPolicy(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyPasswordDefault)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_password_test.go
+++ b/okta/resource_okta_policy_password_test.go
@@ -19,7 +19,8 @@ func TestAccOktaPolicyPassword_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyPassword)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createPolicyCheckDestroy(policyPassword),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_profile_enrollment_apps_test.go
+++ b/okta/resource_okta_policy_profile_enrollment_apps_test.go
@@ -16,7 +16,8 @@ func TestAccOktaPolicyProfileEnrollmentApps(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyProfileEnrollmentApps)
 	resourceName2 := fmt.Sprintf("%s.test_2", policyProfileEnrollmentApps)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_profile_enrollment_test.go
+++ b/okta/resource_okta_policy_profile_enrollment_test.go
@@ -15,7 +15,8 @@ func TestAccOktaPolicyProfileEnrollment(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", policyProfileEnrollment)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createPolicyCheckDestroy(policyProfileEnrollment),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_rule_idp_discovery_test.go
+++ b/okta/resource_okta_policy_rule_idp_discovery_test.go
@@ -20,7 +20,8 @@ func TestAccOktaPolicyRuleIdpDiscovery_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyRuleIdpDiscovery)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRuleIdpDiscovery),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_rule_mfa_test.go
+++ b/okta/resource_okta_policy_rule_mfa_test.go
@@ -16,7 +16,8 @@ func TestAccOktaMfaPolicyRule_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyRuleMfa)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRuleMfa),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_rule_password_test.go
+++ b/okta/resource_okta_policy_rule_password_test.go
@@ -20,7 +20,8 @@ func TestAccOktaPolicyRulePassword_crud(t *testing.T) {
 	resourceName := buildResourceFQN(policyRulePassword, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRulePassword),
 		Steps: []resource.TestStep{
@@ -53,7 +54,8 @@ func TestAccOktaPolicyRulePassword_priorityError(t *testing.T) {
 	config := testOktaPolicyRulePriorityError(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRulePassword),
 		Steps: []resource.TestStep{
@@ -73,7 +75,8 @@ func TestAccOktaPolicyRulePassword_priority(t *testing.T) {
 	name := buildResourceName(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRulePassword),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_rule_profile_enrollment_test.go
+++ b/okta/resource_okta_policy_rule_profile_enrollment_test.go
@@ -15,7 +15,8 @@ func TestAccOktaPolicyRuleProfileEnrollment(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", policyRuleProfileEnrollment)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRuleProfileEnrollment),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_rule_sign_on_test.go
+++ b/okta/resource_okta_policy_rule_sign_on_test.go
@@ -13,7 +13,8 @@ func TestAccOktaPolicyRuleSignon_defaultErrors(t *testing.T) {
 	config := testOktaPolicyRuleSignOnDefaultErrors(acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRuleSignOn),
 		Steps: []resource.TestStep{
@@ -37,7 +38,8 @@ func TestAccOktaPolicyRuleSignon_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policyRuleSignOn)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createRuleCheckDestroy(policyRuleSignOn),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_policy_sign_on_test.go
+++ b/okta/resource_okta_policy_sign_on_test.go
@@ -14,7 +14,8 @@ func TestAccOktaPolicySignOn_defaultError(t *testing.T) {
 	config := testOktaPolicySignOnDefaultErrors(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createPolicyCheckDestroy(policySignOn),
 		Steps: []resource.TestStep{
@@ -35,7 +36,8 @@ func TestAccOktaPolicySignOn_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", policySignOn)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createPolicyCheckDestroy(policySignOn),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_profile_mapping_test.go
+++ b/okta/resource_okta_profile_mapping_test.go
@@ -18,7 +18,8 @@ func TestAccOktaProfileMapping_crud(t *testing.T) {
 	preventDelete := mgr.GetFixtures("prevent_delete.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(profileMapping, doesOktaProfileExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_rate_limiting_test.go
+++ b/okta/resource_okta_rate_limiting_test.go
@@ -15,7 +15,8 @@ func TestAccOktaRateLimiting_crud(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_resource_set_test.go
+++ b/okta/resource_okta_resource_set_test.go
@@ -18,7 +18,8 @@ func TestAccOktaResourceSet(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", resourceSet)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(resourceSet, doesResourceSetExist),
 			Steps: []resource.TestStep{
@@ -80,7 +81,8 @@ func TestAccResrouceOktaResourceSet_Issue1097_Pagination(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", resourceSet)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createCheckResourceDestroy(resourceSet, doesResourceSetExist),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_role_subscription_test.go
+++ b/okta/resource_okta_role_subscription_test.go
@@ -15,7 +15,8 @@ func TestAccOktaRoleSubscription_crud(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_template_email_test.go
+++ b/okta/resource_okta_template_email_test.go
@@ -16,7 +16,8 @@ func TestAccOktaEmailTemplate_crud(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(templateEmail, doesEmailTemplateExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_template_sms_test.go
+++ b/okta/resource_okta_template_sms_test.go
@@ -17,7 +17,8 @@ func TestAccOktaSmsTemplate_crud(t *testing.T) {
 	updated := mgr.GetFixtures("updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(templateSms, doesSmsTemplateExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_theme_test.go
+++ b/okta/resource_okta_theme_test.go
@@ -20,7 +20,8 @@ func TestAccResourceOktaTheme_import_update(t *testing.T) {
 
 	// okta_theme is read and update only, so set up the test by importing the theme first
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy: func(s *terraform.State) error {
 			// theme api doens't have real delete for a theme

--- a/okta/resource_okta_threat_insight_settings_test.go
+++ b/okta/resource_okta_threat_insight_settings_test.go
@@ -19,7 +19,8 @@ func TestAccThreatInsightSettings(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", threatInsightSettings)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaThreatInsightSettingsDestroy(),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_trusted_origin_test.go
+++ b/okta/resource_okta_trusted_origin_test.go
@@ -18,7 +18,8 @@ func TestAccOktaTrustedOrigin_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.testAcc_%d", trustedOrigin, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckTrustedOriginDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_user_admin_roles_test.go
+++ b/okta/resource_okta_user_admin_roles_test.go
@@ -18,7 +18,8 @@ func TestAccOktaUserAdminRoles_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", userAdminRoles)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_user_base_schema_property_test.go
+++ b/okta/resource_okta_user_base_schema_property_test.go
@@ -24,7 +24,8 @@ func TestAccOktaUserBaseSchema_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.%s", userBaseSchemaProperty, firstNameTestProp)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil, // can't delete base properties
 		Steps: []resource.TestStep{
@@ -82,7 +83,8 @@ func TestAccOktaUserBaseSchemaLogin_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.%s", userBaseSchemaProperty, loginTestProp)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      nil, // can't delete base properties
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_user_custom_schema_property_test.go
+++ b/okta/resource_okta_user_custom_schema_property_test.go
@@ -22,7 +22,8 @@ func TestAccResourceOktaUserSchema_crud(t *testing.T) {
 	resourceName := buildResourceFQN(userSchemaProperty, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -120,7 +121,8 @@ func TestAccResourceOktaUserSchema_array_enum(t *testing.T) {
 	arrayNumber := mgr.GetFixtures("array_number.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -224,7 +226,8 @@ func TestAccResourceOktaUserSchema_array_enum_number(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -315,7 +318,8 @@ func TestAccResourceOktaUserSchema_enum_number(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -402,7 +406,8 @@ func TestAccResourceOktaUserSchema_array_enum_integer(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -493,7 +498,8 @@ func TestAccResourceOktaUserSchema_enum_integer(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -582,7 +588,8 @@ func TestAccResourceOktaUserSchema_array_enum_boolean(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -661,7 +668,8 @@ func TestAccResourceOktaUserSchema_enum_boolean(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -734,7 +742,8 @@ func TestAccResourceOktaUserSchema_array_enum_string(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{
@@ -825,7 +834,8 @@ func TestAccResourceOktaUserSchema_enum_string(t *testing.T) {
 	mgr := newFixtureManager(userSchemaProperty)
 	resourceName := fmt.Sprintf("%s.test", userSchemaProperty)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaUserSchemasDestroy(),
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_user_factor_question_test.go
+++ b/okta/resource_okta_user_factor_question_test.go
@@ -19,7 +19,8 @@ func TestAccOktaUserFactorQuestion_crud(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", userFactorQuestion)
 	resource.Test(
 		t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        testAccErrorChecks(t),
 			ProviderFactories: testAccProvidersFactories,
 			CheckDestroy:      createUserFactorCheckDestroy(userFactorQuestion),
 			Steps: []resource.TestStep{

--- a/okta/resource_okta_user_group_memberships_test.go
+++ b/okta/resource_okta_user_group_memberships_test.go
@@ -16,7 +16,8 @@ func TestAccOktaUserGroupMemberships_crud(t *testing.T) {
 	remove := mgr.GetFixtures("basic_removal.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_user_test.go
+++ b/okta/resource_okta_user_test.go
@@ -26,7 +26,8 @@ func TestAccOktaUser_customProfileAttributes(t *testing.T) {
 	email := fmt.Sprintf("testAcc-%d@example.com", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -94,7 +95,8 @@ func TestAccOktaUser_groupMembership(t *testing.T) {
 	email := fmt.Sprintf("testAcc-%d@example.com", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -136,7 +138,8 @@ func TestAccOktaUser_invalidCustomProfileAttribute(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -158,7 +161,8 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 	email := fmt.Sprintf("testAcc-%d@example.com", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -230,7 +234,8 @@ func TestAccOktaUser_updateCredentials(t *testing.T) {
 	email := fmt.Sprintf("testAcc-%d@example.com", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -281,7 +286,8 @@ func TestAccOktaUser_statusDeprovisioned(t *testing.T) {
 	email := fmt.Sprintf("testAcc-%d@example.com", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -311,7 +317,8 @@ func TestAccOktaUserHashedPassword(t *testing.T) {
 	email := fmt.Sprintf("testAcc-%d@example.com", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -347,7 +354,8 @@ func TestAccOktaUser_updateDeprovisioned(t *testing.T) {
 	config := mgr.GetFixtures("deprovisioned.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{
@@ -373,7 +381,8 @@ func TestAccOktaUser_loginUpdates(t *testing.T) {
 	updatedEmail := fmt.Sprintf("testAccUpdated-%d@example.com", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      testAccCheckUserDestroy,
 		Steps: []resource.TestStep{

--- a/okta/resource_okta_user_type_test.go
+++ b/okta/resource_okta_user_type_test.go
@@ -19,7 +19,8 @@ func TestAccOktaUserType_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("okta_user_type_updated.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      createCheckResourceDestroy(userType, doesUserTypeExist),
 		Steps: []resource.TestStep{

--- a/okta/resource_security_notification_emails_test.go
+++ b/okta/resource_security_notification_emails_test.go
@@ -19,7 +19,8 @@ func TestAccSecurityNotificationEmails(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", securityNotificationEmails)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
 		ProviderFactories: testAccProvidersFactories,
 		CheckDestroy:      checkOktaSecurityNotificationEmailsDestroy(),
 		Steps: []resource.TestStep{

--- a/okta/utils_for_test.go
+++ b/okta/utils_for_test.go
@@ -105,6 +105,13 @@ func newTestOktaClientWithResponse(response roundTripFunc) (context.Context, *ok
 }
 
 const ErrorCheckMissingPermission = "You do not have permission to access the feature you are requesting"
+const ErrorCheckCannotCreateSWA = "Cannot create application instance template_swa."
+const ErrorCheckCannotCreateBasicAuth = "Cannot create application instance template_basic_auth."
+const ErrorCheckCannotCreateSPS = "Cannot create application instance template_sps."
+const ErrorCheckCannotCreateAWSConole = "Cannot create application instance aws_console."
+const ErrorCheckCannotCreateSWAThreeField = "Cannot create application instance template_swa3field."
+const ErrorCheckFFGroupMembershipRules = "GROUP_MEMBERSHIP_RULES is not enabled."
+const ErrorCheckFFMFAPolicy = "Invalid policy type specified. Missing Required Feature Flag OKTA_MFA_POLICY"
 
 // testAccErrorChecks Ability to skip tests that have specific errors.
 func testAccErrorChecks(t *testing.T) resource.ErrorCheckFunc {
@@ -113,6 +120,27 @@ func testAccErrorChecks(t *testing.T) resource.ErrorCheckFunc {
 			return nil
 		}
 		if err = errorCheckSkipMessagesContaining(t, ErrorCheckMissingPermission)(err); err != nil {
+			return err
+		}
+		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateSWA)(err); err != nil {
+			return err
+		}
+		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateBasicAuth)(err); err != nil {
+			return err
+		}
+		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateSPS)(err); err != nil {
+			return err
+		}
+		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateAWSConole)(err); err != nil {
+			return err
+		}
+		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateSWAThreeField)(err); err != nil {
+			return err
+		}
+		if err = errorCheckSkipMessagesContaining(t, ErrorCheckFFGroupMembershipRules)(err); err != nil {
+			return err
+		}
+		if err = errorCheckSkipMessagesContaining(t, ErrorCheckFFMFAPolicy)(err); err != nil {
 			return err
 		}
 
@@ -132,6 +160,27 @@ func errorCheckSkipMessagesContaining(t *testing.T, messages ...string) resource
 			missingFlags := []string{}
 			if message == ErrorCheckMissingPermission {
 				missingFlags = append(missingFlags, "ADVANCED_SSO")
+			}
+			if message == ErrorCheckCannotCreateSWA {
+				missingFlags = append(missingFlags, "ALLOW_SWA")
+			}
+			if message == ErrorCheckCannotCreateBasicAuth {
+				missingFlags = append(missingFlags, "ALLOW_SWA")
+			}
+			if message == ErrorCheckCannotCreateSPS {
+				missingFlags = append(missingFlags, "ALLOW_SWA")
+			}
+			if message == ErrorCheckCannotCreateAWSConole {
+				missingFlags = append(missingFlags, "ALLOW_SWA")
+			}
+			if message == ErrorCheckCannotCreateSWAThreeField {
+				missingFlags = append(missingFlags, "ALLOW_SWA")
+			}
+			if message == ErrorCheckFFGroupMembershipRules {
+				missingFlags = append(missingFlags, "GROUP_MEMBERSHIP_RULES")
+			}
+			if message == ErrorCheckFFMFAPolicy {
+				missingFlags = append(missingFlags, "OKTA_MFA_POLICY")
 			}
 			if strings.Contains(errorMessage, message) {
 				t.Skipf("Skipping test for:\n%sOrg possibly missing flags %+v", errorMessage, missingFlags)

--- a/okta/utils_for_test.go
+++ b/okta/utils_for_test.go
@@ -104,14 +104,16 @@ func newTestOktaClientWithResponse(response roundTripFunc) (context.Context, *ok
 	return oktaCtx, c, nil
 }
 
-const ErrorCheckMissingPermission = "You do not have permission to access the feature you are requesting"
-const ErrorCheckCannotCreateSWA = "Cannot create application instance template_swa."
-const ErrorCheckCannotCreateBasicAuth = "Cannot create application instance template_basic_auth."
-const ErrorCheckCannotCreateSPS = "Cannot create application instance template_sps."
-const ErrorCheckCannotCreateAWSConole = "Cannot create application instance aws_console."
-const ErrorCheckCannotCreateSWAThreeField = "Cannot create application instance template_swa3field."
-const ErrorCheckFFGroupMembershipRules = "GROUP_MEMBERSHIP_RULES is not enabled."
-const ErrorCheckFFMFAPolicy = "Invalid policy type specified. Missing Required Feature Flag OKTA_MFA_POLICY"
+const (
+	ErrorCheckMissingPermission         = "You do not have permission to access the feature you are requesting"
+	ErrorCheckCannotCreateSWA           = "Cannot create application instance template_swa"
+	ErrorCheckCannotCreateBasicAuth     = "Cannot create application instance template_basic_auth"
+	ErrorCheckCannotCreateSPS           = "Cannot create application instance template_sps"
+	ErrorCheckCannotCreateAWSConole     = "Cannot create application instance aws_console"
+	ErrorCheckCannotCreateSWAThreeField = "Cannot create application instance template_swa3field"
+	ErrorCheckFFGroupMembershipRules    = "GROUP_MEMBERSHIP_RULES is not enabled"
+	ErrorCheckFFMFAPolicy               = "Missing Required Feature Flag OKTA_MFA_POLICY"
+)
 
 // testAccErrorChecks Ability to skip tests that have specific errors.
 func testAccErrorChecks(t *testing.T) resource.ErrorCheckFunc {
@@ -119,28 +121,31 @@ func testAccErrorChecks(t *testing.T) resource.ErrorCheckFunc {
 		if err == nil {
 			return nil
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckMissingPermission)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckMissingPermission, err) {
 			return err
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateSWA)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckMissingPermission, err) {
 			return err
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateBasicAuth)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckCannotCreateSWA, err) {
 			return err
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateSPS)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckCannotCreateBasicAuth, err) {
 			return err
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateAWSConole)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckCannotCreateSPS, err) {
 			return err
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckCannotCreateSWAThreeField)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckCannotCreateAWSConole, err) {
 			return err
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckFFGroupMembershipRules)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckCannotCreateSWAThreeField, err) {
 			return err
 		}
-		if err = errorCheckSkipMessagesContaining(t, ErrorCheckFFMFAPolicy)(err); err != nil {
+		if errorCheckMessageContaining(t, ErrorCheckFFGroupMembershipRules, err) {
+			return err
+		}
+		if errorCheckMessageContaining(t, ErrorCheckFFMFAPolicy, err) {
 			return err
 		}
 
@@ -148,45 +153,41 @@ func testAccErrorChecks(t *testing.T) resource.ErrorCheckFunc {
 	}
 }
 
-// errorCheckSkipMessagesContaining skips tests based on error messages that indicate unsupported features
-func errorCheckSkipMessagesContaining(t *testing.T, messages ...string) resource.ErrorCheckFunc {
-	return func(err error) error {
-		if err == nil {
-			return nil
-		}
-
-		for _, message := range messages {
-			errorMessage := err.Error()
-			missingFlags := []string{}
-			if message == ErrorCheckMissingPermission {
-				missingFlags = append(missingFlags, "ADVANCED_SSO")
-			}
-			if message == ErrorCheckCannotCreateSWA {
-				missingFlags = append(missingFlags, "ALLOW_SWA")
-			}
-			if message == ErrorCheckCannotCreateBasicAuth {
-				missingFlags = append(missingFlags, "ALLOW_SWA")
-			}
-			if message == ErrorCheckCannotCreateSPS {
-				missingFlags = append(missingFlags, "ALLOW_SWA")
-			}
-			if message == ErrorCheckCannotCreateAWSConole {
-				missingFlags = append(missingFlags, "ALLOW_SWA")
-			}
-			if message == ErrorCheckCannotCreateSWAThreeField {
-				missingFlags = append(missingFlags, "ALLOW_SWA")
-			}
-			if message == ErrorCheckFFGroupMembershipRules {
-				missingFlags = append(missingFlags, "GROUP_MEMBERSHIP_RULES")
-			}
-			if message == ErrorCheckFFMFAPolicy {
-				missingFlags = append(missingFlags, "OKTA_MFA_POLICY")
-			}
-			if strings.Contains(errorMessage, message) {
-				t.Skipf("Skipping test for:\n%sOrg possibly missing flags %+v", errorMessage, missingFlags)
-			}
-		}
-
-		return err
+func errorCheckMessageContaining(t *testing.T, message string, err error) bool {
+	if err == nil {
+		return false
 	}
+
+	errorMessage := err.Error()
+	missingFlags := []string{}
+	if message == ErrorCheckMissingPermission {
+		missingFlags = append(missingFlags, "ADVANCED_SSO")
+	}
+	if message == ErrorCheckCannotCreateSWA {
+		missingFlags = append(missingFlags, "ALLOW_SWA")
+	}
+	if message == ErrorCheckCannotCreateBasicAuth {
+		missingFlags = append(missingFlags, "ALLOW_SWA")
+	}
+	if message == ErrorCheckCannotCreateSPS {
+		missingFlags = append(missingFlags, "ALLOW_SWA")
+	}
+	if message == ErrorCheckCannotCreateAWSConole {
+		missingFlags = append(missingFlags, "ALLOW_SWA")
+	}
+	if message == ErrorCheckCannotCreateSWAThreeField {
+		missingFlags = append(missingFlags, "ALLOW_SWA")
+	}
+	if message == ErrorCheckFFGroupMembershipRules {
+		missingFlags = append(missingFlags, "GROUP_MEMBERSHIP_RULES")
+	}
+	if message == ErrorCheckFFMFAPolicy {
+		missingFlags = append(missingFlags, "OKTA_MFA_POLICY")
+	}
+	if strings.Contains(errorMessage, message) {
+		t.Skipf("Skipping test for:\n%sOrg possibly missing flags %+v", errorMessage, missingFlags)
+		return true
+	}
+
+	return false
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.30"
+      version = "~> 3.35"
     }
   }
 }


### PR DESCRIPTION
## 3.35.0 (August 25, 2022)

NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:

* Adds customizable Timeouts to resources/data that rely on syncing users and groups to avoid context.DeadlineExceeded
 [#1207](https://github.com/okta/terraform-provider-okta/pull/1207). Thanks, [@emanor-okta](https://github.com/emanor-okta)!
  * [Terraform documentation: Resources - Retries and Customizable Timeouts](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts)
  * Resources: `okta_app_auto_login`, `okta_app_basic_auth`, `okta_app_bookmark`, `okta_app_group_assignment`, `okta_app_oauth`, `okta_app_saml`, `okta_app_secure_password_store`, `okta_app_shared_credentials`, `okta_app_swa`

BUG FIXES:

* Correctly collect network zones in datasource `okta_network_zone` [#1239](https://github.com/okta/terraform-provider-okta/pull/1239). Thanks, [@natmariam](https://github.com/natmariam)!
* Adding `CHROMEOS` to `os_type` in `platform_include` [#1261](https://github.com/okta/terraform-provider-okta/pull/1261). Thanks, [@monde](https://github.com/monde)!
* Update okta-sdk-golang that correctly caches OAuth2 access tokens [#1262](https://github.com/okta/terraform-provider-okta/pull/1262). Thanks, [@monde](https://github.com/monde)!
* Update role types validation on resource `okta_role_subscription` [#1265](https://github.com/okta/terraform-provider-okta/pull/1265). Thanks, [@monde](https://github.com/monde)!
* Correct pagination to list all email templates on data source `okta_email_templates` [#1266](https://github.com/okta/terraform-provider-okta/pull/1266). Thanks, [@monde](https://github.com/monde)!

PROJECT IMPROVEMENTS:

* Show current version for provider config in documentation [#1256](https://github.com/okta/terraform-provider-okta/pull/1256). Thanks, [@ErelAdoni](https://github.com/ErelAdoni)!
* Code clean up from go vet and format [#1264](https://github.com/okta/terraform-provider-okta/pull/1264). Thanks, [@monde](https://github.com/monde)!
