### PR TITLE
Update basic_updated.tf

### DIFF
--- a/examples/okta_app_signon_policy_rule/basic_updated.tf
+++ b/examples/okta_app_signon_policy_rule/basic_updated.tf
@@ -91,18 +91,16 @@ resource "okta_app_signon_policy_rule" "test" {
     os_type = "MACOS"
     type    = "DESKTOP"
   }
-# FIXME Okta API for /api/v1/policies/{policyId}/rules/{ruleId}
-# is not returning os_expression even when it has been set throwing off the TF state.
-#  platform_include {
-#    os_expression = ".*"
-#    os_type = "OTHER"
-#    type    = "DESKTOP"
-#  }
-#  platform_include {
-#    os_expression = ".*"
-#    os_type = "OTHER"
-#    type    = "MOBILE"
-#  }
+  platform_include {
+    os_expression = ""
+    os_type = "OTHER"
+    type    = "DESKTOP"
+  }
+  platform_include {
+    os_expression = ""
+    os_type = "OTHER"
+    type    = "MOBILE"
+  }
   platform_include {
     os_type = "WINDOWS"
     type    = "DESKTOP"


### PR DESCRIPTION
the only valid `os_expression` seems to be `""`. there doesn't seem to be a way to set it in the Okta Admin UI.

note, i didn't test this example...