### PR TITLE
Ensure `jwks_uri` or `jwks` can be set when using private_key_jwt

### DIFF
--- a/okta/data_source_okta_group_rule.go
+++ b/okta/data_source_okta_group_rule.go
@@ -57,7 +57,7 @@ func dataSourceGroupRuleRead(ctx context.Context, d *schema.ResourceData, m inte
 	} else {
 		ruleName, nameOk := d.GetOk("name")
 		if nameOk {
-			var name = ruleName.(string)
+			name := ruleName.(string)
 			searchParams := &query.Params{Search: name, Limit: 1}
 			rules, _, err := getOktaClientFromMetadata(m).Group.ListGroupRules(ctx, searchParams)
 			switch {

--- a/okta/provider_test.go
+++ b/okta/provider_test.go
@@ -27,9 +27,7 @@ import (
 	"github.com/okta/terraform-provider-okta/sdk"
 )
 
-var (
-	testAccProvidersFactories map[string]func() (*schema.Provider, error)
-)
+var testAccProvidersFactories map[string]func() (*schema.Provider, error)
 
 func init() {
 	provider := Provider()

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -843,8 +843,10 @@ func validateAppOAuth(d *schema.ResourceData) error {
 			return errors.New("'name' 'value' and in 'groups_claim' should not be empty")
 		}
 	}
-	if _, ok := d.GetOk("jwks"); !ok && d.Get("token_endpoint_auth_method").(string) == "private_key_jwt" {
-		return errors.New("'jwks' is required when 'token_endpoint_auth_method' is 'private_key_jwt'")
+	_, jwks := d.GetOk("jwks")
+	_, jwks_uri := d.GetOk("jwks_uri")
+	if !(jwks || jwks_uri) && d.Get("token_endpoint_auth_method").(string) == "private_key_jwt" {
+		return errors.New("'jwks' or 'jwks_uri' is required when 'token_endpoint_auth_method' is 'private_key_jwt'")
 	}
 	if d.Get("login_mode").(string) != "DISABLED" {
 		if d.Get("login_uri").(string) == "" {

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -105,6 +105,8 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 
 - `jwks` - (Optional) JSON Web Key set. [Admin Console JWK Reference](https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/main/#generate-the-jwk-in-the-admin-console)
 
+- `jwks_uri` - (Optional) URL of the custom authorization server's JSON Web Key Set document.
+
 - `label` - (Required) The Application's display name.
 
 - `login_mode` - (Optional) The type of Idp-Initiated login that the client supports, if any. Valid values: `"DISABLED"`, `"SPEC"`, `"OKTA"`. Default is `"DISABLED"`.
@@ -190,7 +192,7 @@ Valid values: `"CUSTOM_URL"`,`"ORG_URL"` or `"DYNAMIC"`. Default is `"ORG_URL"`.
 
 ## Timeouts
 
-The `timeouts` block allows you to specify custom [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions: 
+The `timeouts` block allows you to specify custom [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 - `create` - Create timeout (default 1 hour).
 


### PR DESCRIPTION
Small bugfix to ensure `jwks_uri` can be used and additionally adds the field into documentation for the resource and error message.

- Fixes #1583 
- Tested locally & confirmed works ✔️ 


/cc @MikeMondragon-okta @duytiennguyen-okta 



#### Testing

The following app uses `jwks_uri`. Tested creation and updating. Updating log shown below:
```
terraform state show 'resource123'
# resource123:
resource "okta_app_oauth" "default" {
    accessibility_self_service = false
    admin_note                 = <<-EOT
        Old
    EOT
    app_links_json             = jsonencode(
        {
            oidc_client_link = true
        }
    )
    app_settings_json          = jsonencode({})
    auto_key_rotation          = true
    auto_submit_toolbar        = false
    client_id                  = "XXXXXXXXX"
    consent_method             = "TRUSTED"
    grant_types                = [
        "client_credentials",
    ]
    hide_ios                   = true
    hide_web                   = true
    id                         = "XXXXXXXXX"
    implicit_assignment        = false
    issuer_mode                = "CUSTOM_URL"
    jwks_uri                   = "https://example.com"
    label                      = "XXXX"
    login_mode                 = "DISABLED"
    login_scopes               = []
    logo                       = "5ede509fb78728daf69f9720660b7490da1903f91ce44df8337049d4d9b4b81f"
    logo_url                   = "https://ok14static.oktacdn.com/fs/bco/4/fs06l2v85f2YdeKbw697"
    name                       = "oidc_client"
    omit_secret                = true
    pkce_required              = false
    post_logout_redirect_uris  = []
    redirect_uris              = []
    response_types             = [
        "token",
    ]
    sign_on_mode               = "OPENID_CONNECT"
    status                     = "ACTIVE"
    token_endpoint_auth_method = "private_key_jwt"
    type                       = "service"
    user_name_template         = "${source.login}"
    user_name_template_type    = "BUILT_IN"
    wildcard_redirect          = "DISABLED"
}
```

Updating:
```
resource123 will be updated in-place
  ~ resource "okta_app_oauth" "resource123" {
      ~ admin_note                 = <<-EOT
          - Old
          + New
        EOT
        id                         = "XXXXXXX"
        name                       = "oidc_client"
        # (30 unchanged attributes hidden)
    }

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
