### PR TITLE
add engine type check during config phase

### DIFF
--- a/okta/provider.go
+++ b/okta/provider.go
@@ -418,6 +418,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diag.Errorf("[ERROR] invalid configuration: %v", err)
 	}
 
+	// Discover if the Okta Org is Classic or OIE
+	if org, _, err := config.supplementClient.GetWellKnownOktaOrganization(ctx); err == nil {
+		config.classicOrg = (org.Pipeline == "v1") // v1 == Classic, idx == OIE
+	}
+
 	return &config, nil
 }
 


### PR DESCRIPTION
Add the engine check to determine if there is a need to get or assign the default access policy (which is OIE only)