### PR TITLE
Add `client_secret` attribute on data source `okta_app_oauth`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-hclog v1.3.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
-	github.com/okta/okta-sdk-golang/v2 v2.14.1-0.20220912225624-eed2478b2ec8
+	github.com/okta/okta-sdk-golang/v2 v2.14.1-0.20220914175214-588bce2f1414
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/okta/okta-sdk-golang/v2 v2.14.0 h1:Z2Gs6lnKALHkCw4AM6+h/nLkXKzmiR5bGn
 github.com/okta/okta-sdk-golang/v2 v2.14.0/go.mod h1:dz30v3ctAiMb7jpsCngGfQUAEGm1/NsWT92uTbNDQIs=
 github.com/okta/okta-sdk-golang/v2 v2.14.1-0.20220912225624-eed2478b2ec8 h1:2IHWR+QxBCBTbyX3BY5093l/PAvHzPF2rYoiqv2qzwY=
 github.com/okta/okta-sdk-golang/v2 v2.14.1-0.20220912225624-eed2478b2ec8/go.mod h1:dz30v3ctAiMb7jpsCngGfQUAEGm1/NsWT92uTbNDQIs=
+github.com/okta/okta-sdk-golang/v2 v2.14.1-0.20220914175214-588bce2f1414 h1:KlTCbr7DPfUMq9gQ+WcyLpOUaRIxrGCogYhkXCnaPjY=
+github.com/okta/okta-sdk-golang/v2 v2.14.1-0.20220914175214-588bce2f1414/go.mod h1:dz30v3ctAiMb7jpsCngGfQUAEGm1/NsWT92uTbNDQIs=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 h1:pSCLCl6joCFRnjpeojzOpEYs4q7Vditq8fySFG5ap3Y=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/okta/data_source_okta_app_oauth.go
+++ b/okta/data_source_okta_app_oauth.go
@@ -216,7 +216,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, m inter
 		}
 		// There can be only two client secrets. Choose the latest created one that is active
 		if len(secretList) > 0 {
-			if secretList[0].Status == "ACTIVE" && secretList[1].Status == "ACTIVE" {
+			if len(secretList) > 1 && secretList[0].Status == "ACTIVE" && secretList[1].Status == "ACTIVE" {
 				if secretList[1].LastUpdated > secretList[0].LastUpdated {
 					clientSecret = secretList[1].ClientSecret
 				} else {
@@ -224,7 +224,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, m inter
 				}
 			} else if secretList[0].Status == "ACTIVE" {
 				clientSecret = secretList[0].ClientSecret
-			} else if secretList[1].Status == "ACTIVE" {
+			} else if len(secretList) > 1 && secretList[1].Status == "ACTIVE" {
 				clientSecret = secretList[1].ClientSecret
 			}
 		}

--- a/okta/data_source_okta_app_oauth.go
+++ b/okta/data_source_okta_app_oauth.go
@@ -119,6 +119,12 @@ func dataSourceAppOauth() *schema.Resource {
 				Computed:    true,
 				Description: "OAuth client ID",
 			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "OAuth client secret",
+			},
 			"policy_uri": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -208,6 +214,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, m inter
 		_ = d.Set("logo_uri", app.Settings.OauthClient.LogoUri)
 		_ = d.Set("login_uri", app.Settings.OauthClient.InitiateLoginUri)
 		_ = d.Set("client_id", app.Credentials.OauthClient.ClientId)
+		_ = d.Set("client_secret", app.Credentials.OauthClient.ClientSecret)
 		_ = d.Set("policy_uri", app.Settings.OauthClient.PolicyUri)
 		_ = d.Set("wildcard_redirect", app.Settings.OauthClient.WildcardRedirect)
 		for i := range app.Settings.OauthClient.ResponseTypes {

--- a/okta/data_source_okta_app_oauth_test.go
+++ b/okta/data_source_okta_app_oauth_test.go
@@ -26,6 +26,7 @@ func TestAccOktaDataSourceAppOauth_read(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "client_id"),
+					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "client_secret"),
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "grant_types.#"),
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "redirect_uris.#"),
 					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "type"),

--- a/website/docs/d/app_oauth.html.markdown
+++ b/website/docs/d/app_oauth.html.markdown
@@ -75,6 +75,8 @@ data "okta_app_oauth" "test" {
 
 - `client_id` - OAuth client ID. If set during creation, app is created with this id.
 
+- `client_secret` - The latest active client secret of the application. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
+
 - `client_uri` - URI to a web page providing information about the client.
 
 - `policy_uri` - URI to web page providing client policy document.


### PR DESCRIPTION
Adds latest active client secret value for data source okta_app_oauth.
Expands and refactors work from

- @dkulchinsky 
- @rickardp
- #1279
- #1280
- #1285

Tests pass on OIE and Classic

```
$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaDataSourceAppOauth_read$ ./okta 2>&1
=== RUN   TestAccOktaDataSourceAppOauth_read
--- PASS: TestAccOktaDataSourceAppOauth_read (15.49s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    15.723s
```