### PR TITLE
v4.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 4.1.0 (June 30, 2023)
+
+### NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:
+* New Data Source `okta_group_rule` [#1606](https://github.com/okta/terraform-provider-okta/pull/1606), [#1617](https://github.com/okta/terraform-provider-okta/pull/1617). Thanks, [@steveAG](https://github.com/steveAG)!
+
+### IMPROVEMENTS
+
+* Improve `okta_email_customization`, correct delete bug, document and test `depends_on` best practice [#1616](https://github.com/okta/terraform-provider-okta/pull/1616). Thanks, [@monde](https://github.com/monde)!
+* Flexible `okta_brand` data source and resource with `default` ID; Improve `okta_auth_server_default` [#1570](https://github.com/okta/terraform-provider-okta/pull/1570). Thanks, [@monde](https://github.com/monde)!
+* Show appropriate terraform logo for light and dark themes in README [#1574](https://github.com/okta/terraform-provider-okta/pull/1574). Thanks, [@thekbb](https://github.com/thekbb)!
+* Update the description for the `platform_include` block of `app_signon_policy_rule` to outline requirement for the `os_expression` argument to be set when `os_type` is set to `OTHER` [#1600](https://github.com/okta/terraform-provider-okta/pull/1600). Thanks, [@achuchulev](https://github.com/achuchulev)!
+* Update okta documentation [#1614](https://github.com/okta/terraform-provider-okta/pull/1614). Thanks, [@duytiennguyen-okta](https://github.com/ duytiennguyen-okta)!
+* Fix doc typo [#1611](https://github.com/okta/terraform-provider-okta/pull/1611). Thanks, [@monde](https://github.com/monde)!
+
 ## 4.0.3 (June 26, 2023)
 
 ### NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:

--- a/okta/config.go
+++ b/okta/config.go
@@ -160,7 +160,7 @@ func oktaSDKClient(c *Config) (client *sdk.Client, err error) {
 		sdk.WithRateLimitMaxBackOff(int64(c.maxWait)),
 		sdk.WithRequestTimeout(int64(c.requestTimeout)),
 		sdk.WithRateLimitMaxRetries(int32(c.retryCount)),
-		sdk.WithUserAgentExtra("okta-terraform/4.0.3"),
+		sdk.WithUserAgentExtra("okta-terraform/4.1.0"),
 	}
 
 	switch {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 4.0.3"
+      version = "~> 4.1.0"
     }
   }
 }


### PR DESCRIPTION
## 4.1.0 (June 30, 2023)

### NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:
* New Data Source `okta_group_rule` [#1606](https://github.com/okta/terraform-provider-okta/pull/1606), [#1617](https://github.com/okta/terraform-provider-okta/pull/1617). Thanks, [@steveAG](https://github.com/steveAG)!

### IMPROVEMENTS

* Improve `okta_email_customization`, correct delete bug, document and test `depends_on` best practice [#1616](https://github.com/okta/terraform-provider-okta/pull/1616). Thanks, [@monde](https://github.com/monde)!
* Flexible `okta_brand` data source and resource with `default` ID; Improve `okta_auth_server_default` [#1570](https://github.com/okta/terraform-provider-okta/pull/1570). Thanks, [@monde](https://github.com/monde)!
* Show appropriate terraform logo for light and dark themes in README [#1574](https://github.com/okta/terraform-provider-okta/pull/1574). Thanks, [@thekbb](https://github.com/thekbb)!
* Update the description for the `platform_include` block of `app_signon_policy_rule` to outline requirement for the `os_expression` argument to be set when `os_type` is set to `OTHER` [#1600](https://github.com/okta/terraform-provider-okta/pull/1600). Thanks, [@achuchulev](https://github.com/achuchulev)!
* Update okta documentation [#1614](https://github.com/okta/terraform-provider-okta/pull/1614). Thanks, [@duytiennguyen-okta](https://github.com/ duytiennguyen-okta)!
* Fix doc typo [#1611](https://github.com/okta/terraform-provider-okta/pull/1611). Thanks, [@monde](https://github.com/monde)!