### PR TITLE
[READY] Update `okta_user` to Support Ignoring Custom Profile Attributes

### DIFF
--- a/examples/okta_user/custom_attributes_to_ignore.tf
+++ b/examples/okta_user/custom_attributes_to_ignore.tf
@@ -1,0 +1,29 @@
+resource "okta_user_schema_property" "test" {
+  index  = "customAttribute123"
+  title  = "terraform acceptance test"
+  type   = "string"
+  master = "PROFILE_MASTER"
+}
+
+resource "okta_user_schema_property" "test2" {
+  index  = "customAttribute1234"
+  title  = "terraform acceptance test"
+  type   = "string"
+  master = "PROFILE_MASTER"
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  custom_profile_attributes_to_ignore = ["customAttribute123"]
+  custom_profile_attributes           = <<JSON
+  {
+    "customAttribute1234": "testing-custom-attribute"
+  }
+JSON
+
+  depends_on = [okta_user_schema_property.test, okta_user_schema_property.test2]
+}

--- a/okta/data_source_okta_user.go
+++ b/okta/data_source_okta_user.go
@@ -123,7 +123,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 		user = users[0]
 	}
 	d.SetId(user.Id)
-	rawMap := flattenUser(user)
+	rawMap := flattenUser(user, []string{})
 	err = setNonPrimitives(d, rawMap)
 	if err != nil {
 		return diag.Errorf("failed to set user's properties: %v", err)

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -111,7 +111,7 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, m interfac
 	includeRoles := d.Get("include_roles").(bool)
 	arr := make([]map[string]interface{}, len(users))
 	for i, user := range users {
-		rawMap := flattenUser(user)
+		rawMap := flattenUser(user, []string{})
 		rawMap["id"] = user.Id
 		if includeGroups {
 			groups, err := getGroupsForUser(ctx, user.Id, client)

--- a/okta/resource_okta_user_test.go
+++ b/okta/resource_okta_user_test.go
@@ -20,6 +20,7 @@ func TestAccOktaUser_customProfileAttributes(t *testing.T) {
 	mgr := newFixtureManager(user)
 	config := mgr.GetFixtures("custom_attributes.tf", ri, t)
 	arrayAttrConfig := mgr.GetFixtures("custom_attributes_array.tf", ri, t)
+	ignoreConfig := mgr.GetFixtures("custom_attributes_to_ignore.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("remove_custom_attributes.tf", ri, t)
 	importConfig := mgr.GetFixtures("import.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", user)
@@ -53,6 +54,18 @@ func TestAccOktaUser_customProfileAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes", "{\"array123\":[\"test\"],\"number123\":1}"),
 				),
 			},
+			{
+				Config:  ignoreConfig,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Smith"),
+					resource.TestCheckResourceAttr(resourceName, "login", email),
+					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes", "{\"customAttribute1234\":\"testing-custom-attribute\"}"), // Note: "customAttribute123" is ignored and should not be present
+				),
+			},
+
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(

--- a/okta/resource_okta_user_type.go
+++ b/okta/resource_okta_user_type.go
@@ -23,17 +23,17 @@ func resourceUserType() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The display name for the type",
+				Description: "Name of the user type",
 			},
 			"display_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The display name for the type	",
+				Description: "The display name of the user type",
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "A human-readable description of the type",
+				Description: "A human-readable description of the User type",
 			},
 		},
 	}

--- a/okta/user.go
+++ b/okta/user.go
@@ -420,7 +420,7 @@ func isCustomUserAttr(key string) bool {
 	return !contains(profileKeys, key)
 }
 
-func flattenUser(u *okta.User) map[string]interface{} {
+func flattenUser(u *okta.User, filteredCustomAttributes []string) map[string]interface{} {
 	customAttributes := make(map[string]interface{})
 	attrs := map[string]interface{}{}
 
@@ -429,6 +429,12 @@ func flattenUser(u *okta.User) map[string]interface{} {
 			attrKey := camelCaseToUnderscore(k)
 
 			if isCustomUserAttr(attrKey) {
+
+				// Exclude any custom attributes that should be filtered
+				if contains(filteredCustomAttributes, attrKey) {
+					continue
+				}
+
 				// Supporting any potential type
 				ref := reflect.ValueOf(v)
 				switch ref.Kind() {

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -88,6 +88,10 @@ The following arguments are supported:
 
 - `custom_profile_attributes` - (Optional) raw JSON containing all custom profile attributes.
 
+- `custom_profile_attributes_to_ignore` - (Optional) List of custom_profile_attribute keys that should be excluded from being
+managed by Terraform. This is useful in situations where specific custom fields may contain sensitive information and
+should be managed outside of Terraform.
+
 - `admin_roles` - (Optional) Administrator roles assigned to User.
   - `DEPRECATED`: Please replace usage with the `okta_user_admin_roles` resource.
 
@@ -156,28 +160,28 @@ The following arguments are supported:
 - `expire_password_on_create` - (Optional) If set to `true`, the user will have to change the password at the next login. This property will be used
   when user is being created and works only when `password` field is set. Default is `false`.
 
-- `old_password` - (Optional) Old user password. **IMPORTANT**: Should be ONLY set in case the password was changed 
-outside the provider. After successful password change this field should be removed and `password` field should be used 
+- `old_password` - (Optional) Old user password. **IMPORTANT**: Should be ONLY set in case the password was changed
+outside the provider. After successful password change this field should be removed and `password` field should be used
 for further changes.
 
-- `password_inline_hook` (Optional) Specifies that a Password Import Inline Hook should be triggered to handle verification 
-of the user's password the first time the user logs in. This allows an existing password to be imported into Okta directly 
+- `password_inline_hook` (Optional) Specifies that a Password Import Inline Hook should be triggered to handle verification
+of the user's password the first time the user logs in. This allows an existing password to be imported into Okta directly
 from some other store. When updating a user with a password hook the user must be in the `STAGED` status. The `password`
-field should not be specified when using Password Import Inline Hook. 
+field should not be specified when using Password Import Inline Hook.
 
 - `recovery_question` - (Optional) User password recovery question.
 
 - `recovery_answer` - (Optional) User password recovery answer.
 
-- `password hash` - (Optional) Specifies a hashed password to import into Okta. When updating a user with a hashed password the user must be in the `STAGED` status.  
+- `password hash` - (Optional) Specifies a hashed password to import into Okta. When updating a user with a hashed password the user must be in the `STAGED` status.
   - `algorithm"` - (Required) The algorithm used to generate the hash using the password (and salt, when applicable). Must be set to BCRYPT, SHA-512, SHA-256, SHA-1 or MD5.
-  - `salt` - (Optional) Only required for salted hashes. For BCRYPT, this specifies the radix64-encoded salt used to generate 
+  - `salt` - (Optional) Only required for salted hashes. For BCRYPT, this specifies the radix64-encoded salt used to generate
   the hash, which must be 22 characters long. For other salted hashes, this specifies the base64-encoded salt used to generate the hash.
   - `work_factor` - (Optional) Governs the strength of the hash and the time required to compute it. Only required for BCRYPT algorithm. Minimum value is 1, and maximum is 20.
   - `salt_order` - (Optional) Specifies whether salt was pre- or postfixed to the password before hashing. Only required for salted algorithms.
-  - `value` - (Optional) For SHA-512, SHA-256, SHA-1, MD5, this is the actual base64-encoded hash of the password (and salt, if used). 
-  This is the Base64 encoded value of the SHA-512/SHA-256/SHA-1/MD5 digest that was computed by either pre-fixing or post-fixing 
-  the salt to the password, depending on the saltOrder. If a salt was not used in the source system, then this should just be 
+  - `value` - (Optional) For SHA-512, SHA-256, SHA-1, MD5, this is the actual base64-encoded hash of the password (and salt, if used).
+  This is the Base64 encoded value of the SHA-512/SHA-256/SHA-1/MD5 digest that was computed by either pre-fixing or post-fixing
+  the salt to the password, depending on the saltOrder. If a salt was not used in the source system, then this should just be
   the Base64 encoded value of the password's SHA-512/SHA-256/SHA-1/MD5 digest. For BCRYPT, This is the actual radix64-encoded hashed password.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes: #1449 

### Summary
This pull request implements custom profile attribute filtering as specified in #1449. Specifically, it mimics Terraform's native  `lifecycle.ignore_changes` for the JSON encoded `custom_profile_attributes` to achieve similar behavior. This is useful when Terraform manages state for users; however, there may exist cases where some custom profile fields **should not** be managed by state and managed exclusively via the UI or separate team members.

- This is backwards compatible and is only adding new functionality.
- Creation of a new attribute on `okta_user`: `custom_profile_attributes_to_ignore` 

    `custom_profile_attributes_to_ignore` - (Optional) List of custom_profile_attribute keys that should be excluded from being managed by Terraform. This is useful in situations where specific custom fields may contain sensitive information and should be managed outside of Terraform.

### How this works under the hood

* Note: Profile attributes must be specified in entirety as required by the Okta API.
* Goal: Not store custom attributes in state or have diff sets for those keys
* For **New Resources**:  We simply drop any profile keys that are filtered _(If someone wants something filtered/excluded, they shouldn't include it in initial attributes)_
* For **Updated Resources**: We use the values from the server to overwrite the filtered keys so they match exactly resulting in zero diffs. 
* State is then filtered and never saved after update.

### Acceptance Tests

```
root@3891819d1a69:/main# make testacc TEST=./okta TESTARGS='-run=TestAccOktaUser_customProfileAttributes'
TF_ACC=1 go test ./okta -v -run=TestAccOktaUser_customProfileAttributes  -timeout 120m
2023/02/13 07:24:08 [INFO]  running with default http client
=== RUN   TestAccOktaUser_customProfileAttributes
--- PASS: TestAccOktaUser_customProfileAttributes (20.29s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    20.306s
```

> Additionally, thoroughly tested in our internal organization

---

/cc @monde Should be ready for initial review.
