### PR TITLE
Policy Rule Retry On InternalServerError (#836)

### DIFF
--- a/examples/okta_policy_rule_signon/basic_multiple.tf
+++ b/examples/okta_policy_rule_signon/basic_multiple.tf
@@ -1,0 +1,33 @@
+data "okta_group" "all" {
+  name = "Everyone"
+}
+
+resource "okta_network_zone" "test" {
+  name     = "testAcc_replace_with_uuid"
+  type     = "IP"
+  gateways = ["34.82.0.0/15"]
+}
+
+resource "okta_policy_signon" "test" {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = [data.okta_group.all.id]
+}
+
+resource "okta_policy_rule_signon" "test_allow" {
+  policy_id          = okta_policy_signon.test.id
+  name               = "testAccAllow_replace_with_uuid"
+  status             = "ACTIVE"
+  network_connection = "ZONE"
+  network_includes   = [okta_network_zone.test.id]
+}
+
+resource "okta_policy_rule_signon" "test_deny" {
+  policy_id          = okta_policy_signon.test.id
+  name               = "testAccDeny_replace_with_uuid"
+  status             = "ACTIVE"
+  access             = "DENY"
+  network_connection = "ZONE"
+  network_excludes   = [okta_network_zone.test.id]
+}

--- a/examples/okta_policy_rule_signon/factor_sequence.tf
+++ b/examples/okta_policy_rule_signon/factor_sequence.tf
@@ -3,9 +3,9 @@ data "okta_group" "all" {
 }
 
 resource "okta_policy_signon" "test" {
-  name            = "testAcc_replace_with_uuid"
-  status          = "ACTIVE"
-  description     = "Terraform Acceptance Test SignOn Policy"
+  name        = "testAcc_replace_with_uuid"
+  status      = "ACTIVE"
+  description = "Terraform Acceptance Test SignOn Policy"
   groups_included = [
     data.okta_group.all.id
   ]
@@ -16,13 +16,13 @@ data "okta_behavior" "new_city" {
 }
 
 resource "okta_network_zone" "test" {
-  name       = "testAcc_replace_with_uuid"
-  type       = "IP"
-  gateways   = [
+  name = "testAcc_replace_with_uuid"
+  type = "IP"
+  gateways = [
     "1.2.3.4/24",
     "2.3.4.5-2.3.4.15"
   ]
-  proxies    = [
+  proxies = [
     "2.2.3.4/24",
     "3.3.4.5-3.3.4.15"
   ]

--- a/examples/okta_policy_rule_signon/okta_identity_provider.tf
+++ b/examples/okta_policy_rule_signon/okta_identity_provider.tf
@@ -3,21 +3,21 @@ data "okta_group" "all" {
 }
 
 resource "okta_policy_signon" "test" {
-  name            = "testAcc_replace_with_uuid"
-  status          = "ACTIVE"
-  description     = "Terraform Acceptance Test SignOn Policy"
+  name        = "testAcc_replace_with_uuid"
+  status      = "ACTIVE"
+  description = "Terraform Acceptance Test SignOn Policy"
   groups_included = [
     data.okta_group.all.id
   ]
 }
 
 resource "okta_policy_rule_signon" "test" {
-  policy_id         = okta_policy_signon.test.id
-  name              = "testAcc_replace_with_uuid"
-  status            = "ACTIVE"
-  mfa_required      = true
-  mfa_lifetime      = 15
-  mfa_prompt        = "SESSION"
+  policy_id    = okta_policy_signon.test.id
+  name         = "testAcc_replace_with_uuid"
+  status       = "ACTIVE"
+  mfa_required = true
+  mfa_lifetime = 15
+  mfa_prompt   = "SESSION"
 }
 
 resource "okta_network_zone" "test" {

--- a/examples/okta_policy_rule_signon/other_identity_provider.tf
+++ b/examples/okta_policy_rule_signon/other_identity_provider.tf
@@ -7,7 +7,7 @@ resource "okta_idp_social" "google" {
   protocol_type       = "OIDC"
   name                = "Google"
   provisioning_action = "DISABLED"
-  scopes              = [
+  scopes = [
     "profile",
     "email",
     "openid",

--- a/okta/resource_okta_policy_rule_sign_on_test.go
+++ b/okta/resource_okta_policy_rule_sign_on_test.go
@@ -121,6 +121,37 @@ func TestAccOktaPolicyRuleSignon_crud(t *testing.T) {
 	})
 }
 
+func TestAccOktaPolicyRuleSignon_multiple(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(policyRuleSignOn)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	basicMultiple := mgr.GetFixtures("basic_multiple.tf", ri, t)
+	resourceName := fmt.Sprintf("%s.test", policyRuleSignOn)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createRuleCheckDestroy(policyRuleSignOn),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					ensureRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
+				),
+			},
+			{
+				Config: basicMultiple,
+				Check: resource.ComposeTestCheckFunc(
+					ensureRuleExists(fmt.Sprintf("%s.test_allow", policyRuleSignOn)),
+					ensureRuleExists(fmt.Sprintf("%s.test_deny", policyRuleSignOn))),
+			},
+		},
+	})
+}
+
 func testOktaPolicyRuleSignOnDefaultErrors(rInt int) string {
 	name := buildResourceName(rInt)
 


### PR DESCRIPTION
For #836 

This adds a retry wrap around the `createPolicyRule` action, which performs a backoff retry if the returned API error is a 500. This is to assist with concurrency errors and/or other internal server errors which occur and cannot be handled by anything other than a retry.

