### PR TITLE
prevent error overwrite in addGroupMember

### DIFF
--- a/okta/group.go
+++ b/okta/group.go
@@ -65,9 +65,9 @@ func listGroups(ctx context.Context, client *okta.Client, qp *query.Params) ([]*
 // Group Primary Key Operations (Use when # groups < # users in operations)
 func addGroupMembers(ctx context.Context, client *okta.Client, groupId string, users []string) error {
 	for _, user := range users {
-		resp, err := client.Group.AddUserToGroup(ctx, groupId, user)
-		exists, err := doesResourceExist(resp, err)
-		if err != nil {
+		resp, err1 := client.Group.AddUserToGroup(ctx, groupId, user)
+		exists, err2 := doesResourceExist(resp, err)
+		if err1 != nil || err2 != nil {
 			return fmt.Errorf("failed to add user (%s) to group (%s): %w", user, groupId, err)
 		}
 		if !exists {


### PR DESCRIPTION
Currently, errors in trying to add a group member (example, a 403)
get ignored, since it gets overwritten in the next line.

This causes terraform to attempt updating tf state when it shouldn't,
putting it into a bad state - the `private` field in tf state becomes
`bnVsbA==`, which is a `null`.

When Okta 403s, we should return the error and not attempt to change
anything in terraform.
