### PR TITLE
Handling 401 errors / okta_idp_saml

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,41 @@
+# TODO
+
+Use the TODO file to capture greater implementation and architecture concepts
+that should be considered in the provider.
+
+## `403 Forbidden` / `401 Unauthorized` errors (November 10, 2022)
+
+The Okta API can return `403 Forbidden` and `401 Unauthorized` errors on some
+endpoints. This typically isn't noticeable if the API token was created by a
+Super Admin on the org. If the token is made with a lesser role, for instance
+Org Admin, or the org doesn't have certain feature enabled, then it interferes
+with consistent behavior in the provider.  Presently, Okta API doesn't document
+which endpoints have permission levels and there isn't any kind of endpoint
+that presents that information in a discoverable way.
+
+Possible solutions.
+
+### New config variable `OTKA_API_TOKEN_ROLE=[super-admin|org-admin|etc]`
+
+Allow the operator to manually set a provider configuration variable
+corresponding to their token's role. The variable could be named somethign like
+Okta API Token Role. Resource code paths can then gate on that variable's value
+and act accordingly for known endpoints having permission levels.
+
+### golang http roundtripper intercepting 401/403 errors
+
+Add in a golang roundtripper https://pkg.go.dev/net/http#RoundTripper that
+intercepts 401/403 responses and returns a soft error.
+
+### Simple guards in code
+
+Proactively guard known endpoint errors in code like is done with
+suppressErrorOn404(resp, err) 
+
+### Additional arguments on resources
+
+Define arguments on resources like `skip_roles` in data source okta_user
+https://registry.terraform.io/providers/okta/okta/latest/docs/data-sources/user
+that allows the operator to explicitly guard behaviors known to have permission
+issues.
+

--- a/okta/resource_okta_idp_saml.go
+++ b/okta/resource_okta_idp_saml.go
@@ -144,8 +144,8 @@ func resourceIdpSamlRead(ctx context.Context, d *schema.ResourceData, m interfac
 	if idp.IssuerMode != "" {
 		_ = d.Set("issuer_mode", idp.IssuerMode)
 	}
-	mapping, _, err := getProfileMappingBySourceID(ctx, idp.Id, "", m)
-	if err != nil {
+	mapping, resp, err := getProfileMappingBySourceID(ctx, idp.Id, "", m)
+	if err := suppressErrorOn401(resp, err); err != nil {
 		return diag.Errorf("failed to get SAML identity provider profile mapping: %v", err)
 	}
 	if mapping != nil {

--- a/okta/resource_okta_idp_saml.go
+++ b/okta/resource_okta_idp_saml.go
@@ -145,7 +145,7 @@ func resourceIdpSamlRead(ctx context.Context, d *schema.ResourceData, m interfac
 		_ = d.Set("issuer_mode", idp.IssuerMode)
 	}
 	mapping, resp, err := getProfileMappingBySourceID(ctx, idp.Id, "", m)
-	if err := suppressErrorOn401(resp, err); err != nil {
+	if err := suppressErrorOn401("resource okta_idp_saml.user_type_id", m, resp, err); err != nil {
 		return diag.Errorf("failed to get SAML identity provider profile mapping: %v", err)
 	}
 	if mapping != nil {

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -284,6 +284,14 @@ func suppressErrorOn404(resp *okta.Response, err error) error {
 	return responseErr(resp, err)
 }
 
+// Useful shortcut for suppressing errors from Okta's SDK when a Org does not have permission to access a feature.
+func suppressErrorOn401(resp *okta.Response, err error) error {
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		return nil
+	}
+	return responseErr(resp, err)
+}
+
 func getParallelismFromMetadata(meta interface{}) int {
 	return meta.(*Config).parallelism
 }

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -284,9 +284,11 @@ func suppressErrorOn404(resp *okta.Response, err error) error {
 	return responseErr(resp, err)
 }
 
-// Useful shortcut for suppressing errors from Okta's SDK when a Org does not have permission to access a feature.
-func suppressErrorOn401(resp *okta.Response, err error) error {
+// Useful shortcut for suppressing errors from Okta's SDK when a Org does not
+// have permission to access a feature.
+func suppressErrorOn401(what string, meta interface{}, resp *okta.Response, err error) error {
 	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		logger(meta).Warn(fmt.Sprintf("Suppressing %q on %q", "401 Unauthorized", what))
 		return nil
 	}
 	return responseErr(resp, err)

--- a/okta/utils_for_test.go
+++ b/okta/utils_for_test.go
@@ -168,6 +168,7 @@ func errorCheckMessageContaining(t *testing.T, message string, err error) bool {
 	missingFlags := []string{}
 	if message == ErrorCheckMissingPermission {
 		missingFlags = append(missingFlags, "ADVANCED_SSO")
+		missingFlags = append(missingFlags, "MAPPINGS_API")
 	}
 	if message == ErrorCheckCannotCreateSWA {
 		missingFlags = append(missingFlags, "ALLOW_SWA")
@@ -191,7 +192,7 @@ func errorCheckMessageContaining(t *testing.T, message string, err error) bool {
 		missingFlags = append(missingFlags, "OKTA_MFA_POLICY")
 	}
 	if strings.Contains(errorMessage, message) {
-		t.Skipf("Skipping test, org possibly missing flags:\n%+v\nerror:\n%s", missingFlags, errorMessage)
+		t.Skipf("Skipping test, org possibly missing flags:\n%s\nerror:\n%s", strings.Join(missingFlags, ", "), errorMessage)
 		return true
 	}
 


### PR DESCRIPTION
Enhancing  Fix okta_idp_saml resource reading when Mappings API is disabled #1355

- Merges in #1355 fix
- Adds an IT
- Logs a warning when a 401 is suppressed
- 