### PR TITLE
Update the description for the "platform_include" block of "app_signon_policy_rule" to outline requirement for the "os_expression" argument to be set when "os_type" is set to "OTHER" 

### DIFF
--- a/website/docs/r/app_signon_policy_rule.html.markdown
+++ b/website/docs/r/app_signon_policy_rule.html.markdown
@@ -300,7 +300,7 @@ The following arguments are supported:
 
 - `platform_include` - (Optional) List of particular platforms or devices to match on.
     - `type` - (Optional) One of: `"ANY"`, `"MOBILE"`, `"DESKTOP"`
-    - `os_expression` - (Optional) Only available when using `os_type = "OTHER"`
+    - `os_expression` - (Optional) Only available and required when using `os_type = "OTHER"`
     - `os_type` - (Optional) One of: `"ANY"`, `"IOS"`, `"WINDOWS"`, `"ANDROID"`, `"OTHER"`, `"OSX"`, `"MACOS"`
 
 - `custom_expression` - (Optional) This is an advanced optional setting. If the expression is formatted incorrectly or conflicts with conditions set above, the rule may not match any users.


### PR DESCRIPTION
Currently, the Okta provider requires the "os_expression" argument to be set when "os_type" is set to "OTHER" which is not clearly outlined within the documentation and when omitted, Terraform will return the following error:

`Error: failed to create app sign on policy rule: the API returned an error: Api validation failed: conditions.platform. Causes: errorSummary: conditions.platform: The condition 'platform' must have os.expression if os.type is OTHER.`

PS.
This could be reflected in the complex example configuration as well.