### PR TITLE
Panic bumper on `profile` attribute in resource `okta_app_group_assignments`

### DIFF
--- a/website/docs/r/app_group_assignments.html.markdown
+++ b/website/docs/r/app_group_assignments.html.markdown
@@ -30,7 +30,19 @@ resource "okta_app_group_assignments" "example" {
 
 ```
 
-!> **NOTE** When using this resource in conjunction with other application resources (e.g. `okta_app_oauth`) it is advisable to add the following `lifecycle` argument to the associated `app_*` resources to prevent the groups being unassigned on subsequent runs:
+!> **NOTE** It would seem that setting/updating base/custom group schema values
+was the original purpose for setting a `profile` JSON value during the [Assign
+group to
+application](https://developer.okta.com/docs/reference/api/apps/#assign-group-to-application)
+API call that will take place when the `priority` value is changed. We couldn't
+verify this works when writing a new integration test against this old feature
+and were receiving an API 400 error. This feature may work for older orgs, or
+classic orgs, but we can not guarantee for all orgs.
+
+!> **NOTE** When using this resource in conjunction with other application
+resources (e.g. `okta_app_oauth`) it is advisable to add the following
+`lifecycle` argument to the associated `app_*` resources to prevent the groups
+being unassigned on subsequent runs:
 
 ```hcl
 resource "okta_app_oauth" "app" {


### PR DESCRIPTION
- Place panic bumper on `profile` attribute in resource `okta_app_group_assignments`
- Update resource `okta_app_group_assignments` with warning this feature may not work for all orgs