### PR TITLE
Added validation for nested resource id structure

### DIFF
--- a/okta/utils.go
+++ b/okta/utils.go
@@ -172,6 +172,15 @@ func createCustomNestedResourceImporter(fields []string, errMessage string) *sch
 	return &schema.ResourceImporter{
 		StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 			parts := strings.Split(d.Id(), "/")
+
+			if len(parts) != len(fields) {
+				for i, field := range fields {
+					fields[i] = "<" + field + ">"
+				}
+				resourceIdFormat := strings.Join(fields[:], "/")
+				return nil, errors.New("invalid structure of nested resource ID. Expected: " + resourceIdFormat)
+			}
+
 			for i, field := range fields {
 				if field == "id" {
 					d.SetId(parts[i])


### PR DESCRIPTION
When importing resources that use `createNestedResourceImporter` function and not providing the amount of 'parts' needed to define the nested resource ID that will result in a runtime error.

For example importing an `okta_auth_server_claim` requires `<auth_server_id>/<id>` when only providing either one of them this results down the line in a `panic: runtime error: index out of range [1] with lenght 1`

![image](https://user-images.githubusercontent.com/13300142/233806597-d357a835-f794-4771-8c14-07ae786aa116.png)


This PR solves this by checking the length of the expected and given lists, it will also give the expected structure in the error message.

![image](https://user-images.githubusercontent.com/13300142/233806642-2271681d-a495-4b0e-8a33-ca55ebd4925a.png)
