### PR TITLE
Update data_source_okta_policy.go

### DIFF
--- a/okta/data_source_okta_policy.go
+++ b/okta/data_source_okta_policy.go
@@ -41,7 +41,7 @@ func dataSourcePolicy() *schema.Resource {
 
 func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	if isClassicOrg(m) {
-		return resourceOIEOnlyFeatureError(appSignOnPolicy)
+		return datasourceOIEOnlyFeatureError(policy)
 	}
 
 	policy, err := findPolicyByNameAndType(ctx, m, d.Get("name").(string), d.Get("type").(string))


### PR DESCRIPTION
This was calling the incorrect error message helper (should be the data sources variant), and with the correct data source name (policy)