### PR TITLE
prep v3.44.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.44.0 (March 10, 2023)
+
+### BUG FIXES:
+
+* Improve JSON serialization of 0 integer values affecting a number of open
+  issues [#1484](https://github.com/okta/terraform-provider-okta/pull/1484).
+  Thanks, [@monde](https://github.com/monde)!
+* Fix panic in `okta_app_saml` when `embed_url` is missing for
+  `preconfigured_app` apps
+  [#1480](https://github.com/okta/terraform-provider-okta/pull/1480).  Thanks,
+  [@monde](https://github.com/monde)!
+
 ## 3.43.0 (March 7, 2023)
 
 ### NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:

--- a/okta/config.go
+++ b/okta/config.go
@@ -147,7 +147,7 @@ func oktaSDKClient(c *Config) (client *okta.Client, err error) {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.43.0"),
+		okta.WithUserAgentExtra("okta-terraform/3.44.0"),
 	}
 
 	switch {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.43"
+      version = "~> 3.44"
     }
   }
 }


### PR DESCRIPTION
## 3.44.0 (March 10, 2023)

### BUG FIXES:

* Improve JSON serialization of 0 integer values affecting a number of open issues [#1484](https://github.com/okta/terraform-provider-okta/pull/1484). Thanks, [@monde](https://github.com/monde)!
* Fix panic in `okta_app_saml` when `embed_url` is missing for `preconfigured_app` apps [#1480](https://github.com/okta/terraform-provider-okta/pull/1480).  Thanks, [@monde](https://github.com/monde)!