### PR TITLE
remove role suppression in data_source_okta_user

### DIFF
--- a/okta/data_source_okta_user.go
+++ b/okta/data_source_okta_user.go
@@ -135,6 +135,10 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 			if err != nil {
 				return diag.Errorf("failed to set user's admin roles: %v", err)
 			}
+			err = setRoles(ctx, d, m)
+			if err != nil {
+				return diag.Errorf("failed to set user's roles: %v", err)
+			}
 		}
 	}
 

--- a/okta/data_source_okta_user_test.go
+++ b/okta/data_source_okta_user_test.go
@@ -83,7 +83,6 @@ func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
 	})
 }
 
-// TODU
 // TestAccDataSourceOktaUser_SkipGroups pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipGroups(t *testing.T) {
 	ri := acctest.RandInt()
@@ -126,7 +125,6 @@ func TestAccDataSourceOktaUser_SkipGroupsSkipRoles(t *testing.T) {
 	})
 }
 
-// TODU
 // TestAccDataSourceOktaUser_NoSkips pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_NoSkips(t *testing.T) {
 	ri := acctest.RandInt()

--- a/okta/data_source_okta_user_test.go
+++ b/okta/data_source_okta_user_test.go
@@ -75,6 +75,7 @@ func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
 				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(false, true), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("data.okta_user.test", "admin_roles.#"),          // skipped
+					resource.TestCheckNoResourceAttr("data.okta_user.test", "roles.#"),                // skipped
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "2"), // Everyone, A Group
 				),
 			},
@@ -82,6 +83,7 @@ func TestAccDataSourceOktaUser_SkipAdminRoles(t *testing.T) {
 	})
 }
 
+// TODU
 // TestAccDataSourceOktaUser_SkipGroups pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_SkipGroups(t *testing.T) {
 	ri := acctest.RandInt()
@@ -95,6 +97,7 @@ func TestAccDataSourceOktaUser_SkipGroups(t *testing.T) {
 				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(true, false), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "2"),       // SUPER_ADMIN, APP_ADMIN
+					resource.TestCheckResourceAttr("data.okta_user.test", "roles.#", "2"),             // SUPER_ADMIN, APP_ADMIN
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "0"), // skipped
 				),
 			},
@@ -115,6 +118,7 @@ func TestAccDataSourceOktaUser_SkipGroupsSkipRoles(t *testing.T) {
 				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(true, true), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "0"),       // skipped
+					resource.TestCheckResourceAttr("data.okta_user.test", "roles.#", "0"),             // skipped
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "0"), // skipped
 				),
 			},
@@ -122,6 +126,7 @@ func TestAccDataSourceOktaUser_SkipGroupsSkipRoles(t *testing.T) {
 	})
 }
 
+// TODU
 // TestAccDataSourceOktaUser_NoSkips pertains to https://github.com/okta/terraform-provider-okta/pull/1137 and https://github.com/okta/terraform-provider-okta/issues/1014
 func TestAccDataSourceOktaUser_NoSkips(t *testing.T) {
 	ri := acctest.RandInt()
@@ -137,6 +142,7 @@ func TestAccDataSourceOktaUser_NoSkips(t *testing.T) {
 				Config: mgr.ConfigReplace(testOktaUserRolesGroupsConfig(false, false), ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.okta_user.test", "admin_roles.#", "2"),       // SUPER_ADMIN, APP_ADMIN
+					resource.TestCheckResourceAttr("data.okta_user.test", "roles.#", "2"),             // SUPER_ADMIN, APP_ADMIN
 					resource.TestCheckResourceAttr("data.okta_user.test", "group_memberships.#", "2"), // Everyone, A Group
 					resource.TestMatchOutput("output_admin_roles", allAdminRolesRegexp),
 					resource.TestMatchOutput("output_group_memberships", allGroupMembershipsRegexp),


### PR DESCRIPTION
post hoc ref:
This change was made in regards of https://github.com/okta/terraform-provider-okta/issues/1208
Instead of "fixing" `admin_roles` on user potentially causing another breaking change, a new `roles` attribute was included on the user data source to allow the operator to see all the roles as they see fit. I see the the implementation didn't take into consideration the `skip_roles` behavior on that data source.