### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,11 +13,13 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Comment or this will be closed in 5 days'
-          days-before-stale: 60
-          days-before-close: 5
+          days-before-stale: 30
+          days-before-close: 35
           remove-stale-when-updated: true
           exempt-issue-labels: 'no-stalebot'
           exempt-pr-labels: 'no-stalebot'
+          stale-issue-label: 'Stale'
+          stale-pr-label: 'Stale'
           any-of-labels: 'waiting-response'
+          labels-to-remove-when-unstale: 'waiting-response'
           close-pr-label: 'stalebot-closed'
-          


### PR DESCRIPTION
`waiting-response` should be removed if the author of an issue or PR responds on the PR

Tweak the `time-to-stale` and `time-to-close`
Total `time-to-close` remains the same (65 days)
 - `Stale` label will be applied sooner (60 Days -> 30 Days)
 - Users will have more time between `Stale` label being added and issue being closed (5 days -> 35 days)
   -  this better accounts for people taking extended PTO from their day jobs which may mean they miss the notification from github of the `Stale` label being added to their issue