### PR TITLE
Added support for retrieving client secret from okta_app_oauth data source

### DIFF
--- a/okta/data_source_okta_app_oauth.go
+++ b/okta/data_source_okta_app_oauth.go
@@ -216,7 +216,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, m inter
 		}
 		// There can be only two client secrets. Choose the latest created one that is active
 		if len(secretList) > 0 {
-			if secretList[0].Status == "ACTIVE" && secretList[1].Status == "ACTIVE" {
+			if len(secretList) > 1 && secretList[0].Status == "ACTIVE" && secretList[1].Status == "ACTIVE" {
 				if secretList[1].LastUpdated > secretList[0].LastUpdated {
 					clientSecret = secretList[1].ClientSecret
 				} else {
@@ -224,7 +224,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, m inter
 				}
 			} else if secretList[0].Status == "ACTIVE" {
 				clientSecret = secretList[0].ClientSecret
-			} else if secretList[1].Status == "ACTIVE" {
+			} else if len(secretList) > 1 && secretList[1].Status == "ACTIVE" {
 				clientSecret = secretList[1].ClientSecret
 			}
 		}


### PR DESCRIPTION
Fixes the problem for the specific case reported in #1279.

This works in the case that I have tested, but I am not sure if it is a good idea to fetch the secrets using this call (maybe it causes problems with token scopes) in which case maybe there is a need to opt in/out of this.

Draft PR because it currently serves as discussion material and I do not expect it to be merged in the current state. I can spend some time fixing it up based on review feedback if this is the correct path for solving this issue.