### PR TITLE
Errors to add user to group are incorrectly ignored.

### DIFF
--- a/okta/group.go
+++ b/okta/group.go
@@ -66,10 +66,10 @@ func listGroups(ctx context.Context, client *okta.Client, qp *query.Params) ([]*
 func addGroupMembers(ctx context.Context, client *okta.Client, groupId string, users []string) error {
 	for _, user := range users {
 		resp, err := client.Group.AddUserToGroup(ctx, groupId, user)
-		exists, err := doesResourceExist(resp, err)
 		if err != nil {
 			return fmt.Errorf("failed to add user (%s) to group (%s): %w", user, groupId, err)
 		}
+		exists, err := doesResourceExist(resp, err)
 		if !exists {
 			return fmt.Errorf("targeted object does not exist: %s", err)
 		}


### PR DESCRIPTION
Errors to add user to group are incorrectly ignored.
See #1269

```
for t in `grep "func Test" okta/resource_okta_group_test.go | awk '{ print $2}'| sed -e 's/(.*//g'`; do
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^${t} ./okta
done
=== RUN   TestAccOktaGroup_crud
--- PASS: TestAccOktaGroup_crud (22.83s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    23.223s
=== RUN   TestAccOktaGroup_customschema
2022/09/12 02:00:33 [ERROR] failed to apply changes after several retries
2022/09/12 02:00:33 [ERROR] failed to apply changes after several retries
2022/09/12 02:00:47 [ERROR] failed to apply changes after several retries
--- PASS: TestAccOktaGroup_customschema (17.49s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    17.747s
```

From @ purajit:
"
Currently, errors in trying to add a group member (example, a 403)
get ignored, since it gets overwritten in the next line.

This causes terraform to attempt updating tf state when it shouldn't,
putting it into a bad state - the private field in tf state becomes
bnVsbA==, which is a null.

When Okta 403s, we should return the error and not attempt to change
anything in terraform.
"