### PR TITLE
Virgofx okta user custom profile attributes

### DIFF
--- a/examples/okta_user/custom_attributes_to_ignore.tf
+++ b/examples/okta_user/custom_attributes_to_ignore.tf
@@ -1,0 +1,29 @@
+resource "okta_user_schema_property" "test" {
+  index  = "customAttribute123"
+  title  = "terraform acceptance test"
+  type   = "string"
+  master = "PROFILE_MASTER"
+}
+
+resource "okta_user_schema_property" "test2" {
+  index  = "customAttribute1234"
+  title  = "terraform acceptance test"
+  type   = "string"
+  master = "PROFILE_MASTER"
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc-replace_with_uuid@example.com"
+  email      = "testAcc-replace_with_uuid@example.com"
+
+  custom_profile_attributes_to_ignore = ["customAttribute123"]
+  custom_profile_attributes           = <<JSON
+  {
+    "customAttribute1234": "testing-custom-attribute"
+  }
+JSON
+
+  depends_on = [okta_user_schema_property.test, okta_user_schema_property.test2]
+}

--- a/okta/data_source_okta_user.go
+++ b/okta/data_source_okta_user.go
@@ -123,7 +123,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 		user = users[0]
 	}
 	d.SetId(user.Id)
-	rawMap := flattenUser(user)
+	rawMap := flattenUser(user, []string{})
 	err = setNonPrimitives(d, rawMap)
 	if err != nil {
 		return diag.Errorf("failed to set user's properties: %v", err)

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -111,7 +111,7 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, m interfac
 	includeRoles := d.Get("include_roles").(bool)
 	arr := make([]map[string]interface{}, len(users))
 	for i, user := range users {
-		rawMap := flattenUser(user)
+		rawMap := flattenUser(user, []string{})
 		rawMap["id"] = user.Id
 		if includeGroups {
 			groups, err := getGroupsForUser(ctx, user.Id, client)

--- a/okta/resource_okta_user_test.go
+++ b/okta/resource_okta_user_test.go
@@ -20,6 +20,7 @@ func TestAccOktaUser_customProfileAttributes(t *testing.T) {
 	mgr := newFixtureManager(user)
 	config := mgr.GetFixtures("custom_attributes.tf", ri, t)
 	arrayAttrConfig := mgr.GetFixtures("custom_attributes_array.tf", ri, t)
+	ignoreConfig := mgr.GetFixtures("custom_attributes_to_ignore.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("remove_custom_attributes.tf", ri, t)
 	importConfig := mgr.GetFixtures("import.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", user)
@@ -53,6 +54,18 @@ func TestAccOktaUser_customProfileAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes", "{\"array123\":[\"test\"],\"number123\":1}"),
 				),
 			},
+			{
+				Config:  ignoreConfig,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Smith"),
+					resource.TestCheckResourceAttr(resourceName, "login", email),
+					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes", "{\"customAttribute1234\":\"testing-custom-attribute\"}"), // Note: "customAttribute123" is ignored and should not be present
+				),
+			},
+
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(

--- a/okta/resource_okta_user_type.go
+++ b/okta/resource_okta_user_type.go
@@ -23,17 +23,17 @@ func resourceUserType() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The display name for the type",
+				Description: "Name of the user type",
 			},
 			"display_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The display name for the type	",
+				Description: "The display name of the user type",
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "A human-readable description of the type",
+				Description: "A human-readable description of the User type",
 			},
 		},
 	}

--- a/okta/user.go
+++ b/okta/user.go
@@ -420,7 +420,7 @@ func isCustomUserAttr(key string) bool {
 	return !contains(profileKeys, key)
 }
 
-func flattenUser(u *okta.User) map[string]interface{} {
+func flattenUser(u *okta.User, filteredCustomAttributes []string) map[string]interface{} {
 	customAttributes := make(map[string]interface{})
 	attrs := map[string]interface{}{}
 
@@ -429,6 +429,12 @@ func flattenUser(u *okta.User) map[string]interface{} {
 			attrKey := camelCaseToUnderscore(k)
 
 			if isCustomUserAttr(attrKey) {
+
+				// Exclude any custom attributes that should be filtered
+				if contains(filteredCustomAttributes, attrKey) {
+					continue
+				}
+
 				// Supporting any potential type
 				ref := reflect.ValueOf(v)
 				switch ref.Kind() {

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -88,6 +88,10 @@ The following arguments are supported:
 
 - `custom_profile_attributes` - (Optional) raw JSON containing all custom profile attributes.
 
+- `custom_profile_attributes_to_ignore` - (Optional) List of custom_profile_attribute keys that should be excluded from being
+managed by Terraform. This is useful in situations where specific custom fields may contain sensitive information and
+should be managed outside of Terraform.
+
 - `admin_roles` - (Optional) Administrator roles assigned to User.
   - `DEPRECATED`: Please replace usage with the `okta_user_admin_roles` resource.
 
@@ -156,28 +160,28 @@ The following arguments are supported:
 - `expire_password_on_create` - (Optional) If set to `true`, the user will have to change the password at the next login. This property will be used
   when user is being created and works only when `password` field is set. Default is `false`.
 
-- `old_password` - (Optional) Old user password. **IMPORTANT**: Should be ONLY set in case the password was changed 
-outside the provider. After successful password change this field should be removed and `password` field should be used 
+- `old_password` - (Optional) Old user password. **IMPORTANT**: Should be ONLY set in case the password was changed
+outside the provider. After successful password change this field should be removed and `password` field should be used
 for further changes.
 
-- `password_inline_hook` (Optional) Specifies that a Password Import Inline Hook should be triggered to handle verification 
-of the user's password the first time the user logs in. This allows an existing password to be imported into Okta directly 
+- `password_inline_hook` (Optional) Specifies that a Password Import Inline Hook should be triggered to handle verification
+of the user's password the first time the user logs in. This allows an existing password to be imported into Okta directly
 from some other store. When updating a user with a password hook the user must be in the `STAGED` status. The `password`
-field should not be specified when using Password Import Inline Hook. 
+field should not be specified when using Password Import Inline Hook.
 
 - `recovery_question` - (Optional) User password recovery question.
 
 - `recovery_answer` - (Optional) User password recovery answer.
 
-- `password hash` - (Optional) Specifies a hashed password to import into Okta. When updating a user with a hashed password the user must be in the `STAGED` status.  
+- `password hash` - (Optional) Specifies a hashed password to import into Okta. When updating a user with a hashed password the user must be in the `STAGED` status.
   - `algorithm"` - (Required) The algorithm used to generate the hash using the password (and salt, when applicable). Must be set to BCRYPT, SHA-512, SHA-256, SHA-1 or MD5.
-  - `salt` - (Optional) Only required for salted hashes. For BCRYPT, this specifies the radix64-encoded salt used to generate 
+  - `salt` - (Optional) Only required for salted hashes. For BCRYPT, this specifies the radix64-encoded salt used to generate
   the hash, which must be 22 characters long. For other salted hashes, this specifies the base64-encoded salt used to generate the hash.
   - `work_factor` - (Optional) Governs the strength of the hash and the time required to compute it. Only required for BCRYPT algorithm. Minimum value is 1, and maximum is 20.
   - `salt_order` - (Optional) Specifies whether salt was pre- or postfixed to the password before hashing. Only required for salted algorithms.
-  - `value` - (Optional) For SHA-512, SHA-256, SHA-1, MD5, this is the actual base64-encoded hash of the password (and salt, if used). 
-  This is the Base64 encoded value of the SHA-512/SHA-256/SHA-1/MD5 digest that was computed by either pre-fixing or post-fixing 
-  the salt to the password, depending on the saltOrder. If a salt was not used in the source system, then this should just be 
+  - `value` - (Optional) For SHA-512, SHA-256, SHA-1, MD5, this is the actual base64-encoded hash of the password (and salt, if used).
+  This is the Base64 encoded value of the SHA-512/SHA-256/SHA-1/MD5 digest that was computed by either pre-fixing or post-fixing
+  the salt to the password, depending on the saltOrder. If a salt was not used in the source system, then this should just be
   the Base64 encoded value of the password's SHA-512/SHA-256/SHA-1/MD5 digest. For BCRYPT, This is the actual radix64-encoded hashed password.
 
 ## Attributes Reference


### PR DESCRIPTION
Bringing in @virgofx'
virgofx:mark/custom-profile-attributes-to-ignore

Closes #1450
Closes #1449

## OIE Org Tests

The one fail on the OIE test was from API sensitivity, I see it passes generally.

```
$ for t in `grep "func Test" okta/resource_okta_user_test.go | awk '{ print $2}'| sed -e 's/(.*//g'`; do
TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^${t}$ ./okta
done
2023/03/03 01:35:56 [INFO]  running with default http client
=== RUN   TestAccOktaUser_customProfileAttributes
--- PASS: TestAccOktaUser_customProfileAttributes (26.65s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    27.198s
2023/03/03 01:36:24 [INFO]  running with default http client
=== RUN   TestAccOktaUser_groupMembership
--- PASS: TestAccOktaUser_groupMembership (11.22s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    11.601s
2023/03/03 01:36:37 [INFO]  running with default http client
=== RUN   TestAccOktaUser_invalidCustomProfileAttribute
--- PASS: TestAccOktaUser_invalidCustomProfileAttribute (1.21s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    1.562s
2023/03/03 01:36:40 [INFO]  running with default http client
=== RUN   TestAccOktaUser_updateAllAttributes
--- PASS: TestAccOktaUser_updateAllAttributes (10.63s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    10.988s
2023/03/03 01:36:52 [INFO]  running with default http client
=== RUN   TestAccOktaUser_updateCredentials
--- PASS: TestAccOktaUser_updateCredentials (12.99s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    13.340s
2023/03/03 01:37:07 [INFO]  running with default http client
=== RUN   TestAccOktaUser_statusDeprovisioned
--- PASS: TestAccOktaUser_statusDeprovisioned (6.33s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.679s
2023/03/03 01:37:15 [INFO]  running with default http client
=== RUN   TestAccOktaUserHashedPassword
--- PASS: TestAccOktaUserHashedPassword (8.43s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    8.790s
2023/03/03 01:37:25 [INFO]  running with default http client
=== RUN   TestAccOktaUser_updateDeprovisioned
--- PASS: TestAccOktaUser_updateDeprovisioned (5.46s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    5.815s
2023/03/03 01:37:32 [INFO]  running with default http client
=== RUN   TestAccOktaUser_loginUpdates
--- PASS: TestAccOktaUser_loginUpdates (6.54s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.879s
2023/03/03 01:36:32 [INFO]  running with default http client
=== RUN   TestIssue1216Suppress403Errors
    utils_for_test.go:221: OKTA_API_TOKEN_ROLE= not, requires "org-admin" value, skipping test
--- SKIP: TestIssue1216Suppress403Errors (0.00s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:37:41 [INFO]  running with default http client
=== RUN   TestAccOktaUser_skip_roles
--- PASS: TestAccOktaUser_skip_roles (3.61s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    3.968s
2023/03/03 02:01:06 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_read
2023/03/03 02:03:01 [ERROR] failed to apply changes after several retries %+v: EXTRA_VALUE_AT_END="updating user custom schema property caused 500 error: the API returned an error: Internal Server Error, x-okta-request-id=ZAJulaaxj-axTcAcqvyW2gAABWU"
    data_source_okta_user_test.go:20: Step 1/2 error: Error running apply: exit status 1

        Error: failed to create or update user custom schema property array123: updating user custom schema property caused 500 error: the API returned an error: Internal Server Error, x-okta-request-id=ZAJulaaxj-axTcAcqvyW2gAABWU

          with okta_user_schema_property.test_array,
          on terraform_plugin_test.tf line 1, in resource "okta_user_schema_property" "test_array":
           1: resource "okta_user_schema_property" "test_array" {

--- FAIL: TestAccDataSourceOktaUser_read (114.74s)
FAIL
FAIL    github.com/okta/terraform-provider-okta/okta    115.066s
FAIL
2023/03/03 02:03:03 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_SkipAdminRoles
--- PASS: TestAccDataSourceOktaUser_SkipAdminRoles (5.90s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.364s
2023/03/03 02:03:10 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_SkipGroups
--- PASS: TestAccDataSourceOktaUser_SkipGroups (5.84s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.173s
2023/03/03 02:03:18 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_SkipGroupsSkipRoles
--- PASS: TestAccDataSourceOktaUser_SkipGroupsSkipRoles (5.40s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    5.736s
2023/03/03 02:03:25 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_NoSkips
--- PASS: TestAccDataSourceOktaUser_NoSkips (6.34s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.670s
```

## Classic Org Tests

```
$ for t in `grep "func Test" okta/resource_okta_user_test.go okta/data_source_okta_user_test.go | awk '{ print $2}'| sed -e 's/(.*//g'`; do                                                                                                        [21/9269]
for> TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^${t}$ ./okta
for> done
2023/03/03 01:50:18 [INFO]  running with default http client
=== RUN   TestAccOktaUser_customProfileAttributes
--- PASS: TestAccOktaUser_customProfileAttributes (29.09s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:50:56 [INFO]  running with default http client
=== RUN   TestAccOktaUser_groupMembership
--- PASS: TestAccOktaUser_groupMembership (10.78s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:51:08 [INFO]  running with default http client
=== RUN   TestAccOktaUser_invalidCustomProfileAttribute
--- PASS: TestAccOktaUser_invalidCustomProfileAttribute (1.25s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:51:11 [INFO]  running with default http client
=== RUN   TestAccOktaUser_updateAllAttributes
--- PASS: TestAccOktaUser_updateAllAttributes (11.52s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:51:24 [INFO]  running with default http client
=== RUN   TestAccOktaUser_updateCredentials
--- PASS: TestAccOktaUser_updateCredentials (11.70s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:51:38 [INFO]  running with default http client
=== RUN   TestAccOktaUser_statusDeprovisioned
--- PASS: TestAccOktaUser_statusDeprovisioned (6.22s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:51:46 [INFO]  running with default http client
=== RUN   TestAccOktaUserHashedPassword
--- PASS: TestAccOktaUserHashedPassword (6.98s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:51:54 [INFO]  running with default http client
=== RUN   TestAccOktaUser_updateDeprovisioned
--- PASS: TestAccOktaUser_updateDeprovisioned (5.11s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:52:01 [INFO]  running with default http client
=== RUN   TestAccOktaUser_loginUpdates
--- PASS: TestAccOktaUser_loginUpdates (6.81s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:52:10 [INFO]  running with default http client
=== RUN   TestIssue1216Suppress403Errors
    utils_for_test.go:221: OKTA_API_TOKEN_ROLE= not, requires "org-admin" value, skipping test
--- SKIP: TestIssue1216Suppress403Errors (0.00s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:52:11 [INFO]  running with default http client
=== RUN   TestAccOktaUser_skip_roles
--- PASS: TestAccOktaUser_skip_roles (3.86s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    (cached)
2023/03/03 01:58:04 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_read
--- PASS: TestAccDataSourceOktaUser_read (22.59s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    22.933s
2023/03/03 01:58:28 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_SkipAdminRoles
--- PASS: TestAccDataSourceOktaUser_SkipAdminRoles (5.48s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    5.813s
2023/03/03 01:58:35 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_SkipGroups
--- PASS: TestAccDataSourceOktaUser_SkipGroups (6.05s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    6.381s
2023/03/03 01:58:43 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_SkipGroupsSkipRoles
--- PASS: TestAccDataSourceOktaUser_SkipGroupsSkipRoles (5.16s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    5.504s
2023/03/03 01:58:50 [INFO]  running with default http client
=== RUN   TestAccDataSourceOktaUser_NoSkips
--- PASS: TestAccDataSourceOktaUser_NoSkips (7.09s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    7.429s
```
