### PR TITLE
Ignore app_user custom profile attributes

### DIFF
--- a/examples/okta_app_user/profile_attributes_to_ignore.tf
+++ b/examples/okta_app_user/profile_attributes_to_ignore.tf
@@ -1,0 +1,27 @@
+resource "okta_app_saml" "test" {
+  label             = "testAcc_replace_with_uuid"
+  preconfigured_app = "google"
+
+  lifecycle {
+    ignore_changes = [users, groups]
+  }
+}
+
+resource "okta_user" "test" {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc_replace_with_uuid@example.com"
+  email      = "testAcc_replace_with_uuid@example.com"
+}
+
+resource "okta_app_user" "test" {
+  app_id   = okta_app_saml.test.id
+  user_id  = okta_user.test.id
+  username = okta_user.test.email
+
+  profile = <<JSON
+{"someAttribute":"testing"}
+JSON
+
+  profile_attributes_to_ignore = ["testCustom"]
+}

--- a/okta/resource_okta_app_user_test.go
+++ b/okta/resource_okta_app_user_test.go
@@ -16,6 +16,7 @@ func TestAccOktaAppUser_crud(t *testing.T) {
 	config := mgr.GetFixtures("basic.tf", t)
 	update := mgr.GetFixtures("update.tf", t)
 	basicProfile := mgr.GetFixtures("basic_profile.tf", t)
+	ignoreConfig := mgr.GetFixtures("profile_attributes_to_ignore.tf", t)
 
 	oktaResourceTest(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
@@ -49,6 +50,16 @@ func TestAccOktaAppUser_crud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "user_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("testAcc_%d@example.com", mgr.Seed)),
 					resource.TestCheckResourceAttr(resourceName, "profile", "{\"testCustom\":\"testing\"}"),
+				),
+			},
+			{
+				Config:  ignoreConfig,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "user_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("testAcc_%d@example.com", mgr.Seed)),
+					resource.TestCheckResourceAttr(resourceName, "profile", "{\"someAttribute\":\"testing\"}"), // Note: "testCustom" is ignored and should not be present
 				),
 			},
 			{

--- a/website/docs/r/app_user.html.markdown
+++ b/website/docs/r/app_user.html.markdown
@@ -40,12 +40,16 @@ The following arguments are supported:
 
 - `user_id` - (Required) User to associate the application with.
 
-- `username` - (Optional) The username to use for the app user. In case the user is assigned to the app with 
+- `username` - (Optional) The username to use for the app user. In case the user is assigned to the app with
   'SHARED_USERNAME_AND_PASSWORD' credentials scheme, this field will be computed and should not be set.
 
 - `password` - (Optional) The password to use.
 
 - `profile` - (Optional) The JSON profile of the App User.
+
+- `profile_attributes_to_ignore` - (Optional) List of profile keys that should be excluded from being managed
+  by Terraform. This is useful in situations where specific profile fields are automatically mapped to app
+  schema properties.
 
 - `retain_assignment` - (Optional) Retain the user association on destroy. If set to true, the resource will be removed from state but not from the Okta app.
 


### PR DESCRIPTION
Potential solve for https://github.com/okta/terraform-provider-okta/issues/1565 

This brings an option to ignore specific attributes from app_user.profile. This is helpful for cases where you have most of the schema mapped to okta user attributes and you want to set a snowflake that is not mapped from tf.

usage:

```hcl
resource "okta_app_user" "test" {
  app_id   = okta_app_saml.test.id
  user_id  = okta_user.test.id
  username = okta_user.test.email

  profile = <<JSON
{"someAttribute":"testing"}
JSON

  profile_attributes_to_ignore = ["testCustom"]
}
```

Note: Can someone run the test suite for me? :)