### PR TITLE
ACC tests for resource changes in PR #1207

### DIFF
--- a/okta/resource_okta_app_auto_login_test.go
+++ b/okta/resource_okta_app_auto_login_test.go
@@ -61,3 +61,35 @@ func TestAccAppAutoLoginApplication_crud(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAppAutoLoginApplication_timeouts(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appAutoLogin)
+	resourceName := fmt.Sprintf("%s.test", appAutoLogin)
+	config := `
+resource "okta_app_auto_login" "test" {
+  label       = "testAcc_replace_with_uuid"
+  sign_on_url = "https://example.com/login.html"
+  timeouts {
+    create = "60m"
+    read = "2h"
+    update = "30m"
+  }
+}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createCheckResourceDestroy(appAutoLogin, createDoesAppExist(okta.NewAutoLoginApplication())),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config, ri),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesAppExist(okta.NewAutoLoginApplication())),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.create", "60m"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.read", "2h"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.update", "30m"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_app_basic_auth_test.go
+++ b/okta/resource_okta_app_basic_auth_test.go
@@ -48,3 +48,36 @@ func TestAccAppBasicAuthApplication_crud(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAppBasicAuthApplication_timeouts(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appBasicAuth)
+	resourceName := fmt.Sprintf("%s.test", appBasicAuth)
+	config := `
+resource "okta_app_basic_auth" "test" {
+  label    = "testAcc_replace_with_uuid"
+  url      = "https://example.com/login.html"
+  auth_url = "https://example.com/auth.html"
+  timeouts {
+    create = "60m"
+    read = "2h"
+    update = "30m"
+  }
+}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createCheckResourceDestroy(appBasicAuth, createDoesAppExist(okta.NewBasicAuthApplication())),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config, ri),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesAppExist(okta.NewAutoLoginApplication())),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.create", "60m"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.read", "2h"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.update", "30m"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_app_saml_test.go
+++ b/okta/resource_okta_app_saml_test.go
@@ -357,3 +357,57 @@ resource "%s" "%s" {
 }
 `, appSaml, name, name)
 }
+
+func TestAccResourceOktaAppSaml_timeouts(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appSaml)
+	resourceName := fmt.Sprintf("%s.test", appSaml)
+	config := `
+resource "okta_app_saml" "test" {
+  label                     = "testAcc_replace_with_uuid"
+  sso_url                   = "http://google.com"
+  recipient                 = "http://here.com"
+  destination               = "http://its-about-the-journey.com"
+  audience                  = "http://audience.com"
+  subject_name_id_template  = "$${user.userName}"
+  subject_name_id_format    = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+  response_signed           = true
+  signature_algorithm       = "RSA_SHA256"
+  digest_algorithm          = "SHA256"
+  honor_force_authn         = false
+  authn_context_class_ref   = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+  single_logout_issuer      = "https://dunshire.okta.com"
+  single_logout_url         = "https://dunshire.okta.com/logout"
+  single_logout_certificate = "MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"
+
+  attribute_statements {
+    type         = "GROUP"
+    name         = "groups"
+    filter_type  = "REGEX"
+    filter_value = ".*"
+  }
+
+  timeouts {
+    create = "60m"
+    read = "2h"
+    update = "30m"
+  }
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createCheckResourceDestroy(appSaml, createDoesAppExist(okta.NewSamlApplication())),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config, ri),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesAppExist(okta.NewAutoLoginApplication())),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.create", "60m"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.read", "2h"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.update", "30m"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_app_shared_credentials_test.go
+++ b/okta/resource_okta_app_shared_credentials_test.go
@@ -74,3 +74,40 @@ func TestAccAppSharedCredentials_crud(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAppSharedCredentials_timeouts(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appSharedCredentials)
+	resourceName := fmt.Sprintf("%s.test", appSharedCredentials)
+	config := `
+resource "okta_app_shared_credentials" "test" {
+  label                            = "testAcc_replace_with_uuid"
+  button_field                     = "btn-login"
+  username_field                   = "txtbox-username"
+  password_field                   = "txtbox-password"
+  url                              = "https://example.com/login-updated.html"
+  shared_username                  = "sharedusername"
+  shared_password                  = "sharedpass"
+  timeouts {
+    create = "60m"
+    read = "2h"
+    update = "30m"
+  }
+}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createCheckResourceDestroy(appSharedCredentials, createDoesAppExist(okta.NewBrowserPluginApplication())),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config, ri),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesAppExist(okta.NewAutoLoginApplication())),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.create", "60m"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.read", "2h"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.update", "30m"),
+				),
+			},
+		},
+	})
+}

--- a/okta/resource_okta_app_swa_test.go
+++ b/okta/resource_okta_app_swa_test.go
@@ -83,3 +83,38 @@ func TestAccAppSwaApplication_crud(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAppSwaApplication_timeouts(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(appSwa)
+	resourceName := fmt.Sprintf("%s.test", appSwa)
+	config := `
+resource "okta_app_swa" "test" {
+  label          = "testAcc_replace_with_uuid"
+  button_field   = "btn-login"
+  password_field = "txtbox-password"
+  username_field = "txtbox-username"
+  url            = "https://example.com/login.html"
+  timeouts {
+    create = "60m"
+    read = "2h"
+    update = "30m"
+  }
+}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createCheckResourceDestroy(appSwa, createDoesAppExist(okta.NewSwaApplication())),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config, ri),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesAppExist(okta.NewAutoLoginApplication())),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.create", "60m"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.read", "2h"),
+					resource.TestCheckResourceAttr(resourceName, "timeouts.update", "30m"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
ACC tests for @emanor-okta's PR #1207 "Adds customizable Timeouts to resources/data that rely on syncing users and groups to avoid context.DeadlineExceeded"

```
 ± for t in TestAccAppAutoLoginApplication_timeouts TestAccAppBasicAuthApplication_timeouts TestAccAppBookmarkApplication_timeouts TestAccAppGroupAssignment_timeouts TestAccResourceOktaAppOauth_timeouts TestAccResourceOktaAppSaml_timeouts TestAccAppSecurePasswordStoreApplication_timeouts TestAccAppSharedCredentials_timeouts TestAccAppSwaApplication_timeouts; do
for> TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^${t}$ ./okta
for> done
=== RUN   TestAccAppAutoLoginApplication_timeouts
--- PASS: TestAccAppAutoLoginApplication_timeouts (7.42s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    7.675s
=== RUN   TestAccAppBasicAuthApplication_timeouts
--- PASS: TestAccAppBasicAuthApplication_timeouts (7.16s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    7.380s
=== RUN   TestAccAppBookmarkApplication_timeouts
--- PASS: TestAccAppBookmarkApplication_timeouts (6.01s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.234s
=== RUN   TestAccAppGroupAssignment_timeouts
--- PASS: TestAccAppGroupAssignment_timeouts (7.60s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    7.828s
=== RUN   TestAccResourceOktaAppOauth_timeouts
--- PASS: TestAccResourceOktaAppOauth_timeouts (6.80s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    7.024s
=== RUN   TestAccResourceOktaAppSaml_timeouts
--- PASS: TestAccResourceOktaAppSaml_timeouts (8.89s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    9.116s
=== RUN   TestAccAppSecurePasswordStoreApplication_timeouts
--- PASS: TestAccAppSecurePasswordStoreApplication_timeouts (6.30s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.526s
=== RUN   TestAccAppSharedCredentials_timeouts
--- PASS: TestAccAppSharedCredentials_timeouts (6.24s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.489s
=== RUN   TestAccAppSwaApplication_timeouts
--- PASS: TestAccAppSwaApplication_timeouts (6.78s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
```