### PR TITLE
Resource Okta User 403s and skip_roles

### DIFF
--- a/okta/data_source_okta_user_test.go
+++ b/okta/data_source_okta_user_test.go
@@ -74,7 +74,7 @@ func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
 			{
 				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(false, true), ri),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "0"),       // skipped
+					resource.TestCheckNoResourceAttr("data.okta_user.test", "admin_roles.#"),          // skipped
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "2"), // Everyone, A Group
 				),
 			},

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -121,7 +121,7 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, m interfac
 			rawMap["group_memberships"] = groups
 		}
 		if includeRoles {
-			roles, err := getAdminRoles(ctx, user.Id, client)
+			roles, _, err := getAdminRoles(ctx, user.Id, client)
 			if err != nil {
 				return diag.Errorf("failed to set user's admin roles: %v", err)
 			}

--- a/okta/resource_okta_group_memberships_test.go
+++ b/okta/resource_okta_group_memberships_test.go
@@ -2,7 +2,6 @@ package okta
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -248,6 +247,10 @@ data "okta_group" "test_b" {
 
 // TestAccOktaGroupMembershipsIssue1119 addresses https://github.com/okta/terraform-provider-okta/issues/1119
 func TestAccOktaGroupMembershipsIssue1119(t *testing.T) {
+	if !allowLongRunningACCTest(t) {
+		return
+	}
+
 	configUsers := ""
 	for i := 0; i < 250; i++ {
 		configUsers = fmt.Sprintf("%s%s", configUsers, configUser(i))
@@ -268,10 +271,6 @@ resource "okta_group" "test" {
 	}
 
 	config := fmt.Sprintf(strFmt, args...)
-	if !allowLongRunningACCTest(t) {
-		t.SkipNow()
-	}
-
 	ri := acctest.RandInt()
 	mgr := newFixtureManager(groupMemberships)
 	config = mgr.ConfigReplace(config, ri)
@@ -296,15 +295,6 @@ resource "okta_group" "test" {
 			},
 		},
 	})
-}
-
-func allowLongRunningACCTest(t *testing.T) bool {
-	envVar := "OKTA_ALLOW_LONG_RUNNING_ACC_TEST"
-	allow := (os.Getenv(envVar) != "")
-	if !allow {
-		t.Logf("%q not present, skipping test", envVar)
-	}
-	return allow
 }
 
 func configGroupMemberships(n int) string {

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -294,6 +294,16 @@ func suppressErrorOn401(what string, meta interface{}, resp *okta.Response, err 
 	return responseErr(resp, err)
 }
 
+// Useful shortcut for suppressing errors from Okta's SDK when a Org does not
+// have permission to access a feature.
+func suppressErrorOn403(what string, meta interface{}, resp *okta.Response, err error) error {
+	if resp != nil && resp.StatusCode == http.StatusForbidden {
+		logger(meta).Warn(fmt.Sprintf("Suppressing %q on %q", "403 Forbidden", what))
+		return nil
+	}
+	return responseErr(resp, err)
+}
+
 func getParallelismFromMetadata(meta interface{}) int {
 	return meta.(*Config).parallelism
 }

--- a/okta/utils_for_test.go
+++ b/okta/utils_for_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -197,4 +198,27 @@ func errorCheckMessageContaining(t *testing.T, message string, err error) bool {
 	}
 
 	return false
+}
+
+// allowLongRunningACCTest Test skip helper for allowing long running tests to
+// be executed.
+func allowLongRunningACCTest(t *testing.T) bool {
+	envVar := "OKTA_ALLOW_LONG_RUNNING_ACC_TEST"
+	allow := (os.Getenv(envVar) != "")
+	if !allow {
+		t.Skipf("%q not present, skipping test", envVar)
+	}
+	return allow
+}
+
+// orgAdminOnlyTest Test skip helper for tests that should only run with a token
+// of org admin permissions, not super admin.
+func orgAdminOnlyTest(t *testing.T) bool {
+	envVar := "OKTA_API_TOKEN_ROLE"
+	envVal := os.Getenv(envVar)
+	allow := (envVal == "org-admin")
+	if !allow {
+		t.Skipf("%s=%s not, requires %q value, skipping test", envVar, envVal, "org-admin")
+	}
+	return allow
 }

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -50,7 +50,7 @@ data "okta_user" "example" {
   - `expression` - (Optional, but overrides name/comparison/value) A raw search expression string. If present it will override name/comparison/value.
 - `compound_search_operator` - (Optional) Given multiple search elements they will be compounded together with the op. Default is `and`, `or` is also valid.
 - `skip_groups` - (Optional) Additional API call to collect user's groups will not be made.
-- `skip_roles` - (Optional) Additional API call to collect user's roles will not be made.
+- `skip_roles` - (Optional) Additional API call to collect user's roles will not be made. `admin_roles` will not be written to state if skipping roles.
 - `delay_read_seconds` - (Optional) Force delay of the user read by N seconds. Useful when eventual consistency of user information needs to be allowed for.
 
 ## Attributes Reference

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -12,6 +12,11 @@ Creates an Okta User.
 
 This resource allows you to create and configure an Okta User.
 
+~> **IMPORTANT** If the provider is executed with a non-super user API token a
+403 occurs when the provider attempts to inspect the user's admin roles. This
+403 is swallowed and a warning is logged allowing the resource to continue
+without this error hindering it.
+
 ## Example Usage
 
 Full profile:

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -15,7 +15,12 @@ This resource allows you to create and configure an Okta User.
 ~> **IMPORTANT** If the provider is executed with a non-super user API token a
 403 occurs when the provider attempts to inspect the user's admin roles. This
 403 is swallowed and a warning is logged allowing the resource to continue
-without this error hindering it.
+without this error hindering it. An empty `admin_roles` array will be present in
+the resource state.
+
+~> **IMPORTANT** Use `skip_roles=true` to avoid `admin_roles` being present in
+resource state. This also prevents the underlying API call for those values to
+be made.
 
 ## Example Usage
 
@@ -129,6 +134,8 @@ The following arguments are supported:
 - `profile_url` - (Optional) User profile property.
 
 - `second_email` - (Optional) User profile property.
+
+- `skip_roles` - (Optional) Additional API call to collect user's roles will not be made. `admin_roles` will not be written to state if skipping roles.
 
 - `state` - (Optional) User profile property.
 


### PR DESCRIPTION
* swallows 403 when resource attempts to set admin_roles with non-super admin API token
* addes `skip_roles` flag to allow explicit gating on the attempt to set roles
* ITs for all scenarios
* documentation