### PR TITLE
Nil guard on `app.Settings.OauthClient`

### DIFF
--- a/website/docs/d/app_oauth.html.markdown
+++ b/website/docs/d/app_oauth.html.markdown
@@ -20,9 +20,13 @@ data "okta_app_oauth" "test" {
 
 ## Argument Reference
 
-- `label` - (Optional) The label of the app to retrieve, conflicts with `label_prefix` and `id`. Label uses
-  the `?q=<label>` query parameter exposed by Okta's API. It should be noted that at this time this searches both `name`
-  and `label`. This is used to avoid paginating through all applications.
+- `label` - (Optional) The label of the app to retrieve, conflicts with
+    `label_prefix` and `id`. Label uses the `?q=<label>` query parameter exposed by
+    Okta's List Apps API. The API will search both `name` and `label` using that
+    query. Therefore similarily named and labeled apps may be returned in the query
+    and have the unitended result of associating the wrong app with this data
+    source. See:
+    https://developer.okta.com/docs/reference/api/apps/#list-applications
 
 - `label_prefix` - (Optional) Label prefix of the app to retrieve, conflicts with `label` and `id`. This will tell the
   provider to do a `starts with` query as opposed to an `equals` query.


### PR DESCRIPTION
Nil guard on `app.Settings.OauthClient`
Protects datasource if the returned app based on the label is not an oauth app.
Closes #1082

Ran tests on OIE and Classic 👍 