### PR TITLE
New data sources: okta_device  okta_devices

### DIFF
--- a/okta/data_source_okta_device.go
+++ b/okta/data_source_okta_device.go
@@ -58,9 +58,12 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.Errorf("user_id not specified")
 	}
 	respDevice, _, err := getSupplementFromMetadata(m).GetDevice(ctx, deviceID.(string))
-	if err != nil {
-		return diag.Errorf("failed to get device by ID: %v", err)
-	}
+    switch {
+    case err != nil:
+        return diag.Errorf("failed to query for devices: %v", err)
+    case respDevice == nil:
+        return diag.Errorf("device with id '%s' does not exist", deviceID)
+    }
 	device = respDevice
 
 	if device == nil {

--- a/okta/data_source_okta_device.go
+++ b/okta/data_source_okta_device.go
@@ -1,0 +1,95 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/terraform-provider-okta/sdk"
+)
+
+func dataSourceDevice() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDeviceRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"profile": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_display_name": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"resource_alternate_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var device *sdk.Device
+	deviceID, ok := d.GetOk("id")
+	if !ok {
+        return diag.Errorf("user_id not specified") 
+    }
+
+    respDevice, _, err := getSupplementFromMetadata(m).GetDevice(ctx, deviceID.(string))
+    if err != nil {
+        return diag.Errorf("failed to get device by ID: %v", err)
+    }
+    device = respDevice
+
+	if device == nil {
+		return nil
+	}
+
+	d.SetId(device.ID)
+
+	_ = d.Set("status", device.Status)
+
+	profile := make(map[string]string)
+	for k, v := range device.Profile {
+		profile[k] = fmt.Sprint(v)
+	}
+	_ = d.Set("profile", profile)
+
+	_ = d.Set("resource_type", device.ResourceType)
+
+	resourceDisplayName := make(map[string]string)
+	for k, v := range device.ResourceDisplayName {
+		resourceDisplayName[k] = fmt.Sprint(v)
+	}
+	_ = d.Set("resource_display_name", device.ResourceDisplayName)
+
+	_ = d.Set("resource_alternate_id", device.ResourceAlternateID)
+	_ = d.Set("resource_id", device.ResourceID)
+
+	return nil
+}
+
+

--- a/okta/data_source_okta_device.go
+++ b/okta/data_source_okta_device.go
@@ -55,21 +55,18 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 	var device *sdk.Device
 	deviceID, ok := d.GetOk("id")
 	if !ok {
-        return diag.Errorf("user_id not specified") 
-    }
-
-    respDevice, _, err := getSupplementFromMetadata(m).GetDevice(ctx, deviceID.(string))
-    if err != nil {
-        return diag.Errorf("failed to get device by ID: %v", err)
-    }
-    device = respDevice
+		return diag.Errorf("user_id not specified")
+	}
+	respDevice, _, err := getSupplementFromMetadata(m).GetDevice(ctx, deviceID.(string))
+	if err != nil {
+		return diag.Errorf("failed to get device by ID: %v", err)
+	}
+	device = respDevice
 
 	if device == nil {
 		return nil
 	}
-
 	d.SetId(device.ID)
-
 	_ = d.Set("status", device.Status)
 
 	profile := make(map[string]string)
@@ -88,8 +85,5 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	_ = d.Set("resource_alternate_id", device.ResourceAlternateID)
 	_ = d.Set("resource_id", device.ResourceID)
-
 	return nil
 }
-
-

--- a/okta/data_source_okta_devices.go
+++ b/okta/data_source_okta_devices.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"hash/crc32"
 
-	"github.com/okta/terraform-provider-okta/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/terraform-provider-okta/sdk"
 )
 
 func dataSourceDevices() *schema.Resource {
@@ -20,7 +20,6 @@ func dataSourceDevices() *schema.Resource {
 				Optional:    true,
 				Description: "Searches for devices owned by the specified user_id",
 			},
-
 			"devices": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -65,11 +64,9 @@ func dataSourceDevices() *schema.Resource {
 
 func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	qp := &query.Params{Limit: defaultPaginationLimit}
-
 	userID, ok := d.GetOk("user_id")
 	var devices []*sdk.Device
-    var err error
-
+	var err error
 	if ok {
 		qp.Expand = "users"
 
@@ -92,24 +89,22 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interf
 	arr := make([]map[string]interface{}, len(devices))
 	for i := range devices {
 		arr[i] = map[string]interface{}{
-			"id":                  devices[i].ID,
-			"status":              devices[i].Status,
-			"resource_type":        devices[i].ResourceType,
+			"id":                    devices[i].ID,
+			"status":                devices[i].Status,
+			"resource_type":         devices[i].ResourceType,
 			"resource_alternate_id": devices[i].ResourceAlternateID,
-			"resource_id":          devices[i].ResourceID,
+			"resource_id":           devices[i].ResourceID,
 		}
 		profile := make(map[string]string)
 		for k, v := range devices[i].Profile {
 			profile[k] = fmt.Sprint(v)
 		}
 		arr[i]["profile"] = profile
-
 		resourceDisplayName := make(map[string]string)
 		for k, v := range devices[i].ResourceDisplayName {
 			resourceDisplayName[k] = fmt.Sprint(v)
 		}
 		arr[i]["resource_display_name"] = resourceDisplayName
-
 	}
 	err = d.Set("devices", arr)
 	return diag.FromErr(err)
@@ -129,6 +124,6 @@ func searchUserDevices(ctx context.Context, devices []*sdk.Device, userID string
 			}
 		}
 	}
-    
+
 	return userDevices
 }

--- a/okta/data_source_okta_devices.go
+++ b/okta/data_source_okta_devices.go
@@ -1,0 +1,134 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/okta/terraform-provider-okta/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+func dataSourceDevices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDevicesRead,
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Searches for devices owned by the specified user_id",
+			},
+
+			"devices": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"profile": {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_display_name": {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"resource_alternate_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	qp := &query.Params{Limit: defaultPaginationLimit}
+
+	userID, ok := d.GetOk("user_id")
+	var devices []*sdk.Device
+    var err error
+
+	if ok {
+		qp.Expand = "users"
+
+		respDevices, _, err := getSupplementFromMetadata(m).ListDevices(ctx, qp)
+		if err != nil {
+			return diag.Errorf("failed to list devices: %v", err)
+		}
+
+		devices = searchUserDevices(ctx, respDevices, userID.(string), m)
+		if err != nil {
+			return diag.Errorf("failed to find devices for specified user: %v", err)
+		}
+	} else {
+		devices, _, err = getSupplementFromMetadata(m).ListDevices(ctx, qp)
+		if err != nil {
+			return diag.Errorf("failed to list devices: %v", err)
+		}
+	}
+	d.SetId(fmt.Sprintf("%d", crc32.ChecksumIEEE([]byte(qp.String()))))
+	arr := make([]map[string]interface{}, len(devices))
+	for i := range devices {
+		arr[i] = map[string]interface{}{
+			"id":                  devices[i].ID,
+			"status":              devices[i].Status,
+			"resource_type":        devices[i].ResourceType,
+			"resource_alternate_id": devices[i].ResourceAlternateID,
+			"resource_id":          devices[i].ResourceID,
+		}
+		profile := make(map[string]string)
+		for k, v := range devices[i].Profile {
+			profile[k] = fmt.Sprint(v)
+		}
+		arr[i]["profile"] = profile
+
+		resourceDisplayName := make(map[string]string)
+		for k, v := range devices[i].ResourceDisplayName {
+			resourceDisplayName[k] = fmt.Sprint(v)
+		}
+		arr[i]["resource_display_name"] = resourceDisplayName
+
+	}
+	err = d.Set("devices", arr)
+	return diag.FromErr(err)
+}
+
+func searchUserDevices(ctx context.Context, devices []*sdk.Device, userID string, m interface{}) []*sdk.Device {
+	var userDevices []*sdk.Device
+	for _, respDevice := range devices {
+		for _, respUser := range respDevice.Embedded["users"] {
+			u := respUser["user"]
+			for key, value := range u.(map[string]interface{}) {
+				if key == "id" {
+					if userID == value {
+						userDevices = append(userDevices, respDevice)
+					}
+				}
+			}
+		}
+	}
+    
+	return userDevices
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -61,6 +61,8 @@ const (
 	captchaOrgWideSettings        = "okta_captcha_org_wide_settings"
 	defaultPolicies               = "okta_default_policies"
 	defaultPolicy                 = "okta_default_policy"
+    device                        = "okta_device"
+    devices                       = "okta_devices"
 	domain                        = "okta_domain"
 	domainCertificate             = "okta_domain_certificate"
 	domainVerification            = "okta_domain_verification"
@@ -390,6 +392,8 @@ func Provider() *schema.Provider {
 			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
 			domain:                   dataSourceDomain(),
+            device:                   dataSourceDevice(),
+            devices:                  dataSourceDevices(),
 			emailCustomization:       dataSourceEmailCustomization(),
 			emailCustomizations:      dataSourceEmailCustomizations(),
 			emailTemplate:            dataSourceEmailTemplate(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -61,8 +61,8 @@ const (
 	captchaOrgWideSettings        = "okta_captcha_org_wide_settings"
 	defaultPolicies               = "okta_default_policies"
 	defaultPolicy                 = "okta_default_policy"
-    device                        = "okta_device"
-    devices                       = "okta_devices"
+	device                        = "okta_device"
+	devices                       = "okta_devices"
 	domain                        = "okta_domain"
 	domainCertificate             = "okta_domain_certificate"
 	domainVerification            = "okta_domain_verification"
@@ -392,8 +392,8 @@ func Provider() *schema.Provider {
 			brand:                    dataSourceBrand(),
 			brands:                   dataSourceBrands(),
 			domain:                   dataSourceDomain(),
-            device:                   dataSourceDevice(),
-            devices:                  dataSourceDevices(),
+			device:                   dataSourceDevice(),
+			devices:                  dataSourceDevices(),
 			emailCustomization:       dataSourceEmailCustomization(),
 			emailCustomizations:      dataSourceEmailCustomizations(),
 			emailTemplate:            dataSourceEmailTemplate(),

--- a/sdk/device.go
+++ b/sdk/device.go
@@ -10,15 +10,15 @@ import (
 )
 
 type Device struct {
-	ID                  string                 `json:"id"`
-	Status              string                 `json:"status"`
-	Profile             map[string]interface{} `json:"profile"`
-	ResourceType        string                 `json:"resourceType"`
-	ResourceDisplayName map[string]interface{} `json:"sourceDisplayName"`
-	ResourceAlternateID string                 `json:"resourceAlternateId"`
-	ResourceID          string                 `json:"resourceId"`
-	Links               interface{}            `json:"_links"`
-    Embedded            map[string][]map[string]interface{}    `json:"_embedded"`
+	ID                  string                              `json:"id"`
+	Status              string                              `json:"status"`
+	Profile             map[string]interface{}              `json:"profile"`
+	ResourceType        string                              `json:"resourceType"`
+	ResourceDisplayName map[string]interface{}              `json:"sourceDisplayName"`
+	ResourceAlternateID string                              `json:"resourceAlternateId"`
+	ResourceID          string                              `json:"resourceId"`
+	Links               interface{}                         `json:"_links"`
+	Embedded            map[string][]map[string]interface{} `json:"_embedded"`
 }
 
 // ListDevices Gets all devices based on the query params

--- a/sdk/device.go
+++ b/sdk/device.go
@@ -27,6 +27,7 @@ func (m *APISupplement) ListDevices(ctx context.Context, qp *query.Params) ([]*D
 	if qp != nil {
 		url += qp.String()
 	}
+    fmt.Printf("THE URL IS %+v", url)
 	req, err := m.RequestExecutor.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/sdk/device.go
+++ b/sdk/device.go
@@ -1,0 +1,94 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+)
+
+type Device struct {
+	ID                  string                 `json:"id"`
+	Status              string                 `json:"status"`
+	Profile             map[string]interface{} `json:"profile"`
+	ResourceType        string                 `json:"resourceType"`
+	ResourceDisplayName map[string]interface{} `json:"sourceDisplayName"`
+	ResourceAlternateID string                 `json:"resourceAlternateId"`
+	ResourceID          string                 `json:"resourceId"`
+	Links               interface{}            `json:"_links"`
+    Embedded            map[string][]map[string]interface{}    `json:"_embedded"`
+}
+
+// ListDevices Gets all devices based on the query params
+func (m *APISupplement) ListDevices(ctx context.Context, qp *query.Params) ([]*Device, *okta.Response, error) {
+	url := "/api/v1/devices"
+	if qp != nil {
+		url += qp.String()
+	}
+	req, err := m.RequestExecutor.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var devices []*Device
+	resp, err := m.RequestExecutor.Do(ctx, req, &devices)
+	if err != nil {
+		return nil, resp, err
+	}
+	return devices, resp, nil
+}
+
+// GetDevice gets device by ID
+func (m *APISupplement) GetDevice(ctx context.Context, id string) (*Device, *okta.Response, error) {
+	url := fmt.Sprintf("/api/v1/devices/%s", id)
+	req, err := m.RequestExecutor.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var device *Device
+	resp, err := m.RequestExecutor.Do(ctx, req, &device)
+	if err != nil {
+		return nil, resp, err
+	}
+	return device, resp, nil
+}
+
+// DeleteDevice deletes device by ID
+func (m *APISupplement) DeleteDevice(ctx context.Context, id string) (*okta.Response, error) {
+	url := fmt.Sprintf("/api/v1/devices/%s", id)
+	req, err := m.RequestExecutor.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return m.RequestExecutor.Do(ctx, req, nil)
+}
+
+func (m *APISupplement) ActivateDevice(ctx context.Context, id string) (*okta.Response, error) {
+	return m.changeDeviceLifecycle(ctx, id, "activate")
+}
+
+func (m *APISupplement) DeactivateDevice(ctx context.Context, id string) (*okta.Response, error) {
+	return m.changeDeviceLifecycle(ctx, id, "deactivate")
+}
+
+func (m *APISupplement) SuspendDevice(ctx context.Context, id string) (*okta.Response, error) {
+	return m.changeDeviceLifecycle(ctx, id, "suspend")
+}
+
+func (m *APISupplement) UnsuspendDevice(ctx context.Context, id string) (*okta.Response, error) {
+	return m.changeDeviceLifecycle(ctx, id, "unsuspend")
+}
+
+func (m *APISupplement) changeDeviceLifecycle(ctx context.Context, id, action string) (*okta.Response, error) {
+	url := fmt.Sprintf("/api/v1/devices/%s/lifecycle/%s", id, action)
+	req, err := m.RequestExecutor.WithAccept("application/json").WithContentType("application/json").NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.RequestExecutor.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}

--- a/website/docs/d/device.html.markdown
+++ b/website/docs/d/device.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_device'
+sidebar_current: 'docs-okta-device'
+description: |-
+Get an okta device by its id
+---
+
+
+# okta_device
+
+Use this data source to get the okta device (by ID). This allows you to retrieve device information for use within Terraform.
+
+## Example Usage
+
+```hcl
+data "okta_device" "example" {
+  id = "guo4a5u7YAHhjXrMN0g4"
+}
+```
+
+## Argument Reference
+
+- `id` - (Required) The ID of the Okta device you want to retrieve.
+
+
+## Attribute Reference
+
+- `id` - ID of the device.
+
+- `status` - Current status of device. One of CREATED, ACTIVE, SUSPENDED or DEACTIVATED.
+
+- `profile` - Device profile properties.
+
+- `resource_type` - Device type.
+
+- `resource_display_name` - Device Display name
+

--- a/website/docs/d/devices.html.markdown
+++ b/website/docs/d/devices.html.markdown
@@ -9,7 +9,8 @@ List okta devices
 
 # okta_devices
 
-Use this data source to list the okta devices, searchable by user_id. This allows you to retrieve device information for use within Terraform.
+Use this data source to list the okta devices, searchable by user_id and okta search parameters.
+This allows you to retrieve device information for use within Terraform.
 
 ## Example Usage
 
@@ -17,12 +18,18 @@ Use this data source to list the okta devices, searchable by user_id. This allow
 data "okta_devices" "example" {
   user_id = "00u22mtxlrJ8YkzXQ357"
 }
+
+data "okta_devices" "example" {
+  search = "status eq \"ACTIVE\""
+}
+
 ```
 
 ## Argument Reference
 
-- `user_id` - (Required) The ID of the Okta user you want to retrieve the list of devices for.
+- `user_id` - (Optional) The ID of the Okta user you want to retrieve the list of devices for.
 
+- `search` - (Optional) The Okta search parameter for finding devices, see https://developer.okta.com/docs/reference/api/devices/#list-devices
 
 ## Attribute Reference
 

--- a/website/docs/d/devices.html.markdown
+++ b/website/docs/d/devices.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_devices'
+sidebar_current: 'docs-okta-devices'
+description: |-
+List okta devices
+---
+
+
+# okta_devices
+
+Use this data source to list the okta devices, searchable by user_id. This allows you to retrieve device information for use within Terraform.
+
+## Example Usage
+
+```hcl
+data "okta_devices" "example" {
+  user_id = "00u22mtxlrJ8YkzXQ357"
+}
+```
+
+## Argument Reference
+
+- `user_id` - (Required) The ID of the Okta user you want to retrieve the list of devices for.
+
+
+## Attribute Reference
+
+- `id` - ID of the device.
+
+- `status` - Current status of device. One of CREATED, ACTIVE, SUSPENDED or DEACTIVATED.
+
+- `profile` - Device profile properties.
+
+- `resource_type` - Device type.
+
+- `resource_display_name` - Device Display name
+


### PR DESCRIPTION
Creates a device and devices data source,

Devices data source has the ability to search with user_id through using "expand" functionality and parsing expanded urls, and with search parameter, which uses https://developer.okta.com/docs/reference/api/devices/#list-devices to search

The intended use case for us, is to get the devices recognized by okta, and push certain fields (such as serial number) into custom attributes in the user profile.  That way we can push those profiles via SCIM to other applications
