### PR TITLE
chore: bump staticcheck from v0.3.2 to v0.3.3

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -89,12 +89,12 @@ lint:
 tools:
 	@which $(GOFMT) || go install mvdan.cc/gofumpt@v0.3.1
 	@which $(TFPROVIDERLINT) || go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.28.1
-	@which $(STATICCHECK) || go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
+	@which $(STATICCHECK) || go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
 tools-update:
 	@go install mvdan.cc/gofumpt@v0.3.1
 	@go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.28.1
-	@go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
+	@go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))


### PR DESCRIPTION
This PR  bumps`staticcheck` from v0.3.2 to v0.3.3.
See: https://github.com/dominikh/go-tools/releases/tag/v0.3.3