### PR TITLE
oauth app data source: allow to retrieve client_secret

### DIFF
--- a/okta/data_source_okta_app_oauth.go
+++ b/okta/data_source_okta_app_oauth.go
@@ -119,6 +119,12 @@ func dataSourceAppOauth() *schema.Resource {
 				Computed:    true,
 				Description: "OAuth client ID",
 			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "OAuth client secret",
+			},
 			"policy_uri": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -201,6 +207,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, m inter
 	_ = d.Set("logo_uri", app.Settings.OauthClient.LogoUri)
 	_ = d.Set("login_uri", app.Settings.OauthClient.InitiateLoginUri)
 	_ = d.Set("client_id", app.Credentials.OauthClient.ClientId)
+	_ = d.Set("client_secret", app.Credentials.OauthClient.ClientSecret)
 	_ = d.Set("policy_uri", app.Settings.OauthClient.PolicyUri)
 	_ = d.Set("wildcard_redirect", app.Settings.OauthClient.WildcardRedirect)
 	respTypes := make([]string, len(app.Settings.OauthClient.ResponseTypes))

--- a/okta/data_source_okta_app_oauth_test.go
+++ b/okta/data_source_okta_app_oauth_test.go
@@ -26,6 +26,7 @@ func TestAccOktaDataSourceAppOauth_read(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "client_id"),
+					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "client_secret"),
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "grant_types.#"),
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "redirect_uris.#"),
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "type"),


### PR DESCRIPTION
test seem to be ok:
```
=== RUN   TestAccOktaDataSourceAppOauth_read
--- PASS: TestAccOktaDataSourceAppOauth_read (46.13s)
```

but I don't have a huge confidence here, so would appreciate any feedback

/cc @monde 