### PR TITLE
Add import functionality for okta_email_customization

### DIFF
--- a/okta/resource_okta_email_customization.go
+++ b/okta/resource_okta_email_customization.go
@@ -15,10 +15,8 @@ func resourceEmailCustomization() *schema.Resource {
 		ReadContext:   resourceEmailCustomizationRead,
 		UpdateContext: resourceEmailCustomizationUpdate,
 		DeleteContext: resourceEmailCustomizationDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: emailCustomizationResourceSchema,
+		Importer:      createNestedResourceImporter([]string{"id", "brand_id", "template_name"}),
+		Schema:        emailCustomizationResourceSchema,
 	}
 }
 

--- a/website/docs/r/email_customization.html.markdown
+++ b/website/docs/r/email_customization.html.markdown
@@ -130,3 +130,11 @@ resource "okta_email_customization" "forgot_password_en_alt" {
 
 - `id` - Customization ID
 - `links` - Link relations for this object - JSON HAL - Discoverable resources related to the email template
+
+## Import
+
+An email customization can be imported using the customization ID, brand ID and template name.
+
+```
+$ terraform import okta_email_customization.example &#60;customization_id&#62;/&#60;brand_id&#62;/&#60;template_name&#62;
+```


### PR DESCRIPTION
Hi

This PR adds import functionality for `okta_email_customization`.

The import resource identifier takes the format `customization_id/brand_id/template_name`

e.g.
```
terraform import okta_email_customization.example oelxxxxxxxxxxxxxx1d7/bndyyyyyyyyyyyyyy1d7/ForgotPassword
```

I haven't been able to get the acceptance tests running locally, so that's a best effort, however I've built and run the provider with terraform and imported resources successfully.