### PR TITLE
Update data_source_okta_policy.go

### DIFF
--- a/okta/data_source_okta_policy.go
+++ b/okta/data_source_okta_policy.go
@@ -2,11 +2,9 @@ package okta
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
 
 func dataSourcePolicy() *schema.Resource {
@@ -19,8 +17,8 @@ func dataSourcePolicy() *schema.Resource {
 				Required:    true,
 			},
 			"type": {
-				Type: schema.TypeString,
-				Description: fmt.Sprintf("Policy type, see https://developer.okta.com/docs/reference/api/policy/#policy-object"),
+				Type:        schema.TypeString,
+				Description: "Policy type, see https://developer.okta.com/docs/reference/api/policy/#policy-object",
 				Required:    true,
 			},
 			"status": {

--- a/okta/data_source_okta_policy.go
+++ b/okta/data_source_okta_policy.go
@@ -20,15 +20,7 @@ func dataSourcePolicy() *schema.Resource {
 			},
 			"type": {
 				Type: schema.TypeString,
-				ValidateDiagFunc: elemInSlice([]string{
-					sdk.SignOnPolicyType,
-					sdk.PasswordPolicyType,
-					sdk.MfaPolicyType,
-					sdk.IdpDiscoveryType,
-					sdk.AccessPolicyType,
-					sdk.ProfileEnrollmentPolicyType,
-				}),
-				Description: fmt.Sprintf("Policy type: %s, %s, %s, or %s", sdk.SignOnPolicyType, sdk.PasswordPolicyType, sdk.MfaPolicyType, sdk.IdpDiscoveryType),
+				Description: fmt.Sprintf("Policy type, see https://developer.okta.com/docs/reference/api/policy/#policy-object"),
 				Required:    true,
 			},
 			"status": {
@@ -40,10 +32,6 @@ func dataSourcePolicy() *schema.Resource {
 }
 
 func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	if isClassicOrg(m) {
-		return resourceOIEOnlyFeatureError(appSignOnPolicy)
-	}
-
 	policy, err := findPolicyByNameAndType(ctx, m, d.Get("name").(string), d.Get("type").(string))
 	if err != nil {
 		return diag.FromErr(err)

--- a/website/docs/d/policy.html.markdown
+++ b/website/docs/d/policy.html.markdown
@@ -23,8 +23,16 @@ data "okta_policy" "example" {
 
 - `name` - (Required) Name of policy to retrieve.
 
-- `type` - (Required) Type of policy to retrieve. Valid values: `"OKTA_SIGN_ON"`, `"PASSWORD"`, `"MFA_ENROLL"`, 
-`"IDP_DISCOVERY"`, `"ACCESS_POLICY"` (**only available as a part of the Identity Engine**), `"PROFILE_ENROLLMENT"` (**only available as a part of the Identity Engine**)
+- `type` - (Required) Type of policy to retrieve. See https://developer.okta.com/docs/reference/api/policy/#policy-object for valid values. Currently:
+    - All: 
+    - `OKTA_SIGN_ON`
+    - `PASSWORD`
+    - `MFA_ENROLL`
+    - `OAUTH_AUTHORIZATION_POLICY`
+    - `IDP_DISCOVERY`
+    - OIE Only:
+    - `ACCESS_POLICY`
+    - `PROFILE_ENROLLMENT`
 
 ## Attributes Reference
 


### PR DESCRIPTION
We shouldn't be blocking with `isClassicOrg` on the GET for a policy as https://developer.okta.com/docs/reference/api/policy/#policy-object documents there are 7 policy types and only two of them are for OIE. And we shouldn't be blocking with a validation function. Let the operator choose their type and have the API return any errors instead of artificially checking here.

All
- OKTA_SIGN_ON
- PASSWORD
- MFA_ENROLL
- OAUTH_AUTHORIZATION_POLICY
- IDP_DISCOVERY

Identity Engine
- ACCESS_POLICY
- PROFILE_ENROLLMENT

Passing OIE org:

```
$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaDataSourcePolicy_read$ ./okta 2>&1
2023/02/08 11:20:04 [INFO]  running with default http client
=== RUN   TestAccOktaDataSourcePolicy_read
--- PASS: TestAccOktaDataSourcePolicy_read (6.07s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.513s
```

Passing Classic org

```
$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccOktaDataSourcePolicy_read$ ./okta 2>&1
2023/02/08 11:20:29 [INFO]  running with default http client
=== RUN   TestAccOktaDataSourcePolicy_read
--- PASS: TestAccOktaDataSourcePolicy_read (2.84s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    3.167s
```