### PR TITLE
Fix flaw in api look up regex.

### DIFF
--- a/okta/internal/apimutex/apimutex.go
+++ b/okta/internal/apimutex/apimutex.go
@@ -134,10 +134,19 @@ var (
 )
 
 func (m *APIMutex) get(method, endPoint string) *APIStatus {
-	// the important point here is the replace all is performing this
+	// The important point here is the replace all is performing this
 	// transformation for the bucket lookup /api/v1/users/abcdefghij0123456789
-	// to /api/v1/users/ID
-	path := reOktaID.ReplaceAllString(endPoint, "ID")
+	// to /api/v1/users/ID .
+	path := reOktaID.ReplaceAllStringFunc(endPoint, func(element string) string {
+		// Any path elements, like "authorizationServers", which are 20
+		// characters long should be handled here.
+		switch element {
+		case "authorizationServers":
+			return element
+		default:
+			return "ID"
+		}
+	})
 	key := m.normalizedKey(method, path)
 	bucket, ok := m.buckets[key]
 	if !ok {

--- a/okta/internal/apimutex/apimutex_test.go
+++ b/okta/internal/apimutex/apimutex_test.go
@@ -81,6 +81,30 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestGetRegex(t *testing.T) {
+	tests := []struct {
+		method         string
+		endPoint       string
+		expectedBucket string
+	}{
+		{http.MethodGet, "/d/n/e", "/"},
+		{http.MethodGet, "/.well-known/acme-challenge/ID", "/.well-known/acme-challenge/{token}"},
+		{http.MethodGet, "/api/v1/groups", "/api/v1/groups"},
+		{http.MethodPost, "/api/v1/groups", "/api/v1/groups"},
+		{http.MethodGet, "/api/v1/authorizationServers/0123456789abcdefghij/policies/0123456789abcdefghij", "/api/v1"},
+	}
+	amu, err := NewAPIMutex(100)
+	if err != nil {
+		t.Fatalf("api mutex constructor had error %+v", err)
+	}
+	for _, test := range tests {
+		result := amu.get(test.method, test.endPoint)
+		if result != amu.status[test.expectedBucket] {
+			t.Fatalf("expected endpoint \"%s %s\" to be in status bucket %q", test.method, test.endPoint, test.expectedBucket)
+		}
+	}
+}
+
 func minRemaining(remaining []int) int {
 	var result int
 	first := true


### PR DESCRIPTION
URI's like `/api/v1/authorizationServers/0123456789abcdefghij/policies/0123456789abcdefghij` were being normalized as `/api/v1/ID/ID/policies/ID` and the regex / string replacement used for this need to be more precise to produce `/api/v1/authorizationServers/ID/policies/ID`

Closes #1417