### PR TITLE
Prep v3.46.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.46.0 (April 14, 2023)
+
+### BUG FIXES
+
+* Update status for Idp OIDC, Idp SAML and Idp Social [#1526](https://github.com/okta/terraform-provider-okta/pull/1526). Thanks, [@duytiennguyen-okta](https://github.com/duytiennguyen-okta)!
+
 ## 3.45.0 (March 29, 2023)
 
 ### BUG FIXES:

--- a/okta/config.go
+++ b/okta/config.go
@@ -147,7 +147,7 @@ func oktaSDKClient(c *Config) (client *okta.Client, err error) {
 		okta.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		okta.WithRequestTimeout(int64(c.requestTimeout)),
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
-		okta.WithUserAgentExtra("okta-terraform/3.45.0"),
+		okta.WithUserAgentExtra("okta-terraform/3.46.0"),
 	}
 
 	switch {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 3.45"
+      version = "~> 3.46"
     }
   }
 }


### PR DESCRIPTION
## 3.46.0 (April 14, 2023)

### BUG FIXES

* Update status for Idp OIDC, Idp SAML and Idp Social [#1526](https://github.com/okta/terraform-provider-okta/pull/1526). Thanks, [@duytiennguyen-okta](https://github.com/duytiennguyen-okta)!