### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,9 +12,12 @@ jobs:
       - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Comment or this will be closed in 5 days'
           days-before-stale: 60
           days-before-close: 5
           remove-stale-when-updated: true
           exempt-issue-labels: 'no-stalebot'
           exempt-pr-labels: 'no-stalebot'
+          any-of-labels: 'waiting-response'
+          close-pr-label: 'stalebot-closed'
+          


### PR DESCRIPTION
Stalebot is currently closing valid outstanding issues

I don't believe these issues are going un-noticed as Okta is triaging these into their Jira backlog, as shown by the `triaged` label and the internal reference URLs that are commented on each issue

That said, I do believe that closing valid outstanding issues because they do not have "+1 comments" once every two months seems to run counter to the community notice in the issue template

> Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
> https://github.com/okta/terraform-provider-okta/blob/6634f216e906bed355438298510b441b4a1fe26d/.github/ISSUE_TEMPLATE/bug_report.md

Closing these issues prematurely may also have impact on the number of community contributions and bug fixes