### PR TITLE
Fix TestAccOktaAppSignOnPolicy so it AccTest Pass

### DIFF
--- a/okta/data_source_okta_policy.go
+++ b/okta/data_source_okta_policy.go
@@ -40,6 +40,10 @@ func dataSourcePolicy() *schema.Resource {
 }
 
 func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if isClassicOrg(m) {
+		return resourceOIEOnlyFeatureError(appSignOnPolicy)
+	}
+
 	policy, err := findPolicyByNameAndType(ctx, m, d.Get("name").(string), d.Get("type").(string))
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Fix TestAccOktaAppSignOnPolicy by updating the `data_source_okta_policy.go` to be OIE aware when running the accept testing on an Okta Classic tenant. 