### PR TITLE
Internal API calls guards during OAuth 2.0 authentication

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -219,6 +219,10 @@ func (c *Config) IsClassicOrg(ctx context.Context) bool {
 	return c.classicOrg
 }
 
+func (c *Config) IsOAuth20Auth() bool {
+	return c.privateKey != "" || c.accessToken != ""
+}
+
 func (c *Config) SetTimeOperations(op TimeOperations) {
 	c.timeOperations = op
 }

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -336,7 +336,7 @@ func resourceAppOAuth() *schema.Resource {
 			"groups_claim": {
 				Type:        schema.TypeSet,
 				MaxItems:    1,
-				Description: "Groups claim for an OpenID Connect client application",
+				Description: "Groups claim for an OpenID Connect client application (argument is ignored when API auth is done with OAuth 2.0 credentials)",
 				Optional:    true,
 				Elem:        groupsClaimResource,
 			},
@@ -404,7 +404,7 @@ func resourceAppOAuthCreate(ctx context.Context, d *schema.ResourceData, m inter
 	if err := validateGrantTypes(d); err != nil {
 		return diag.Errorf("failed to create OAuth application: %v", err)
 	}
-	if err := validateAppOAuth(d); err != nil {
+	if err := validateAppOAuth(d, m); err != nil {
 		return diag.Errorf("failed to create OAuth application: %v", err)
 	}
 	app := buildAppOAuth(d)
@@ -434,6 +434,12 @@ func resourceAppOAuthCreate(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func setAppOauthGroupsClaim(ctx context.Context, d *schema.ResourceData, m interface{}) error {
+	c := m.(*Config)
+	if c.IsOAuth20Auth() {
+		logger(m).Warn("setting groups_claim disabled with OAuth 2.0 API authentication")
+		return nil
+	}
+
 	raw, ok := d.GetOk("groups_claim")
 	if !ok {
 		return nil
@@ -458,6 +464,12 @@ func setAppOauthGroupsClaim(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func updateAppOauthGroupsClaim(ctx context.Context, d *schema.ResourceData, m interface{}) error {
+	c := m.(*Config)
+	if c.IsOAuth20Auth() {
+		logger(m).Warn("updating groups_claim disabled with OAuth 2.0 API authentication")
+		return nil
+	}
+
 	raw, ok := d.GetOk("groups_claim")
 	if !ok {
 		return nil
@@ -522,7 +534,14 @@ func resourceAppOAuthRead(ctx context.Context, d *schema.ResourceData, m interfa
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	_ = d.Set("groups_claim", gc)
+
+	c := m.(*Config)
+	if c.IsOAuth20Auth() {
+		logger(m).Warn("reading groups_claim disabled with OAuth 2.0 API authentication")
+		return nil
+	} else {
+		_ = d.Set("groups_claim", gc)
+	}
 
 	return setOAuthClientSettings(d, app.Settings.OauthClient)
 }
@@ -621,7 +640,7 @@ func resourceAppOAuthUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	if err := validateGrantTypes(d); err != nil {
 		return diag.Errorf("failed to update OAuth application: %v", err)
 	}
-	if err := validateAppOAuth(d); err != nil {
+	if err := validateAppOAuth(d, m); err != nil {
 		return diag.Errorf("failed to create OAuth application: %v", err)
 	}
 	app := buildAppOAuth(d)
@@ -829,18 +848,23 @@ func validateGrantTypes(d *schema.ResourceData) error {
 	return conditionalValidator("grant_types", appType, appMap.RequiredGrantTypes, appMap.ValidGrantTypes, grantTypeList)
 }
 
-func validateAppOAuth(d *schema.ResourceData) error {
+func validateAppOAuth(d *schema.ResourceData, m interface{}) error {
 	raw, ok := d.GetOk("groups_claim")
 	if ok {
-		groupsClaim := raw.(*schema.Set).List()[0].(map[string]interface{})
-		if groupsClaim["type"].(string) == "EXPRESSION" && groupsClaim["filter_type"].(string) != "" {
-			return errors.New("'filter_type' in 'groups_claim' can only be set when 'type' is set to 'FILTER'")
-		}
-		if groupsClaim["type"].(string) == "FILTER" && groupsClaim["filter_type"].(string) == "" {
-			return errors.New("'filter_type' in 'groups_claim' is required when 'type' is set to 'FILTER'")
-		}
-		if groupsClaim["name"].(string) == "" || groupsClaim["value"].(string) == "" {
-			return errors.New("'name' 'value' and in 'groups_claim' should not be empty")
+		c := m.(*Config)
+		if c.IsOAuth20Auth() {
+			logger(m).Warn("groups_claim arguments are disabled with OAuth 2.0 API authentication")
+		} else {
+			groupsClaim := raw.(*schema.Set).List()[0].(map[string]interface{})
+			if groupsClaim["type"].(string) == "EXPRESSION" && groupsClaim["filter_type"].(string) != "" {
+				return errors.New("'filter_type' in 'groups_claim' can only be set when 'type' is set to 'FILTER'")
+			}
+			if groupsClaim["type"].(string) == "FILTER" && groupsClaim["filter_type"].(string) == "" {
+				return errors.New("'filter_type' in 'groups_claim' is required when 'type' is set to 'FILTER'")
+			}
+			if groupsClaim["name"].(string) == "" || groupsClaim["value"].(string) == "" {
+				return errors.New("'name' 'value' and in 'groups_claim' should not be empty")
+			}
 		}
 	}
 	_, jwks := d.GetOk("jwks")

--- a/okta/resource_okta_app_signon_policy_rule.go
+++ b/okta/resource_okta_app_signon_policy_rule.go
@@ -254,7 +254,9 @@ func resourceAppSignOnPolicyRuleRead(ctx context.Context, d *schema.ResourceData
 		if rule.Conditions.Device != nil {
 			_ = d.Set("device_is_managed", rule.Conditions.Device.Managed)
 			_ = d.Set("device_is_registered", rule.Conditions.Device.Registered)
-			m["device_assurances_included"] = convertStringSliceToSetNullable(rule.Conditions.Device.Assurance.Include)
+			if rule.Conditions.Device.Assurance != nil {
+				m["device_assurances_included"] = convertStringSliceToSetNullable(rule.Conditions.Device.Assurance.Include)
+			}
 		}
 		if rule.Conditions.People != nil {
 			if rule.Conditions.People.Users != nil {

--- a/okta/resource_okta_brand.go
+++ b/okta/resource_okta_brand.go
@@ -320,7 +320,7 @@ func buildCreateBrandRequest(model brandResourceModel) (okta.CreateBrandRequest,
 }
 
 func buildUpdateBrandRequest(model brandResourceModel) (okta.BrandRequest, error) {
-	var defaultApp = &okta.DefaultApp{}
+	defaultApp := &okta.DefaultApp{}
 	if !model.DefaultAppAppInstanceID.IsNull() && model.DefaultAppAppInstanceID.ValueString() != "" {
 		defaultApp.AppInstanceId = model.DefaultAppAppInstanceID.ValueStringPointer()
 		defaultApp.AppLinkName = model.DefaultAppAppLinkName.ValueStringPointer()

--- a/okta/resource_okta_profile_mapping.go
+++ b/okta/resource_okta_profile_mapping.go
@@ -244,6 +244,12 @@ func applyMapping(ctx context.Context, d *schema.ResourceData, m interface{}, ma
 	if !d.Get("always_apply").(bool) {
 		return nil
 	}
+	c := m.(*Config)
+	if c.IsOAuth20Auth() {
+		logger(m).Warn("setting alway_apply is disabled with OAuth 2.0 API authentication")
+		return nil
+	}
+
 	source := d.Get("source_id").(string)
 	target := d.Get("target_id").(string)
 	var appID string

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
   `"urn:ietf:params:oauth:grant-type:saml2-bearer"` (*Early Access Property*), `"urn:ietf:params:oauth:grant-type:token-exchange"` (*Early Access Property*),
   `"interaction_code"` (*OIE only*).
 
-- `groups_claim` - (Optional) Groups claim for an OpenID Connect client application. **IMPORTANT**: this field is available only when using api token in the provider config.
+- `groups_claim` - (Optional) Groups claim for an OpenID Connect client application. **IMPORTANT**: this argument is ignored when Okta API authentication is done with OAuth 2.0 credentials
   - `type` - (Required) Groups claim type. Valid values: `"FILTER"`, `"EXPRESSION"`.
   - `filter_type` - (Optional) Groups claim filter. Can only be set if type is `"FILTER"`. Valid values: `"EQUALS"`, `"STARTS_WITH"`, `"CONTAINS"`, `"REGEX"`.
   - `name` - (Required) Name of the claim that will be used in the token.

--- a/website/docs/r/profile_mapping.html.markdown
+++ b/website/docs/r/profile_mapping.html.markdown
@@ -59,7 +59,9 @@ The following arguments are supported:
 
 - `always_apply` (Optional) Whether apply the changes to all users with this profile after updating or creating the these mappings.
  
-~> **WARNING**: `always_apply` is available only when using api token in the provider config.
+~> **WARNING**: `always_apply` is incompatible with OAuth 2.0 authentication and will be ignored when using that type of authentication.
+
+~> **WARNING:** `always_apply` makes use of an internal/private Okta API endpoint that could change without notice rendering this resource inoperable. 
 
 ## Attributes Reference
 

--- a/website/docs/r/rate_limiting.markdown
+++ b/website/docs/r/rate_limiting.markdown
@@ -10,7 +10,7 @@ description: |-
 
 This resource allows you to configure the client-based rate limit and rate limiting communications settings.
 
-~> **WARNING:** This resource is available only when using api token in the provider config.
+~> **WARNING:** This resource is available only when using a SSWS API token in the provider config, it is incompatible with OAuth 2.0 authentication.
 
 ~> **WARNING:** This resource makes use of an internal/private Okta API endpoint that could change without notice rendering this resource inoperable. 
 

--- a/website/docs/r/security_notification_emails.html.markdown
+++ b/website/docs/r/security_notification_emails.html.markdown
@@ -10,7 +10,9 @@ description: |-
 
 This resource allows you to configure Security Notification Emails.
 
-~> **WARNING:** This resource is available only when using api token in the provider config.
+~> **WARNING:** This resource is available only when using a SSWS API token in the provider config, it is incompatible with OAuth 2.0 authentication.
+
+~> **WARNING:** This resource makes use of an internal/private Okta API endpoint that could change without notice rendering this resource inoperable. 
 
 ## Example Usage
 


### PR DESCRIPTION
Guards against making internal API calls when the SDK client is using OAuth 2.0 authentication have been put in place.

Resources
- `okta_profile_mapping`
- `okta_app_oauth`

Note that resource `okta_security_notification_emails` and `okta_rate_limiting` are OAuth 2.0 incompatible.