### PR TITLE
Missed guard on groups claim in `okta_app_oauth` for OAuth 2.0 authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.4.1 (September 11, 2023)
+
+### BUG FIXES
+
+* Missed guard on groups claim in `okta_app_oauth` for OAuth 2.0 authentication [1713](https://github.com/okta/terraform-provider-okta/pull/1713).  Thanks, [@monde](https://github.com/monde)!
+
+### IMPROVEMENTS
+
+* Update okta app oauth to clarify we support multiple jwks creation [#1704](https://github.com/okta/terraform-provider-okta/pull/1704). Thanks, [@duytiennguyen-okta](https://github.com/duytiennguyen-okta)!
+
 ## 4.4.0 (September 7, 2023)
 
 ### NEW - RESOURCES, DATA SOURCES, PROPERTIES, ATTRIBUTES, ENV VARS:

--- a/okta/config.go
+++ b/okta/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	OktaTerraformProviderVersion   = "4.4.0"
+	OktaTerraformProviderVersion   = "4.4.1"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )
 

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -530,16 +530,14 @@ func resourceAppOAuthRead(ctx context.Context, d *schema.ResourceData, m interfa
 		_ = d.Set("client_secret", "")
 	}
 
-	gc, err := flattenGroupsClaim(ctx, d, m)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
 	c := m.(*Config)
 	if c.IsOAuth20Auth() {
 		logger(m).Warn("reading groups_claim disabled with OAuth 2.0 API authentication")
-		return nil
 	} else {
+		gc, err := flattenGroupsClaim(ctx, d, m)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		_ = d.Set("groups_claim", gc)
 	}
 


### PR DESCRIPTION
## 4.4.1 (September 11, 2023)

### BUG FIXES

* Missed guard on groups claim in `okta_app_oauth` for OAuth 2.0 authentication [1713](https://github.com/okta/terraform-provider-okta/pull/1713).  Thanks, [@monde](https://github.com/monde)!

### IMPROVEMENTS

* Update okta app oauth to clarify we support multiple jwks creation [#1704](https://github.com/okta/terraform-provider-okta/pull/1704). Thanks, [@duytiennguyen-okta](https://github.com/duytiennguyen-okta)!

