### PR TITLE
add skip user and skip group

### DIFF
--- a/okta/app.go
+++ b/okta/app.go
@@ -89,6 +89,23 @@ var (
 		},
 	}
 
+	skipUsersAndGroupsSchema = map[string]*schema.Schema{
+		"skip_users": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
+			Default:     false,
+			Deprecated:  "Because of users has been removed, this attribute is a no op and will be removed",
+		},
+		"skip_groups": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Ignore groups sync. This is a temporary solution until 'groups' field is supported in all the app-like resources",
+			Default:     false,
+			Deprecated:  "Because of groups has been removed, this attribute is a no op and will be removed",
+		},
+	}
+
 	appVisibilitySchema = map[string]*schema.Schema{
 		"auto_submit_toolbar": {
 			Type:        schema.TypeBool,

--- a/okta/app.go
+++ b/okta/app.go
@@ -95,14 +95,14 @@ var (
 			Optional:    true,
 			Description: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
 			Default:     false,
-			Deprecated:  "Because of users has been removed, this attribute is a no op and will be removed",
+			Deprecated:  "Because users has been removed, this attribute is a no op and will be removed",
 		},
 		"skip_groups": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Description: "Ignore groups sync. This is a temporary solution until 'groups' field is supported in all the app-like resources",
 			Default:     false,
-			Deprecated:  "Because of groups has been removed, this attribute is a no op and will be removed",
+			Deprecated:  "Because groups has been removed, this attribute is a no op and will be removed",
 		},
 	}
 

--- a/okta/data_source_okta_app.go
+++ b/okta/data_source_okta_app.go
@@ -12,7 +12,7 @@ import (
 func dataSourceApp() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceAppRead,
-		Schema: map[string]*schema.Schema{
+		Schema: buildSchema(skipUsersAndGroupsSchema, map[string]*schema.Schema{
 			"id": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -61,7 +61,7 @@ func dataSourceApp() *schema.Resource {
 				Description: "Users associated with the application",
 				Deprecated:  "The `users` field is now deprecated for the data source `okta_app`, please replace all uses of this with: `okta_app_user_assignments`",
 			},
-		},
+		}),
 	}
 }
 

--- a/okta/data_source_okta_app_oauth.go
+++ b/okta/data_source_okta_app_oauth.go
@@ -15,7 +15,7 @@ import (
 func dataSourceAppOauth() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceAppOauthRead,
-		Schema: map[string]*schema.Schema{
+		Schema: buildSchema(skipUsersAndGroupsSchema, map[string]*schema.Schema{
 			"id": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -140,7 +140,7 @@ func dataSourceAppOauth() *schema.Resource {
 				Computed:    true,
 				Description: "Indicates if the client is allowed to use wildcard matching of redirect_uris",
 			},
-		},
+		}),
 	}
 }
 

--- a/okta/data_source_okta_app_saml.go
+++ b/okta/data_source_okta_app_saml.go
@@ -15,7 +15,7 @@ import (
 func dataSourceAppSaml() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceAppSamlRead,
-		Schema: map[string]*schema.Schema{
+		Schema: buildSchema(skipUsersAndGroupsSchema, map[string]*schema.Schema{
 			"id": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -279,7 +279,7 @@ func dataSourceAppSaml() *schema.Resource {
 				Computed:    true,
 				Description: "SAML Signed Request enabled",
 			},
-		},
+		}),
 	}
 }
 

--- a/okta/resource_okta_group.go
+++ b/okta/resource_okta_group.go
@@ -46,6 +46,13 @@ func resourceGroup() *schema.Resource {
 				Optional:    true,
 				Description: "Group description",
 			},
+			"skip_users": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
+				Default:     false,
+				Deprecated:  "Because of users has been removed, this attribute is a no op and will be removed",
+			},
 			"custom_profile_attributes": {
 				Type:             schema.TypeString,
 				Optional:         true,

--- a/okta/resource_okta_group.go
+++ b/okta/resource_okta_group.go
@@ -51,7 +51,7 @@ func resourceGroup() *schema.Resource {
 				Optional:    true,
 				Description: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
 				Default:     false,
-				Deprecated:  "Because of users has been removed, this attribute is a no op and will be removed",
+				Deprecated:  "Because users has been removed, this attribute is a no op and will be removed",
 			},
 			"custom_profile_attributes": {
 				Type:             schema.TypeString,

--- a/okta/resource_okta_policy_rule_idp_discovery_test.go
+++ b/okta/resource_okta_policy_rule_idp_discovery_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// TODU
 func TestAccOktaPolicyRuleIdpDiscovery_crud(t *testing.T) {
 	mgr := newFixtureManager(policyRuleIdpDiscovery, t.Name())
 	config := mgr.GetFixtures("basic.tf", t)

--- a/okta/resource_okta_user.go
+++ b/okta/resource_okta_user.go
@@ -71,6 +71,13 @@ func resourceUser() *schema.Resource {
 			},
 		},
 		Schema: map[string]*schema.Schema{
+			"skip_roles": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Do not populate user roles information (prevents additional API call)",
+				Deprecated:  "Because admin_roles has been removed, this attribute is a no op and will be removed",
+			},
 			"city": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/okta/resource_okta_user_test.go
+++ b/okta/resource_okta_user_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// TODU
 func TestAccOktaUser_customProfileAttributes(t *testing.T) {
 	mgr := newFixtureManager(user, t.Name())
 	config := mgr.GetFixtures("custom_attributes.tf", t)


### PR DESCRIPTION
Bringing back `skip_users` and `skip_groups` on apps data sources. They are no-ops and irrelevant in v4.x.x on the apps data sources. But we forgot to mark them deprecated along with the `users` and `groups` properties that were marked deprecated in v3.x.x and removed in v4.x.x .