### PR TITLE
New data source: okta_app_user_profile

### DIFF
--- a/examples/okta_app_user_profile/datasource.tf
+++ b/examples/okta_app_user_profile/datasource.tf
@@ -1,0 +1,47 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+
+  lifecycle {
+    ignore_changes = [users, groups]
+  }
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc_replace_with_uuid@example.com"
+  email      = "testAcc_replace_with_uuid@example.com"
+}
+
+resource "okta_app_user_schema_property" "test" {
+  app_id      = okta_app_oauth.test.id
+  index       = "testCustom"
+  title       = "terraform acceptance test"
+  type        = "string"
+  description = "terraform acceptance test updated"
+  required    = true
+  master      = "OKTA"
+  scope       = "SELF"
+}
+
+resource "okta_app_user" "test" {
+  app_id   = okta_app_oauth.test.id
+  user_id  = okta_user.test.id
+  username = okta_user.test.email
+
+  profile = <<JSON
+{"testCustom":"testing"}
+JSON
+
+  depends_on = [okta_app_user_schema_property.test]
+}
+
+data "okta_app_user_profile" "test" {
+  app_id = okta_app_oauth.test.id
+  user_id = okta_user.test.id
+}

--- a/okta/data_source_okta_app_user_profile.go
+++ b/okta/data_source_okta_app_user_profile.go
@@ -1,0 +1,54 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+)
+
+func dataSourceAppUserProfile() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppUserProfileRead,
+		Schema: map[string]*schema.Schema{
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the Okta App being queried for",
+				ForceNew:    true,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the User associated with the application",
+				ForceNew:    true,
+			},
+			"profile": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The application profile for the user",
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func dataSourceAppUserProfileRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := getOktaClientFromMetadata(m)
+	appId := d.Get("app_id").(string)
+	userId := d.Get("user_id").(string)
+
+	var appUser *okta.AppUser
+
+	appUser, resp, err := client.Application.GetApplicationUser(ctx, appId, userId, &query.Params{})
+	if err != nil {
+		return diag.Errorf("unable to get profile for user (%s) assisgned to app (%s): %s", userId, appId, err)
+	}
+
+	d.SetId(appId)
+	_ = d.Set("user_id", userId)
+	_ = d.Set("profile", appUser.Profile)
+	
+	return nil
+}

--- a/okta/data_source_okta_app_user_profile_test.go
+++ b/okta/data_source_okta_app_user_profile_test.go
@@ -1,0 +1,28 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOktaDataSourceAppUserProfile_read(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager("okta_app_user_profile")
+	config := mgr.GetFixtures("datasource.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_app_user_profile.test", "profile"),
+				),
+			},
+		},
+	})
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -42,6 +42,7 @@ const (
 	appUser                       = "okta_app_user"
 	appUserAssignments            = "okta_app_user_assignments"
 	appUserBaseSchemaProperty     = "okta_app_user_base_schema_property"
+	appUserProfile                = "okta_app_user_profile"
 	appUserSchemaProperty         = "okta_app_user_schema_property"
 	authenticator                 = "okta_authenticator"
 	authServer                    = "okta_auth_server"
@@ -379,6 +380,7 @@ func Provider() *schema.Provider {
 			appSaml:                  dataSourceAppSaml(),
 			appSignOnPolicy:          dataSourceAppSignOnPolicy(),
 			appUserAssignments:       dataSourceAppUserAssignments(),
+			appUserProfile:           dataSourceAppUserProfile(),
 			authenticator:            dataSourceAuthenticator(),
 			authServer:               dataSourceAuthServer(),
 			authServerClaim:          dataSourceAuthServerClaim(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -42,7 +42,6 @@ const (
 	appUser                       = "okta_app_user"
 	appUserAssignments            = "okta_app_user_assignments"
 	appUserBaseSchemaProperty     = "okta_app_user_base_schema_property"
-	appUserProfile                = "okta_app_user_profile"
 	appUserSchemaProperty         = "okta_app_user_schema_property"
 	authenticator                 = "okta_authenticator"
 	authServer                    = "okta_auth_server"

--- a/website/docs/d/app_user_profile.html.markdown
+++ b/website/docs/d/app_user_profile.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_app_user_profile'
+sidebar_current: 'docs-okta-datasource-app-user-profile'
+description: |-
+Get the application profile for a user assigned to an Okta application.
+---
+
+
+# okta_app_user_profile
+
+Use this data source to get the app profile for a user assigned to the given Okta application (by ID). This allows you to retrieve
+custom app profile attributes for use within Terraform.
+
+## Example Usage
+
+```hcl
+data "okta_app" "example" {
+  label = "Example App"
+
+  skip_groups = true
+  skip_users  = true
+}
+
+data "okta_user" "example" {
+  user_id = "00u22mtxlrJ8YkzXQ357"
+}
+
+data "okta_app_user_profile" "test" {
+  app_id  = data.okta_app.example.id
+  user_id = data.okta_user.example.id
+}
+```
+
+## Argument Reference
+
+- `app_id` - (Required) The ID of the Okta application you want to retrieve the user profile for.
+
+- `user_id` - (Required) The ID of the user you want to retrieve the user profile for.
+
+## Attribute Reference
+
+- `app_id` - ID of the application.
+
+- `user_id` - ID of the user.
+
+- `profile` - The profile for the user.
+


### PR DESCRIPTION
Adds a new data source which gets the application profile for a user assigned to a given application.

Application profiles can contain custom attributes that are not part of the base user profile, which sometimes need to be read via Terraform.

This new data source will allow the custom attributes for an application profile to be read on a per-user basis.