### PR TITLE
Fix/refine okta_app_oauth behavior for args `auto_key_rotation`, `pkce_required`, `token_endpoint_auth_method`

### DIFF
--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -16,7 +16,6 @@ import (
 
 type (
 	applicationMap struct {
-		Type               string
 		RequiredGrantTypes []string
 		ValidGrantTypes    []string
 	}
@@ -38,7 +37,7 @@ const (
 // is the best way to implement this logic, as it needs to introspect.
 // NOTE: opened a ticket to Okta to fix their docs, they are off.
 // https://developer.okta.com/docs/api/resources/apps#credentials-settings-details
-var appGrantTypeMap = map[string]*applicationMap{
+var appRequirementsByType = map[string]*applicationMap{
 	"web": {
 		RequiredGrantTypes: []string{
 			authorizationCode,
@@ -55,7 +54,6 @@ var appGrantTypeMap = map[string]*applicationMap{
 		},
 	},
 	"native": {
-		Type: "native",
 		RequiredGrantTypes: []string{
 			authorizationCode,
 		},
@@ -169,6 +167,9 @@ func resourceAppOAuth() *schema.Resource {
 				Default:          "client_secret_basic",
 				Description:      "Requested authentication method for the token endpoint.",
 			},
+			// API docs say that auto_key_rotation will alwas be set true if it
+			// is missing on input therefore we can declare it's default to be
+			// true in the schema.
 			"auto_key_rotation": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -211,7 +212,19 @@ func resourceAppOAuth() *schema.Resource {
 			"pkce_required": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Require Proof Key for Code Exchange (PKCE) for additional verification key rotation mode. `true` for `browser` and `native` application types.",
+				Description: "Require Proof Key for Code Exchange (PKCE) for additional verification key rotation mode. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					appType := d.Get("type").(string)
+					// Here, we juggle getting around setting a default pkce
+					// value as the behavior is dependant on the app type.
+					if appType == "native" || appType == "browser" {
+						// when pkce_required is not set in the HCL
+						if old == "true" && new == "false" {
+							return true
+						}
+					}
+					return false
+				},
 			},
 			"redirect_uris": {
 				Type:        schema.TypeList,
@@ -705,7 +718,7 @@ func buildAppOAuth(d *schema.ResourceData) *okta.OpenIdConnectApplication {
 
 	// If grant_types are not set, we default to the bare minimum.
 	if len(grantTypes) < 1 {
-		appMap, ok := appGrantTypeMap[appType]
+		appMap, ok := appRequirementsByType[appType]
 		if ok {
 			if appMap.RequiredGrantTypes == nil {
 				grantTypes = appMap.ValidGrantTypes
@@ -728,6 +741,17 @@ func buildAppOAuth(d *schema.ResourceData) *okta.OpenIdConnectApplication {
 		}
 	}
 
+	var pkceRequired bool
+	pkce := d.GetRawConfig().GetAttr("pkce_required")
+	// if the operator doesn't set pkce then it is true else honor the HCL value
+	switch {
+	case pkce.IsNull():
+		pkceRequired = true
+	case pkce.True():
+		pkceRequired = true
+	default:
+		pkceRequired = false
+	}
 	app.Label = d.Get("label").(string)
 	authMethod := d.Get("token_endpoint_auth_method").(string)
 	app.Credentials = &okta.OAuthApplicationCredentials{
@@ -735,8 +759,8 @@ func buildAppOAuth(d *schema.ResourceData) *okta.OpenIdConnectApplication {
 			AutoKeyRotation:         boolPtr(d.Get("auto_key_rotation").(bool)),
 			ClientId:                d.Get("client_id").(string),
 			TokenEndpointAuthMethod: authMethod,
-			PkceRequired:            boolPtr(d.Get("pkce_required").(bool)),
 			ClientSecret:            d.Get("client_secret").(string),
+			PkceRequired:            boolPtr(pkceRequired),
 		},
 		UserNameTemplate: buildUserNameTemplate(d),
 	}
@@ -829,7 +853,7 @@ func buildAppOAuth(d *schema.ResourceData) *okta.OpenIdConnectApplication {
 func validateGrantTypes(d *schema.ResourceData) error {
 	grantTypeList := convertInterfaceToStringSet(d.Get("grant_types"))
 	appType := d.Get("type").(string)
-	appMap, ok := appGrantTypeMap[appType]
+	appMap, ok := appRequirementsByType[appType]
 	if !ok {
 		return nil
 	}

--- a/okta/resource_okta_app_oauth_test.go
+++ b/okta/resource_okta_app_oauth_test.go
@@ -764,6 +764,103 @@ func TestAccResourceOktaAppOauth_config_combinations(t *testing.T) {
 				{"should-not", "get-here"},
 			},
 		},
+		{
+			name: "web-pkce-not-set",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "web"},
+				{"pkce_required", "false"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "web-pkce-set-true",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  pkce_required  = true
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "web"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "web-pkce-set-false",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  pkce_required  = false
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "web"},
+				{"pkce_required", "false"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "web-pkce-not-set-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			expectErrorMessage: `''pkce_required'' must be set to true when ''token_endpoint_auth_method'' is ''none''`,
+			attrPairs: [][]string{
+				{"should-not", "get-here"},
+			},
+		},
+		{
+			name: "web-pkce-set-true-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  pkce_required  = true
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			expectErrorMessage: `token_endpoint_auth_method: 'token_endpoint_auth_method' is invalid. Valid values: [client_secret_basic, client_secret_post, client_secret_jwt, private_key_jwt]`,
+			attrPairs: [][]string{
+				{"should-not", "get-here"},
+			},
+		},
+		{
+			name: "web-pkce-set-false-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  pkce_required  = false
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			expectErrorMessage: `''pkce_required'' must be set to true when ''token_endpoint_auth_method'' is ''none''`,
+			attrPairs: [][]string{
+				{"should-not", "get-here"},
+			},
+		},
 	}
 	for _, test := range cases {
 		ri := acctest.RandInt()

--- a/okta/resource_okta_app_oauth_test.go
+++ b/okta/resource_okta_app_oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -544,4 +545,260 @@ resource "okta_app_oauth" "test" {
 			},
 		},
 	})
+}
+
+// TestAccResourceOktaAppOauth_config_combinations
+// W.R.T. https://github.com/okta/terraform-provider-okta/issues/1325
+// Documentation of the the API behavior of pkce_required when the app type is
+// "browser" or "native"
+//
+// https://developer.okta.com/docs/reference/api/apps/#username-template-object
+func TestAccResourceOktaAppOauth_config_combinations(t *testing.T) {
+	mgr := newFixtureManager(appOAuth)
+
+	cases := []struct {
+		name               string
+		config             string
+		attrPairs          [][]string
+		expectErrorMessage string
+	}{
+		{
+			name: "native-pkce-not-set",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "native"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "native"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "native-pkce-set-true",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "native"
+  pkce_required  = true
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "native"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "native-pkce-set-false",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "native"
+  pkce_required  = false
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "native"},
+				{"pkce_required", "false"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "native-pkce-not-set-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "native"
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "native"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "none"},
+			},
+		},
+		{
+			name: "native-pkce-set-true-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "native"
+  pkce_required  = true
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "native"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "none"},
+			},
+		},
+		{
+			name: "native-pkce-set-false-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "native"
+  pkce_required  = false
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			expectErrorMessage: `''pkce_required'' must be set to true when ''token_endpoint_auth_method'' is ''none''`,
+			attrPairs: [][]string{
+				{"should-not", "get-here"},
+			},
+		},
+		{
+			name: "browser-pkce-not-set",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "browser"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "browser"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "browser-pkce-set-true",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "browser"
+  pkce_required  = true
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "browser"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "browser-pkce-set-false",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "browser"
+  pkce_required  = false
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "browser"},
+				{"pkce_required", "false"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "client_secret_basic"},
+			},
+		},
+		{
+			name: "browser-pkce-not-set-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "browser"
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "browser"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "none"},
+			},
+		},
+		{
+			name: "browser-pkce-set-true-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "browser"
+  pkce_required  = true
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			attrPairs: [][]string{
+				{"type", "browser"},
+				{"pkce_required", "true"},
+				{"auto_key_rotation", "true"},
+				{"token_endpoint_auth_method", "none"},
+			},
+		},
+		{
+			name: "browser-pkce-set-false-token-none",
+			config: `resource "okta_app_oauth" "%s" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "browser"
+  pkce_required  = false
+  token_endpoint_auth_method = "none"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://example.com/"]
+  response_types = ["code"]
+}`,
+			expectErrorMessage: `''pkce_required'' must be set to true when ''token_endpoint_auth_method'' is ''none''`,
+			attrPairs: [][]string{
+				{"should-not", "get-here"},
+			},
+		},
+	}
+	for _, test := range cases {
+		ri := acctest.RandInt()
+		resourceName := fmt.Sprintf("%s.%s", appOAuth, test.name)
+		config := fmt.Sprintf(test.config, test.name)
+		testFuncs := []resource.TestCheckFunc{
+			ensureResourceExists(resourceName, createDoesAppExist(okta.NewAutoLoginApplication())),
+		}
+		for _, pair := range test.attrPairs {
+			testFuncs = append(testFuncs, resource.TestCheckResourceAttr(resourceName, pair[0], pair[1]))
+		}
+		errorCheck := testAccErrorChecks(t)
+		if test.expectErrorMessage != "" {
+			errorCheck = func(err error) error {
+				if err == nil {
+					return errors.New("expected an error")
+				}
+				if !strings.Contains(err.Error(), test.expectErrorMessage) {
+					return fmt.Errorf("expected error %q, got %q", test.expectErrorMessage, err.Error())
+				}
+				return nil
+			}
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          testAccPreCheck(t),
+			ErrorCheck:        errorCheck,
+			ProviderFactories: testAccProvidersFactories,
+			CheckDestroy:      createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
+			Steps: []resource.TestStep{
+				{
+					Config: mgr.ConfigReplace(config, ri),
+					Check:  resource.ComposeTestCheckFunc(testFuncs...),
+				},
+			},
+		})
+	}
 }

--- a/okta/utils_for_test.go
+++ b/okta/utils_for_test.go
@@ -118,7 +118,6 @@ const (
 
 // testAccErrorChecks Intended for use with TF sdk TestCase ErrorCheck function.
 // Ability to skip tests that have specific errors.
-
 func testAccErrorChecks(t *testing.T) resource.ErrorCheckFunc {
 	return func(err error) error {
 		if err == nil {

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -136,7 +136,16 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 
 - `refresh_token_rotation` - (Optional) Refresh token rotation behavior. Valid values: `"STATIC"` or `"ROTATE"`.
 
-- `response_types` - (Optional) List of OAuth 2.0 response type strings.
+- `response_types` - (Optional) List of OAuth 2.0 response type strings. Array
+    values of `"code"`, `"token"`, `"id_token"`. The `grant_types` and `response_types`
+    values described are partially orthogonal, as they refer to arguments
+    passed to different endpoints in the OAuth 2.0 protocol (opens new window).
+    However, they are related in that the `grant_types` available to a client
+    influence the `response_types` that the client is allowed to use, and vice versa.
+    For instance, a grant_types value that includes authorization_code implies a
+    `response_types` value that includes code, as both values are defined as part of
+    the OAuth 2.0 authorization code grant.
+    See: https://developer.okta.com/docs/reference/api/apps/#add-oauth-2-0-client-application
 
 - `skip_groups` - (Optional) Indicator that allows the app to skip `groups` sync (it's also can be provided during import). Default is `false`.
 

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -57,11 +57,15 @@ The following arguments are supported:
 
 - `app_settings_json` - (Optional) Application settings in JSON format.
 
-- `auto_key_rotation` - (Optional) Requested key rotation mode. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
+- `auto_key_rotation` - (Optional) Requested key rotation mode.  If
+    `auto_key_rotation` isn't specified, the client automatically opts in for Okta's
+    key rotation. You can update this property via the API or via the administrator
+    UI.
+    See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
 
 - `auto_submit_toolbar` - (Optional) Display auto submit toolbar.
 
-- `client_basic_secret` - (Optional) OAuth client secret key, this can be set when token_endpoint_auth_method is client_secret_basic.
+- `client_basic_secret` - (Optional) OAuth client secret key, this can be set when `token_endpoint_auth_method` is `"client_secret_basic"`.
 
 - `client_id` - (Optional) OAuth client ID. If set during creation, app is created with this id. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
 
@@ -114,7 +118,11 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 
 - `omit_secret` - (Optional) This tells the provider not to persist the application's secret to state. Your app's `client_secret` will be recreated if this ever changes from true => false.
 
-- `pkce_required` - (Optional) Require Proof Key for Code Exchange (PKCE) for additional verification. `true` for `browser` and `native` application types. See https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
+- `pkce_required` - (Optional) Require Proof Key for Code Exchange (PKCE) for
+    additional verification.  If `pkce_required` isn't specified when adding a new
+    application, Okta sets it to `true` by default for `"browser"` and `"native"`
+    application types.
+    See https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
 
 - `policy_uri` - (Optional) URI to web page providing client policy document.
 
@@ -136,7 +144,15 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 
 - `status` - (Optional) The status of the application, by default, it is `"ACTIVE"`.
 
-- `token_endpoint_auth_method` - (Optional) Requested authentication method for the token endpoint. It can be set to `"none"`, `"client_secret_post"`, `"client_secret_basic"`, `"client_secret_jwt"`, `"private_key_jwt"`. To enable PKCE, set this to `"none"`. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
+- `token_endpoint_auth_method` - (Optional) Requested authentication method for
+    the token endpoint. It can be set to `"none"`, `"client_secret_post"`,
+    `"client_secret_basic"`, `"client_secret_jwt"`, `"private_key_jwt"`.  Use
+    `pkce_required` to require PKCE for your confidential clients using the
+    Authorization Code flow. If `"token_endpoint_auth_method"` is `"none"`,
+    `pkce_required` needs to be `true`. If `pkce_required` isn't specified when
+    adding a new application, Okta sets it to `true` by default for `"browser"` and
+    `"native"` application types.
+    See https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
 
 - `tos_uri` - (Optional) URI to web page providing client tos (terms of service).
 


### PR DESCRIPTION
    Fix/refine okta_app_oauth behavior w.r.t. API documentation for
    arguments `auto_key_rotation`, `pkce_required`,
    `token_endpoint_auth_method`

Closes #1325