### PR TITLE
DRY up backoff.Backoff set up and proper use of context.Context

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -53,13 +53,13 @@ testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) $(TEST_FILTER) -timeout 120m
 
 test-play-vcr-acc:
-	OKTA_VCR_TF_ACC=play TF_ACC=1 go test $(TEST) -v $(TESTARGS) $(TEST_FILTER) -timeout 120m
+	OKTA_VCR_TF_ACC=play TF_ACC=1 go test -tags unit -mod=readonly -test.v -timeout 120m ./okta
 
 smoke-test-play-vcr-acc:
-	OKTA_VCR_TF_ACC=play TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^$(smoke_tests)$$ ./okta
+	OKTA_VCR_TF_ACC=play TF_ACC=1 go test -tags unit -mod=readonly -test.v -timeout 120m -run ^$(smoke_tests)$$ ./okta
 
 test-record-vcr-acc:
-	OKTA_VCR_TF_ACC=record TF_ACC=1 go test $(TEST) -v $(TESTARGS) $(TEST_FILTER) -timeout 120m
+	OKTA_VCR_TF_ACC=record TF_ACC=1 go test -tags unit -mod=readonly -test.v -timeout 120m ./okta
 
 vet:
 	@echo "==> Checking source code against go vet and staticcheck"

--- a/okta/app.go
+++ b/okta/app.go
@@ -428,13 +428,11 @@ func deleteApplication(ctx context.Context, d *schema.ResourceData, m interface{
 
 	// Okta Core can have eventual consistency issues when deactivating an app
 	// which is required before deleting the app.
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = 5 * time.Second
-
+	boc := newExponentialBackOffWithContext(ctx, 5*time.Second)
 	err := backoff.Retry(func() error {
 		_, err := client.Application.DeleteApplication(ctx, d.Id())
 		return err
-	}, b)
+	}, boc)
 
 	return err
 }

--- a/okta/app.go
+++ b/okta/app.go
@@ -431,7 +431,7 @@ func deleteApplication(ctx context.Context, d *schema.ResourceData, m interface{
 	boc := newExponentialBackOffWithContext(ctx, 5*time.Second)
 	err := backoff.Retry(func() error {
 		_, err := client.Application.DeleteApplication(ctx, d.Id())
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 		return err

--- a/okta/app.go
+++ b/okta/app.go
@@ -431,6 +431,9 @@ func deleteApplication(ctx context.Context, d *schema.ResourceData, m interface{
 	boc := newExponentialBackOffWithContext(ctx, 5*time.Second)
 	err := backoff.Retry(func() error {
 		_, err := client.Application.DeleteApplication(ctx, d.Id())
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 		return err
 	}, boc)
 

--- a/okta/data_source_okta_group.go
+++ b/okta/data_source_okta_group.go
@@ -60,7 +60,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, m interfac
 		delay, err := strconv.Atoi(n.(string))
 		if err == nil {
 			logger(m).Info("delaying group read by ", delay, " seconds")
-			time.Sleep(time.Duration(delay) * time.Second)
+			m.(*Config).timeOperations.Sleep(time.Duration(delay) * time.Second)
 		} else {
 			logger(m).Warn("group read delay value ", n, " is not an integer")
 		}

--- a/okta/data_source_okta_user.go
+++ b/okta/data_source_okta_user.go
@@ -92,7 +92,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 		delay, err := strconv.Atoi(n.(string))
 		if err == nil {
 			logger(m).Info("delaying user read by ", delay, " seconds")
-			time.Sleep(time.Duration(delay) * time.Second)
+			m.(*Config).timeOperations.Sleep(time.Duration(delay) * time.Second)
 		} else {
 			logger(m).Warn("user read delay value ", n, " is not an integer")
 		}

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -77,7 +77,7 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, m interfac
 		delay, err := strconv.Atoi(n.(string))
 		if err == nil {
 			logger(m).Info("delaying users read by ", delay, " seconds")
-			time.Sleep(time.Duration(delay) * time.Second)
+			m.(*Config).timeOperations.Sleep(time.Duration(delay) * time.Second)
 		} else {
 			logger(m).Warn("users read delay value ", n, " is not an integer")
 		}

--- a/okta/policy_rule.go
+++ b/okta/policy_rule.go
@@ -111,7 +111,7 @@ func createRule(ctx context.Context, d *schema.ResourceData, m interface{}, temp
 	boc := newExponentialBackOffWithContext(ctx, backoff.DefaultMaxElapsedTime)
 	err = backoff.Retry(func() error {
 		ruleObj, resp, err := getAPISupplementFromMetadata(m).CreatePolicyRule(ctx, policyID, template)
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 		if resp.StatusCode == http.StatusInternalServerError {

--- a/okta/policy_rule.go
+++ b/okta/policy_rule.go
@@ -111,6 +111,9 @@ func createRule(ctx context.Context, d *schema.ResourceData, m interface{}, temp
 	boc := newExponentialBackOffWithContext(ctx, backoff.DefaultMaxElapsedTime)
 	err = backoff.Retry(func() error {
 		ruleObj, resp, err := getAPISupplementFromMetadata(m).CreatePolicyRule(ctx, policyID, template)
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 		if resp.StatusCode == http.StatusInternalServerError {
 			return err
 		}

--- a/okta/policy_rule.go
+++ b/okta/policy_rule.go
@@ -108,6 +108,7 @@ func createRule(ctx context.Context, d *schema.ResourceData, m interface{}, temp
 		return fmt.Errorf("'policy_id' field should be set")
 	}
 	var rule *sdk.SdkPolicyRule
+	boc := newExponentialBackOffWithContext(ctx, backoff.DefaultMaxElapsedTime)
 	err = backoff.Retry(func() error {
 		ruleObj, resp, err := getAPISupplementFromMetadata(m).CreatePolicyRule(ctx, policyID, template)
 		if resp.StatusCode == http.StatusInternalServerError {
@@ -118,7 +119,7 @@ func createRule(ctx context.Context, d *schema.ResourceData, m interface{}, temp
 		}
 		rule = ruleObj
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, boc)
 	if err != nil {
 		return fmt.Errorf("failed to create policy rule: %v", err)
 	}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -7,7 +7,9 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -476,4 +478,14 @@ func resourceFuncNoOp(context.Context, *schema.ResourceData, interface{}) diag.D
 func int64Ptr(what int) *int64 {
 	result := int64(what)
 	return &result
+}
+
+// newExponentialBackOffWithContext helper to dry up creating a backoff object that is exponential and has context
+func newExponentialBackOffWithContext(ctx context.Context, maxElapsedTime time.Duration) backoff.BackOffContext {
+	bOff := backoff.NewExponentialBackOff()
+	bOff.MaxElapsedTime = maxElapsedTime
+
+	// NOTE: backoff.BackOffContext is an interface that embeds backoff.Backoff
+	// so the greater context is considered on backoff.Retry
+	return backoff.WithContext(bOff, ctx)
 }

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -492,6 +492,5 @@ func newExponentialBackOffWithContext(ctx context.Context, maxElapsedTime time.D
 
 // doNotRetry helper function to flag if provider should be using backoff.Retry
 func doNotRetry(m interface{}, err error) bool {
-	config := m.(*Config)
-	return config.timeOperations.DoNotRetry(err)
+	return m.(*Config).timeOperations.DoNotRetry(err)
 }

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -489,3 +489,13 @@ func newExponentialBackOffWithContext(ctx context.Context, maxElapsedTime time.D
 	// so the greater context is considered on backoff.Retry
 	return backoff.WithContext(bOff, ctx)
 }
+
+// doNotRetry helper function to flag if provider should be using backoff.Retry
+func doNotRetry(err error) bool {
+	// NOTE: here we are considering the test environment in production which is
+	// not a good practice. However in this case we don't want backoff retries
+	// executing if the provider is running in the VCR test environment when it
+	// is recording API calls. We can re-record tests that fail because of rate
+	// limiting.
+	return err != nil && os.Getenv("OKTA_VCR_TF_ACC") == "record"
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -491,11 +491,7 @@ func newExponentialBackOffWithContext(ctx context.Context, maxElapsedTime time.D
 }
 
 // doNotRetry helper function to flag if provider should be using backoff.Retry
-func doNotRetry(err error) bool {
-	// NOTE: here we are considering the test environment in production which is
-	// not a good practice. However in this case we don't want backoff retries
-	// executing if the provider is running in the VCR test environment when it
-	// is recording API calls. We can re-record tests that fail because of rate
-	// limiting.
-	return err != nil && os.Getenv("OKTA_VCR_TF_ACC") == "record"
+func doNotRetry(m interface{}, err error) bool {
+	config := m.(*Config)
+	return config.timeOperations.DoNotRetry(err)
 }

--- a/okta/provider_test.go
+++ b/okta/provider_test.go
@@ -395,6 +395,8 @@ func getCachedConfig(ctx context.Context, d *schema.ResourceData, configureFunc 
 	}
 
 	config := c.(*Config)
+	config.SetTimeOperations(NewTestTimeOperations())
+
 	transport := config.oktaClient.GetConfig().HttpClient.Transport
 
 	rec, err := recorder.NewAsMode(mgr.CassettePath(), mgr.VCRMode(), transport)

--- a/okta/resource_okta_app_user_custom_schema_property.go
+++ b/okta/resource_okta_app_user_custom_schema_property.go
@@ -116,9 +116,7 @@ func setAppUserSchemaProperty(ctx context.Context, d *schema.ResourceData, m int
 	if err != nil {
 		return err
 	}
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 30
-	bOff.InitialInterval = time.Second
+	boc := newExponentialBackOffWithContext(ctx, 30*time.Second)
 	err = backoff.Retry(func() error {
 		if err := updateAppUserSubSchemaProperty(ctx, d, m); err != nil {
 			if errors.Is(err, errInvalidElemFormat) {
@@ -135,7 +133,7 @@ func setAppUserSchemaProperty(ctx context.Context, d *schema.ResourceData, m int
 			return fmt.Errorf("application user schema property '%s' was not created/updated for '%s' app", d.Get("index").(string), d.Get("app_id").(string))
 		}
 		return nil
-	}, bOff)
+	}, boc)
 	return err
 }
 
@@ -194,9 +192,7 @@ func updateAppUserSubSchemaProperty(ctx context.Context, d *schema.ResourceData,
 	}
 	custom := buildCustomUserSchema(d.Get("index").(string), subSchema)
 	retypeUserSchemaPropertyEnums(custom)
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 10
-	bOff.InitialInterval = time.Second
+	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		_, _, err := getOktaClientFromMetadata(m).UserSchema.
 			UpdateApplicationUserProfile(ctx, d.Get("app_id").(string), *custom)
@@ -215,7 +211,7 @@ func updateAppUserSubSchemaProperty(ctx context.Context, d *schema.ResourceData,
 			return backoff.Permanent(fmt.Errorf("failed to update custom app user schema property: %w", err))
 		}
 		return backoff.Permanent(fmt.Errorf("failed to update custom app user schema property: %w", err))
-	}, bOff)
+	}, boc)
 	return err
 }
 

--- a/okta/resource_okta_app_user_custom_schema_property.go
+++ b/okta/resource_okta_app_user_custom_schema_property.go
@@ -119,7 +119,7 @@ func setAppUserSchemaProperty(ctx context.Context, d *schema.ResourceData, m int
 	boc := newExponentialBackOffWithContext(ctx, 30*time.Second)
 	err = backoff.Retry(func() error {
 		if err := updateAppUserSubSchemaProperty(ctx, d, m); err != nil {
-			if doNotRetry(err) {
+			if doNotRetry(m, err) {
 				return backoff.Permanent(err)
 			}
 			if errors.Is(err, errInvalidElemFormat) {
@@ -199,7 +199,7 @@ func updateAppUserSubSchemaProperty(ctx context.Context, d *schema.ResourceData,
 	err = backoff.Retry(func() error {
 		_, _, err := getOktaClientFromMetadata(m).UserSchema.
 			UpdateApplicationUserProfile(ctx, d.Get("app_id").(string), *custom)
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 		if err == nil {

--- a/okta/resource_okta_domain_verification.go
+++ b/okta/resource_okta_domain_verification.go
@@ -31,6 +31,9 @@ func resourceDomainVerificationCreate(ctx context.Context, d *schema.ResourceDat
 	boc := newExponentialBackOffWithContext(ctx, 30*time.Second)
 	err := backoff.Retry(func() error {
 		domain, _, err := getOktaClientFromMetadata(m).Domain.VerifyDomain(ctx, d.Get("domain_id").(string))
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 		if err != nil {
 			return backoff.Permanent(fmt.Errorf("failed to verify domain: %v", err))
 		}

--- a/okta/resource_okta_domain_verification.go
+++ b/okta/resource_okta_domain_verification.go
@@ -31,7 +31,7 @@ func resourceDomainVerificationCreate(ctx context.Context, d *schema.ResourceDat
 	boc := newExponentialBackOffWithContext(ctx, 30*time.Second)
 	err := backoff.Retry(func() error {
 		domain, _, err := getOktaClientFromMetadata(m).Domain.VerifyDomain(ctx, d.Get("domain_id").(string))
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 		if err != nil {

--- a/okta/resource_okta_group.go
+++ b/okta/resource_okta_group.go
@@ -86,9 +86,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	if err != nil {
 		return diag.Errorf("failed to create group: %v", err)
 	}
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 10
-	bOff.InitialInterval = time.Second
+	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		g, resp, err := getOktaClientFromMetadata(m).Group.GetGroup(ctx, responseGroup.Id)
 		if err := suppressErrorOn404(resp, err); err != nil {
@@ -98,7 +96,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 			return fmt.Errorf("group '%s' hasn't been created after multiple checks", responseGroup.Id)
 		}
 		return nil
-	}, bOff)
+	}, boc)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/okta/resource_okta_group.go
+++ b/okta/resource_okta_group.go
@@ -89,6 +89,9 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		g, resp, err := getOktaClientFromMetadata(m).Group.GetGroup(ctx, responseGroup.Id)
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 		if err := suppressErrorOn404(resp, err); err != nil {
 			return backoff.Permanent(err)
 		}

--- a/okta/resource_okta_group.go
+++ b/okta/resource_okta_group.go
@@ -89,7 +89,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		g, resp, err := getOktaClientFromMetadata(m).Group.GetGroup(ctx, responseGroup.Id)
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 		if err := suppressErrorOn404(resp, err); err != nil {

--- a/okta/resource_okta_group_custom_schema_property.go
+++ b/okta/resource_okta_group_custom_schema_property.go
@@ -118,7 +118,7 @@ func alterCustomGroupSchema(ctx context.Context, m interface{}, index string, sc
 		retypeGroupSchemaPropertyEnums(schema)
 		updated, resp, err := getOktaClientFromMetadata(m).GroupSchema.UpdateGroupSchema(ctx, *schema)
 		stringifyGroupSchemaPropertyEnums(schema)
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 

--- a/okta/resource_okta_group_custom_schema_property.go
+++ b/okta/resource_okta_group_custom_schema_property.go
@@ -118,6 +118,9 @@ func alterCustomGroupSchema(ctx context.Context, m interface{}, index string, sc
 		retypeGroupSchemaPropertyEnums(schema)
 		updated, resp, err := getOktaClientFromMetadata(m).GroupSchema.UpdateGroupSchema(ctx, *schema)
 		stringifyGroupSchemaPropertyEnums(schema)
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 
 		if err != nil {
 			if resp != nil && resp.StatusCode == 500 {

--- a/okta/resource_okta_group_custom_schema_property.go
+++ b/okta/resource_okta_group_custom_schema_property.go
@@ -109,11 +109,7 @@ func resourceGroupSchemaRead(ctx context.Context, d *schema.ResourceData, m inte
 func alterCustomGroupSchema(ctx context.Context, m interface{}, index string, schema *sdk.GroupSchema, isDeleteOperation bool) (*sdk.GroupSchemaAttribute, error) {
 	var schemaAttribute *sdk.GroupSchemaAttribute
 
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 120
-	bOff.InitialInterval = time.Second
-	bc := backoff.WithContext(bOff, ctx)
-
+	boc := newExponentialBackOffWithContext(ctx, 120*time.Second)
 	err := backoff.Retry(func() error {
 		// NOTE: Enums on the schema can be typed other than string but the
 		// Terraform SDK is staticly defined at runtime for string so we need to
@@ -143,7 +139,7 @@ func alterCustomGroupSchema(ctx context.Context, m interface{}, index string, sc
 			return nil
 		}
 		return errors.New("failed to apply changes after several retries")
-	}, bc)
+	}, boc)
 	if err != nil {
 		logger(m).Error("failed to apply changes after several retries", err)
 	}

--- a/okta/resource_okta_group_memberships.go
+++ b/okta/resource_okta_group_memberships.go
@@ -58,10 +58,7 @@ func resourceGroupMembershipsCreate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 10
-	bOff.InitialInterval = time.Second
-
+	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	// During create the Okta service can have eventual consistency issues when
 	// adding users to a group. Use a backoff to wait for at list one user to be
 	// associated with the group.
@@ -75,7 +72,7 @@ func resourceGroupMembershipsCreate(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 		return fmt.Errorf("group (%s) did not have expected user memberships after multiple checks", groupId)
-	}, bOff)
+	}, boc)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/okta/resource_okta_group_memberships.go
+++ b/okta/resource_okta_group_memberships.go
@@ -65,7 +65,7 @@ func resourceGroupMembershipsCreate(ctx context.Context, d *schema.ResourceData,
 	err = backoff.Retry(func() error {
 		// TODO, should we wait for all users to be added to the group?
 		ok, err := checkIfGroupHasUsers(ctx, client, groupId, users)
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 		if err != nil {

--- a/okta/resource_okta_group_memberships.go
+++ b/okta/resource_okta_group_memberships.go
@@ -65,6 +65,9 @@ func resourceGroupMembershipsCreate(ctx context.Context, d *schema.ResourceData,
 	err = backoff.Retry(func() error {
 		// TODO, should we wait for all users to be added to the group?
 		ok, err := checkIfGroupHasUsers(ctx, client, groupId, users)
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 		if err != nil {
 			return backoff.Permanent(err)
 		}

--- a/okta/resource_okta_group_role.go
+++ b/okta/resource_okta_group_role.go
@@ -117,6 +117,8 @@ func resourceGroupRoleCreate(ctx context.Context, d *schema.ResourceData, m inte
 	err = backoff.Retry(func() error {
 		err := resourceGroupRoleRead(ctx, d, m)
 		if err != nil {
+			// NOTE: we don't need a doNotRetry(err) check because this is going
+			// to backoff permanently as-is
 			return backoff.Permanent(fmt.Errorf("%s", err[0].Summary))
 		}
 		if d.Id() != "" {

--- a/okta/resource_okta_group_role.go
+++ b/okta/resource_okta_group_role.go
@@ -113,9 +113,7 @@ func resourceGroupRoleCreate(ctx context.Context, d *schema.ResourceData, m inte
 		}
 	}
 	d.SetId(role.Id)
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 10
-	bOff.InitialInterval = time.Second
+	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		err := resourceGroupRoleRead(ctx, d, m)
 		if err != nil {
@@ -125,7 +123,7 @@ func resourceGroupRoleCreate(ctx context.Context, d *schema.ResourceData, m inte
 			return nil
 		}
 		return fmt.Errorf("role %s was not assigned to a group %s", roleType, groupID)
-	}, bOff)
+	}, boc)
 	return diag.FromErr(err)
 }
 

--- a/okta/resource_okta_group_role.go
+++ b/okta/resource_okta_group_role.go
@@ -117,7 +117,7 @@ func resourceGroupRoleCreate(ctx context.Context, d *schema.ResourceData, m inte
 	err = backoff.Retry(func() error {
 		err := resourceGroupRoleRead(ctx, d, m)
 		if err != nil {
-			// NOTE: we don't need a doNotRetry(err) check because this is going
+			// NOTE: we don't need a doNotRetry(m, err) check because this is going
 			// to backoff permanently as-is
 			return backoff.Permanent(fmt.Errorf("%s", err[0].Summary))
 		}

--- a/okta/resource_okta_user.go
+++ b/okta/resource_okta_user.go
@@ -441,7 +441,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	// status changing can only happen after user is created as well
 	if d.Get("status").(string) == userStatusSuspended || d.Get("status").(string) == userStatusDeprovisioned {
-		err := updateUserStatus(ctx, user.Id, d.Get("status").(string), client)
+		err := updateUserStatus(m, ctx, user.Id, d.Get("status").(string), client)
 		if err != nil {
 			return diag.Errorf("failed to update user status: %v", err)
 		}
@@ -515,7 +515,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 	// run the update status func first so a user that was previously deprovisioned
 	// can be updated further if it's status changed in it's terraform configs
 	if statusChange {
-		err := updateUserStatus(ctx, d.Id(), status, client)
+		err := updateUserStatus(m, ctx, d.Id(), status, client)
 		if err != nil {
 			return diag.Errorf("failed to update user status: %v", err)
 		}

--- a/okta/resource_okta_user_custom_schema_property.go
+++ b/okta/resource_okta_user_custom_schema_property.go
@@ -158,6 +158,9 @@ func alterCustomUserSchema(ctx context.Context, m interface{}, userType, index s
 		retypeUserSchemaPropertyEnums(schema)
 		updated, resp, err := getOktaClientFromMetadata(m).UserSchema.UpdateUserProfile(ctx, typeSchemaID, *schema)
 		stringifyUserSchemaPropertyEnums(schema)
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 
 		if err != nil {
 			if resp != nil && resp.StatusCode == 500 {

--- a/okta/resource_okta_user_custom_schema_property.go
+++ b/okta/resource_okta_user_custom_schema_property.go
@@ -149,11 +149,7 @@ func alterCustomUserSchema(ctx context.Context, m interface{}, userType, index s
 	}
 	var schemaAttribute *sdk.UserSchemaAttribute
 
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 120
-	bOff.InitialInterval = time.Second
-	bc := backoff.WithContext(bOff, ctx)
-
+	boc := newExponentialBackOffWithContext(ctx, 120*time.Second)
 	err = backoff.Retry(func() error {
 		// NOTE: Enums on the schema can be typed other than string but the
 		// Terraform SDK is staticly defined at runtime for string so we need to
@@ -183,7 +179,7 @@ func alterCustomUserSchema(ctx context.Context, m interface{}, userType, index s
 			return nil
 		}
 		return errors.New("failed to apply changes after several retries")
-	}, bc)
+	}, boc)
 	if err != nil {
 		logger(m).Error("failed to apply changes after several retries", err)
 	}

--- a/okta/resource_okta_user_custom_schema_property.go
+++ b/okta/resource_okta_user_custom_schema_property.go
@@ -158,7 +158,7 @@ func alterCustomUserSchema(ctx context.Context, m interface{}, userType, index s
 		retypeUserSchemaPropertyEnums(schema)
 		updated, resp, err := getOktaClientFromMetadata(m).UserSchema.UpdateUserProfile(ctx, typeSchemaID, *schema)
 		stringifyUserSchemaPropertyEnums(schema)
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -44,9 +44,7 @@ func resourceUserGroupMembershipsCreate(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Second * 10
-	bOff.InitialInterval = time.Second
+	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
 		if err != nil {
@@ -56,7 +54,7 @@ func resourceUserGroupMembershipsCreate(ctx context.Context, d *schema.ResourceD
 			return nil
 		}
 		return fmt.Errorf("user (%s) did not have expected group memberships after multiple checks", userId)
-	}, bOff)
+	}, boc)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -47,6 +47,9 @@ func resourceUserGroupMembershipsCreate(ctx context.Context, d *schema.ResourceD
 	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
+		if doNotRetry(err) {
+			return backoff.Permanent(err)
+		}
 		if err != nil {
 			return backoff.Permanent(err)
 		}

--- a/okta/resource_okta_user_group_memberships.go
+++ b/okta/resource_okta_user_group_memberships.go
@@ -47,7 +47,7 @@ func resourceUserGroupMembershipsCreate(ctx context.Context, d *schema.ResourceD
 	boc := newExponentialBackOffWithContext(ctx, 10*time.Second)
 	err = backoff.Retry(func() error {
 		ok, err := checkIfUserHasGroups(ctx, client, userId, groups)
-		if doNotRetry(err) {
+		if doNotRetry(m, err) {
 			return backoff.Permanent(err)
 		}
 		if err != nil {

--- a/okta/utils_for_test.go
+++ b/okta/utils_for_test.go
@@ -216,7 +216,9 @@ func testAttributeJSON(name, attribute, expectedJSON string) resource.TestCheckF
 // thanks github.com/hashicorp/terraform-provider-google/google/provider_test.go
 func sleepInSecondsForTest(t int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		time.Sleep(time.Duration(t) * time.Second)
+		if os.Getenv("OKTA_VCR_TF_ACC") != "play" {
+			time.Sleep(time.Duration(t) * time.Second)
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
This PR DRY's up setting up backoff.Backoff where we needed to do API retries in various resources. It also correctly makes use of the calling context when setting up backoff which we hadn't be doing in most of the instances. The refactor was originally to make our VCR test recording run more quickly but exposed that we weren't making proper use of context with backoffs.

A time operations interface is added to the config to allow changing clock behavior to be more efficient in a test environment.

This is a refactor that sets up saving about 28% time recording VCR tests and speeds up replaying by 4x.