### PR TITLE
Prep v3.41.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.41.0 (January 27, 2023)
+
+### PROJECT IMPROVEMENTS:
+
+* Enable okta_password authenticator for okta_policy_mfa [#1210](https://github.com/okta/terraform-provider-okta/pull/1210). Tests [#1427](https://github.com/okta/terraform-provider-okta/pull/1427). Thanks, [@nickrmc83](https://github.com/nickrmc83)!
+* Update resource documentation with link to role-type api doc references [#1430](https://github.com/okta/terraform-provider-okta/pull/1430). Thanks, [@noinarisak](https://github.com/noinarisak)!
+
 ## 3.40.0 (January 09, 2023)
 
 ### BUG FIXES:

--- a/okta/config.go
+++ b/okta/config.go
@@ -133,7 +133,7 @@ func oktaSDKClient(c *Config) (client *okta.Client, err error) {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.40.0"),
+		okta.WithUserAgentExtra("okta-terraform/3.41.0"),
 	}
 
 	switch {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.40"
+      version = "~> 3.41"
     }
   }
 }


### PR DESCRIPTION
## 3.41.0 (January 27, 2023)

### PROJECT IMPROVEMENTS:

* Enable okta_password authenticator for okta_policy_mfa [#1210](https://github.com/okta/terraform-provider-okta/pull/1210). Tests [#1427](https://github.com/okta/terraform-provider-okta/pull/1427). Thanks, [@nickrmc83](https://github.com/nickrmc83)!
* Update resource documentation with link to role-type api doc references [#1430](https://github.com/okta/terraform-provider-okta/pull/1430). Thanks, [@noinarisak](https://github.com/noinarisak)!
