### PR TITLE
Create unstale.yml

### DIFF
--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -1,0 +1,50 @@
+name: Remove Label on Issue Comment
+
+permissions:
+  issues: write
+  
+on:
+  issue_comment:
+    types: [created]
+    
+jobs:
+  issue_commented:
+    name: Issue comment
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labelToRemove = 'waiting-response';
+            const issueNumber = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: owner,
+              repo: repo,
+              issue_number: issueNumber
+            });
+            
+            const labelNames = labels.map(label => label.name);
+            
+            if (labelNames.includes(labelToRemove)) {
+              await github.rest.issues.removeLabel({
+                issue_number: issueNumber,
+                owner: owner,
+                repo: repo,
+                name: labelToRemove
+              });
+            }
+  # pr_commented:
+  #   # This job only runs for pull request comments
+  #   name: PR comment
+  #   if: ${{ github.event.issue.pull_request }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: |
+  #         echo A comment on PR $NUMBER
+  #       env:
+  #         NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
StaleBot doesn't appear to be removing `waiting-response` when an issue is commented on because the issue is not yet stale for the setting `labels-to-remove-when-unstale` to kick in