### PR TITLE
v3.42.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.42.0 (February 10, 2023)
+
+### NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:
+
+* New data source [`okta_domain`](https://registry.terraform.io/providers/okta/okta/latest/docs/data-sources/domain) see PR 1447 notes in BUG FIXES
+* Actual PEM text values in `okta_domain_certificate` for attributes `certificate`, `certificate_chain`, and `private_key`, see PR 1447 notes in BUG FIXES
+* New attribute `roles` in data source `okta_user` [#1437](https://github.com/okta/terraform-provider-okta/pull/1437). Thanks, [@duytiennguyen-okta](https://github.com/duytiennguyen-okta)!
+
+### BUG FIXES:
+
+* Don't md5sum to save space on `okta_domain_certificate` values for attributes `certificate`, `certificate_chain`, and `private_key`, per TF best practices [#1447](https://github.com/okta/terraform-provider-okta/pull/1447). Thanks, [@monde](https://github.com/monde)!
+* Remove org type restrictions and artificial input check on `type` attribute for  data source `okta_policy`  [#1445](https://github.com/okta/terraform-provider-okta/pull/1445). Thanks, [@monde](https://github.com/monde)!
+* Improve resource `okta_app_saml` documentation  [#1439](https://github.com/okta/terraform-provider-okta/pull/1439). Thanks, [@exitcode0](https://github.com/exitcode0)!
+
 ## 3.41.0 (January 27, 2023)
 
 ### PROJECT IMPROVEMENTS:

--- a/okta/config.go
+++ b/okta/config.go
@@ -133,7 +133,7 @@ func oktaSDKClient(c *Config) (client *okta.Client, err error) {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.41.0"),
+		okta.WithUserAgentExtra("okta-terraform/3.42.0"),
 	}
 
 	switch {

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -83,6 +83,7 @@ data "okta_user" "example" {
 - `preferred_language` - User's preferred written or spoken languages.
 - `primary_phone` - Primary phone number of user such as home number.
 - `profile_url` - URL of user's online profile (e.g. a web page).
+- `roles` - All roles assigned to user.
 - `second_email` - Secondary email address of user typically used for account recovery.
 - `state` - State or region component of user's address (region).
 - `status` - Current status of user.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.41"
+      version = "~> 3.42"
     }
   }
 }


### PR DESCRIPTION
## 3.42.0 (February 10, 2023)

### NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:

* New data source [`okta_domain`](https://registry.terraform.io/providers/okta/okta/latest/docs/data-sources/domain) see PR 1447 notes in BUG FIXES
* Actual PEM text values in `okta_domain_certificate` for attributes `certificate`, `certificate_chain`, and `private_key`, see PR 1447 notes in BUG FIXES
* New attribute `roles` in data source `okta_user` [#1437](https://github.com/okta/terraform-provider-okta/pull/1437). Thanks, [@duytiennguyen-okta](https://github.com/duytiennguyen-okta)!

### BUG FIXES:

* Don't md5sum to save space on `okta_domain_certificate` values for attributes `certificate`, `certificate_chain`, and `private_key`, per TF best practices [#1447](https://github.com/okta/terraform-provider-okta/pull/1447). Thanks, [@monde](https://github.com/monde)!
* Remove org type restrictions and artificial input check on `type` attribute for  data source `okta_policy`  [#1445](https://github.com/okta/terraform-provider-okta/pull/1445). Thanks, [@monde](https://github.com/monde)!
* Improve resource `okta_app_saml` documentation  [#1439](https://github.com/okta/terraform-provider-okta/pull/1439). Thanks, [@exitcode0](https://github.com/exitcode0)!