### PR TITLE
deps: bump goreleaser-action from v3.1.0 to v3.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.1.0
+        uses: goreleaser/goreleaser-action@v3.2.0
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
See: https://github.com/goreleaser/goreleaser-action/releases/tag/v3.2.0