### PR TITLE
Correct okta_email_customization docs

### DIFF
--- a/website/docs/r/email_customization.html.markdown
+++ b/website/docs/r/email_customization.html.markdown
@@ -77,9 +77,5 @@ resource "okta_email_customization" "forgot_password_en_alt" {
 
 ## Attributes Reference
 
-- `id` - (Read-Only) Customization ID
-- `links` - (Read-Only) Link relations for this object - JSON HAL - Discoverable resources related to the email template
-- `language` - The language supported by the customization
-- `is_default` - Whether the customization is the default
-- `subject` - The subject of the customization
-- `body` - The body of the customization
+- `id` - Customization ID
+- `links` - Link relations for this object - JSON HAL - Discoverable resources related to the email template

--- a/website/docs/r/email_customization.html.markdown
+++ b/website/docs/r/email_customization.html.markdown
@@ -70,7 +70,8 @@ resource "okta_email_customization" "forgot_password_en_alt" {
 `"SelfServiceUnlockOnUnlockedAccount"`,
 `"UserActivation"`
 - `language` - The language supported by the customization
-- `is_default` - Whether the customization is the default. If `is_default` is true and there is already a default customization when this resource is created will cause an error. Only set to true for updating a resource.
+- `is_default` - Whether the customization is the default
+  - Setting `is_default` to true when there is already a default customization will cause an error when this resource is created.
 - `subject` - The subject of the customization
 - `body` - The body of the customization
 

--- a/website/docs/r/email_customization.html.markdown
+++ b/website/docs/r/email_customization.html.markdown
@@ -36,7 +36,38 @@ resource "okta_email_customization" "forgot_password_en_alt" {
 ## Arguments Reference
 
 - `brand_id` - (Required) Brand ID
-- `template_name` - (Required) Template Name
+- `template_name` - (Required) Template Name. Valid values: `"AccountLockout"`,
+`"ADForgotPassword"`,
+`"ADForgotPasswordDenied"`,
+`"ADSelfServiceUnlock"`,
+`"ADUserActivation"`,
+`"AuthenticatorEnrolled"`,
+`"AuthenticatorReset"`,
+`"ChangeEmailConfirmation"`,
+`"EmailChallenge"`,
+`"EmailChangeConfirmation"`,
+`"EmailFactorVerification"`,
+`"ForgotPassword"`,
+`"ForgotPasswordDenied"`,
+`"IGAReviewerEndNotification"`,
+`"IGAReviewerNotification"`,
+`"IGAReviewerPendingNotification"`,
+`"IGAReviewerReassigned"`,
+`"LDAPForgotPassword"`,
+`"LDAPForgotPasswordDenied"`,
+`"LDAPSelfServiceUnlock"`,
+`"LDAPUserActivation"`,
+`"MyAccountChangeConfirmation"`,
+`"NewSignOnNotification"`,
+`"OktaVerifyActivation"`,
+`"PasswordChanged"`,
+`"PasswordResetByAdmin"`,
+`"PendingEmailChange"`,
+`"RegistrationActivation"`,
+`"RegistrationEmailVerification"`,
+`"SelfServiceUnlock"`,
+`"SelfServiceUnlockOnUnlockedAccount"`,
+`"UserActivation"`
 
 ## Attributes Reference
 

--- a/website/docs/r/email_customization.html.markdown
+++ b/website/docs/r/email_customization.html.markdown
@@ -36,7 +36,8 @@ resource "okta_email_customization" "forgot_password_en_alt" {
 ## Arguments Reference
 
 - `brand_id` - (Required) Brand ID
-- `template_name` - (Required) Template Name. Valid values: `"AccountLockout"`,
+- `template_name` - (Required) Template Name
+  - Example values: `"AccountLockout"`,
 `"ADForgotPassword"`,
 `"ADForgotPasswordDenied"`,
 `"ADSelfServiceUnlock"`,
@@ -68,12 +69,16 @@ resource "okta_email_customization" "forgot_password_en_alt" {
 `"SelfServiceUnlock"`,
 `"SelfServiceUnlockOnUnlockedAccount"`,
 `"UserActivation"`
+- `language` - The language supported by the customization
+- `is_default` - Whether the customization is the default. If `is_default` is true and there is already a default customization when this resource is created will cause an error. Only set to true for updating a resource.
+- `subject` - The subject of the customization
+- `body` - The body of the customization
 
 ## Attributes Reference
 
 - `id` - (Read-Only) Customization ID
 - `links` - (Read-Only) Link relations for this object - JSON HAL - Discoverable resources related to the email template
 - `language` - The language supported by the customization
-- `is_default` - Whether the customization is the default. If `is_default` is true and there is already a default customization when this resource is created will cause an error. Only set to true for updating a resource.
+- `is_default` - Whether the customization is the default
 - `subject` - The subject of the customization
 - `body` - The body of the customization


### PR DESCRIPTION
Add missing arguments originally listed as attributes

Add example `template_name` argument values for `okta_email_customization` resources