### PR TITLE
Update "id" and "name" attributes of okta_group data source to be computed.

### DIFF
--- a/okta/data_source_okta_group.go
+++ b/okta/data_source_okta_group.go
@@ -19,11 +19,13 @@ func dataSourceGroup() *schema.Resource {
 			"id": {
 				Type:          schema.TypeString,
 				Computed:      true,
+				Optional:      true,
 				ConflictsWith: []string{"name", "type"},
 			},
 			"name": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 			"type": {
 				Type:             schema.TypeString,

--- a/okta/data_source_okta_group.go
+++ b/okta/data_source_okta_group.go
@@ -18,12 +18,12 @@ func dataSourceGroup() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:          schema.TypeString,
-				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"name", "type"},
 			},
 			"name": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"type": {
 				Type:             schema.TypeString,


### PR DESCRIPTION
This allows the values to be passed in to these attributes and remain option. However, Terraform will know the attributes are non-optional attributes when using attributes in other resources.

This avoids errors "The argument "<attribute>" is required, but no definition was found." when using the id attribute of the data source as the value to a required attribute of another resource.

Issue #1642

Apologies in advanced - I see the latest version of the provider published to Hashicorp registry is 3.46.0, so assume this is the branch to merge changes into