### PR TITLE
Add missing arg to docs.

### DIFF
--- a/website/docs/r/app_user_base_schema_property.html.markdown
+++ b/website/docs/r/app_user_base_schema_property.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 
 - `pattern` - (Optional) The validation pattern to use for the subschema, only available for `login` property. Must be in form of `.+`, or `[<pattern>]+`.
 
+- `user_type` - User type ID. By default, it is `"default"`.
+
 ## Attributes Reference
 
 - `app_id` - ID of the application the user property is associated with.

--- a/website/docs/r/app_user_base_schema_property.html.markdown
+++ b/website/docs/r/app_user_base_schema_property.html.markdown
@@ -16,11 +16,11 @@ This resource allows you to configure a base app user schema property.
 
 ```hcl
 resource "okta_app_user_base_schema_property" "example" {
-  app_id      = "<app id>"
-  index       = "customPropertyName"
-  title       = "customPropertyName"
-  type        = "string"
-  master      = "OKTA"
+  app_id = "<app id>"
+  index  = "customPropertyName"
+  title  = "customPropertyName"
+  type   = "string"
+  master = "OKTA"
 }
 ```
 


### PR DESCRIPTION
The supported argument `user_type` for resource `okta_app_user_base_schema_property` is missing from the docs.

This PR adds the argument to the docs.

This is my first PR here so I'm unsure if there's more you need me to do. I read the contributing docs, and I think this should be enough, please let me know if there is more you need.