### PR TITLE
New data source: okta_group_rule

### DIFF
--- a/examples/okta_group_rule/datasource.tf
+++ b/examples/okta_group_rule/datasource.tf
@@ -1,0 +1,15 @@
+resource "okta_group" "test" {
+  name = "testAcc_replace_with_uuid"
+}
+
+resource "okta_group_rule" "test" {
+  name              = "testAcc_replace_with_uuid"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.firstName,\"andy\")"
+}
+
+data "okta_group_rule" "test" {
+  id          = okta_group_rule.test.id
+}

--- a/examples/okta_group_rule/datasource.tf
+++ b/examples/okta_group_rule/datasource.tf
@@ -10,6 +10,10 @@ resource "okta_group_rule" "test" {
   expression_value  = "String.startsWith(user.firstName,\"andy\")"
 }
 
-data "okta_group_rule" "test" {
+data "okta_group_rule" "test_by_id" {
   id          = okta_group_rule.test.id
+}
+
+data "okta_group_rule" "test_by_name" {
+  name          = "testAcc_replace_with_uuid"
 }

--- a/okta/data_source_okta_group_rule.go
+++ b/okta/data_source_okta_group_rule.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/terraform-provider-okta/sdk"
+	"github.com/okta/terraform-provider-okta/sdk/query"
 )
 
 func dataSourceGroupRule() *schema.Resource {
@@ -12,12 +14,13 @@ func dataSourceGroupRule() *schema.Resource {
 		ReadContext: dataSourceGroupRuleRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
 			},
 			"name": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 			"group_assignments": {
 				Type:     schema.TypeSet,
@@ -43,30 +46,48 @@ func dataSourceGroupRule() *schema.Resource {
 }
 
 func dataSourceGroupRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	ruleID, ok := d.GetOk("id")
-	if ok {
-		rule, _, err := getOktaClientFromMetadata(m).Group.GetGroupRule(ctx, ruleID.(string), nil)
+	var rule *sdk.GroupRule
+	ruleID, idOk := d.GetOk("id")
+	if idOk {
+		respRule, _, err := getOktaClientFromMetadata(m).Group.GetGroupRule(ctx, ruleID.(string), nil)
 		if err != nil {
 			return diag.Errorf("failed get group rule by ID: %v", err)
 		}
-		d.SetId(rule.Id)
-		_ = d.Set("name", rule.Name)
-		_ = d.Set("status", rule.Status)
-		if rule.Conditions != nil {
-			_ = d.Set("expression_type", rule.Conditions.Expression.Type)
-			_ = d.Set("expression_value", rule.Conditions.Expression.Value)
-		}
-		if rule.Conditions.People != nil && rule.Conditions.People.Users != nil {
-			_ = d.Set("users_excluded", convertStringSliceToSet(rule.Conditions.People.Users.Exclude))
-		}
-		err = setNonPrimitives(d, map[string]interface{}{
-			"group_assignments": convertStringSliceToSet(rule.Actions.AssignUserToGroups.GroupIds),
-		})
-		if err != nil {
-			return diag.Errorf("failed to set group rule properties: %v", err)
-		}
-		return nil
+		rule = respRule
 	} else {
-		return diag.Errorf("config must provide 'id' to retrieve a group rule")
+		ruleName, nameOk := d.GetOk("name")
+		if nameOk {
+			var name = ruleName.(string)
+			searchParams := &query.Params{Search: name, Limit: 1}
+			rules, _, err := getOktaClientFromMetadata(m).Group.ListGroupRules(ctx, searchParams)
+			switch {
+			case err != nil:
+				return diag.Errorf("failed to get group rule by name: %v", err)
+			case len(rules) < 1:
+				return diag.Errorf("group rule with name '%s' does not exist", name)
+			case rules[0].Name != name:
+				logger(m).Warn("group rule with exact name match was not found: using partial match which contains name as a substring", "name", rules[0].Name)
+			}
+			rule = rules[0]
+		} else {
+			return diag.Errorf("config must provide 'name' or 'id' to retrieve a group rule")
+		}
 	}
+	d.SetId(rule.Id)
+	_ = d.Set("name", rule.Name)
+	_ = d.Set("status", rule.Status)
+	if rule.Conditions != nil {
+		_ = d.Set("expression_type", rule.Conditions.Expression.Type)
+		_ = d.Set("expression_value", rule.Conditions.Expression.Value)
+	}
+	if rule.Conditions.People != nil && rule.Conditions.People.Users != nil {
+		_ = d.Set("users_excluded", convertStringSliceToSet(rule.Conditions.People.Users.Exclude))
+	}
+	err := setNonPrimitives(d, map[string]interface{}{
+		"group_assignments": convertStringSliceToSet(rule.Actions.AssignUserToGroups.GroupIds),
+	})
+	if err != nil {
+		return diag.Errorf("failed to set group rule properties: %v", err)
+	}
+	return nil
 }

--- a/okta/data_source_okta_group_rule.go
+++ b/okta/data_source_okta_group_rule.go
@@ -1,0 +1,72 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGroupRule() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGroupRuleRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_assignments": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"expression_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expression_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": statusSchema,
+			"users_excluded": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceGroupRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	ruleID, ok := d.GetOk("id")
+	if ok {
+		rule, _, err := getOktaClientFromMetadata(m).Group.GetGroupRule(ctx, ruleID.(string), nil)
+		if err != nil {
+			return diag.Errorf("failed get group rule by ID: %v", err)
+		}
+		d.SetId(rule.Id)
+		_ = d.Set("name", rule.Name)
+		_ = d.Set("status", rule.Status)
+		if rule.Conditions != nil {
+			_ = d.Set("expression_type", rule.Conditions.Expression.Type)
+			_ = d.Set("expression_value", rule.Conditions.Expression.Value)
+		}
+		if rule.Conditions.People != nil && rule.Conditions.People.Users != nil {
+			_ = d.Set("users_excluded", convertStringSliceToSet(rule.Conditions.People.Users.Exclude))
+		}
+		err = setNonPrimitives(d, map[string]interface{}{
+			"group_assignments": convertStringSliceToSet(rule.Actions.AssignUserToGroups.GroupIds),
+		})
+		if err != nil {
+			return diag.Errorf("failed to set group rule properties: %v", err)
+		}
+		return nil
+	} else {
+		return diag.Errorf("config must provide 'id' to retrieve a group rule")
+	}
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -368,6 +368,7 @@ func Provider() *schema.Provider {
 			defaultPolicy:            dataSourceDefaultPolicy(),
 			group:                    dataSourceGroup(),
 			groupEveryone:            dataSourceEveryoneGroup(),
+			groupRule:                dataSourceGroupRule(),
 			groups:                   dataSourceGroups(),
 			idpMetadataSaml:          dataSourceIdpMetadataSaml(),
 			idpOidc:                  dataSourceIdpOidc(),

--- a/website/docs/d/group_rule.html.markdown
+++ b/website/docs/d/group_rule.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "okta"
+page_title: "Okta: okta_group_rule"
+sidebar_current: "docs-okta-datasource-group-rule"
+description: |- Get a group rule from Okta.
+---
+
+# okta_group_rule
+
+Use this data source to retrieve a group rule from Okta.
+
+## Example Usage
+
+```hcl
+data "okta_group_rule" "test" {
+  id = okta_group_rule.example.id
+}
+```
+
+## Arguments Reference
+
+- `id` - (Required) ID of the group rule to retrieve.
+
+
+## Attributes Reference
+
+- `id` - The ID of the Group Rule.
+
+- `name` - The name of the Group Rule.
+
+- `group_assignments` - The list of group ids to assign the users to.
+
+- `expression_type` - The expression type to use to invoke the rule.
+
+- `expression_value` - The expression value.
+
+- `status` - The status of the group rule.
+
+- `users_excluded` - The list of user IDs that would be excluded when rules are processed.

--- a/website/docs/d/group_rule.html.markdown
+++ b/website/docs/d/group_rule.html.markdown
@@ -19,8 +19,8 @@ data "okta_group_rule" "test" {
 
 ## Arguments Reference
 
-- `id` - (Required) ID of the group rule to retrieve.
-
+- `id` - (Optional) The ID of the group rule to retrieve.
+- `name` - (Optional) The name of the Group Rule to retrieve.
 
 ## Attributes Reference
 

--- a/website/okta.erb
+++ b/website/okta.erb
@@ -70,6 +70,9 @@
             <li<%= sidebar_current("docs-okta-datasource-group") %>>
               <a href="/docs/providers/okta/d/group.html">okta_group</a>
             </li>
+            <li<%= sidebar_current("docs-okta-datasource-group-rule") %>>
+              <a href="/docs/providers/okta/d/group_rule.html">okta_group_rule</a>
+            </li>
             <li<%= sidebar_current("docs-okta-datasource-groups") %>>
               <a href="/docs/providers/okta/d/groups.html">okta_groups</a>
             </li>


### PR DESCRIPTION
Adds a new data source to retrieve a group rule.

We're using this to build an optional safety check in our application module to reduce the impact of unexpected mass unassign from a high-impact application.

- Read the current rule state (new data source) and compare it to the provided expression input variable to detect an expression change.
- Use a resource precondition to block apply on expression change if user de-provisioning is enabled for the associated application (read from the existing application data source).