### PR TITLE
Bringing in PR 1210

### DIFF
--- a/okta/provider_test.go
+++ b/okta/provider_test.go
@@ -38,14 +38,17 @@ func init() {
 	// tests may need to query the okta API for status and the Terraform SDK
 	// doesn't expose the provider's meta data where we store the provider's
 	// config until after tests have completed.
-	config := &Config{
-		orgName: os.Getenv("OKTA_ORG_NAME"),
-		domain:  os.Getenv("OKTA_BASE_URL"),
-	}
-	config.logger = providerLogger(config)
-	testSDKClient, _ = oktaSDKClient(config)
-	testSupplementClient = &sdk.APISupplement{
-		RequestExecutor: testSDKClient.CloneRequestExecutor(),
+	if os.Getenv("TF_ACC") != "" {
+		// only set up for acceptance tests
+		config := &Config{
+			orgName: os.Getenv("OKTA_ORG_NAME"),
+			domain:  os.Getenv("OKTA_BASE_URL"),
+		}
+		config.logger = providerLogger(config)
+		testSDKClient, _ = oktaSDKClient(config)
+		testSupplementClient = &sdk.APISupplement{
+			RequestExecutor: testSDKClient.CloneRequestExecutor(),
+		}
 	}
 }
 

--- a/okta/provider_test.go
+++ b/okta/provider_test.go
@@ -15,11 +15,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/terraform-provider-okta/sdk"
 )
 
 var (
 	testAccProvidersFactories map[string]func() (*schema.Provider, error)
 	testAccProvider           *schema.Provider
+	testSDKClient             *okta.Client
+	testSupplementClient      *sdk.APISupplement
 )
 
 func init() {
@@ -28,6 +31,21 @@ func init() {
 		"okta": func() (*schema.Provider, error) {
 			return testAccProvider, nil
 		},
+	}
+
+	// We need to be able to query the SDK with an Okta SDK golang client that
+	// is outside of the client that terraform provider creates. This is because
+	// tests may need to query the okta API for status and the Terraform SDK
+	// doesn't expose the provider's meta data where we store the provider's
+	// config until after tests have completed.
+	config := &Config{
+		orgName: os.Getenv("OKTA_ORG_NAME"),
+		domain:  os.Getenv("OKTA_BASE_URL"),
+	}
+	config.logger = providerLogger(config)
+	testSDKClient, _ = oktaSDKClient(config)
+	testSupplementClient = &sdk.APISupplement{
+		RequestExecutor: testSDKClient.CloneRequestExecutor(),
 	}
 }
 
@@ -61,6 +79,27 @@ func oktaConfig() (*Config, error) {
 		return config, fmt.Errorf("error initializing Okta client: %v", err)
 	}
 	return config, nil
+}
+
+// testOIEOnlyAccPreCheck is a resource.test PreCheck function that will place a
+// logical skip of OIE tests when tests are run against a classic org.
+func testOIEOnlyAccPreCheck(t *testing.T) func() {
+	return func() {
+		err := accPreCheck()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		org, _, err := testSupplementClient.GetWellKnownOktaOrganization(context.TODO())
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// v1 == Classic, idx == OIE
+		if org.Pipeline != "idx" {
+			t.Skipf("%q test is for OIE orgs only", t.Name())
+		}
+	}
 }
 
 func testAccPreCheck(t *testing.T) func() {

--- a/okta/resource_okta_policy_mfa.go
+++ b/okta/resource_okta_policy_mfa.go
@@ -90,7 +90,7 @@ func buildSettings(d *schema.ResourceData) *sdk.PolicySettings {
 	if d.Get("is_oie") == true {
 		authenticators := []*sdk.PolicyAuthenticator{}
 
-		for _, key := range remove(sdk.AuthenticatorProviders, sdk.OktaPasswordFactor) {
+		for _, key := range sdk.AuthenticatorProviders {
 			rawFactor := d.Get(key).(map[string]interface{})
 			enroll := rawFactor["enroll"]
 			if enroll == nil {
@@ -155,7 +155,7 @@ func syncSettings(d *schema.ResourceData, settings *sdk.PolicySettings) {
 	_ = d.Set("is_oie", settings.Type == "AUTHENTICATORS")
 
 	if settings.Type == "AUTHENTICATORS" {
-		for _, key := range remove(sdk.AuthenticatorProviders, sdk.OktaPasswordFactor) {
+		for _, key := range sdk.AuthenticatorProviders {
 			syncAuthenticator(d, key, settings.Authenticators)
 		}
 	} else {
@@ -189,14 +189,9 @@ func syncFactor(d *schema.ResourceData, k string, f *sdk.PolicyFactor) {
 func syncAuthenticator(d *schema.ResourceData, k string, authenticators []*sdk.PolicyAuthenticator) {
 	for _, authenticator := range authenticators {
 		if authenticator.Key == k {
-			// Skip OktaPassword as this should never be returned for MFA policies using authenticator.
-			// Enrollment policy changes for OIE for password
-			// https://help.okta.com/okta_help.htm?type=oie&id=ext-about-mfa-enrol-policies
-			if k != sdk.OktaPasswordFactor {
-				_ = d.Set(k, map[string]interface{}{
-					"enroll": authenticator.Enroll.Self,
-				})
-			}
+			_ = d.Set(k, map[string]interface{}{
+				"enroll": authenticator.Enroll.Self,
+			})
 			return
 		}
 	}

--- a/okta/resource_okta_policy_mfa_test.go
+++ b/okta/resource_okta_policy_mfa_test.go
@@ -48,3 +48,58 @@ func TestAccOktaMfaPolicy_crud(t *testing.T) {
 		},
 	})
 }
+
+// TestAccOktaMfaPolicy_PR_1210 deals with testing
+// https://github.com/okta/terraform-provider-okta/pull/1210
+func TestAccOktaMfaPolicy_PR_1210(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(policyMfa)
+	config := `
+data "okta_group" "all" {
+  name = "Everyone"
+}
+resource "okta_policy_mfa" "test" {
+  name        = "testAcc_replace_with_uuid"
+  status = "ACTIVE"
+  description = "Terraform Acceptance Test MFA Policy"
+  priority = 1
+  is_oie  = true
+
+  okta_password = {
+    enroll = "REQUIRED"
+  }
+
+  okta_email = {
+    enroll = "NOT_ALLOWED"
+  }
+
+  fido_webauthn = {
+    enroll = "REQUIRED"
+  }
+
+  groups_included = [data.okta_group.all.id]
+}
+	`
+	resourceName := fmt.Sprintf("%s.test", policyMfa)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testOIEOnlyAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      createPolicyCheckDestroy(policyMfa),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config, ri),
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(ri)),
+					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
+					resource.TestCheckResourceAttr(resourceName, "description", "Terraform Acceptance Test MFA Policy"),
+					resource.TestCheckResourceAttr(resourceName, "okta_password.enroll", "REQUIRED"),
+					resource.TestCheckResourceAttr(resourceName, "okta_email.enroll", "NOT_ALLOWED"),
+					resource.TestCheckResourceAttr(resourceName, "fido_webauthn.enroll", "REQUIRED"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
- Bringing in @ nickrmc83's code in PR  "Enable okta_password authenticator for okta_policy_mfa" #1210 
- Adding test for #1210 
- Mild provider config refactor to DRY up having a SDK client in the test harness for pre-checks

Testing on an OIE org:
```
$ go clean -testcache
$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaMfaPolicy_PR_1210$ ./okta 2>&1
2023/01/17 06:44:17 [INFO]  running with default http client
=== RUN   TestAccOktaMfaPolicy_PR_1210
--- PASS: TestAccOktaMfaPolicy_PR_1210 (4.34s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    4.693s

$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaMfaPolicy_Issue_1176$ ./okta 2>&1
2023/01/18 09:10:31 [INFO]  running with default http client
=== RUN   TestAccOktaMfaPolicy_Issue_1176
--- PASS: TestAccOktaMfaPolicy_Issue_1176 (9.66s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    11.532s
```

Testing on an Classic org
```
$ go clean -testcache
$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaMfaPolicy_PR_1210$ ./okta 2>&1
2023/01/17 06:45:19 [INFO]  running with default http client
=== RUN   TestAccOktaMfaPolicy_PR_1210
    provider_test.go:100: "TestAccOktaMfaPolicy_PR_1210" test is for OIE orgs only
--- SKIP: TestAccOktaMfaPolicy_PR_1210 (0.20s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    0.592s
```