### PR TITLE
Guard config panic

### DIFF
--- a/examples/okta_group/okta_group.tf
+++ b/examples/okta_group/okta_group.tf
@@ -1,4 +1,4 @@
 resource "okta_group" "test" {
-  name        = "testAcc"
+  name        = "testAcc_replace_with_uuid"
   description = "testing, testing"
 }

--- a/examples/okta_group/okta_group_updated.tf
+++ b/examples/okta_group/okta_group_updated.tf
@@ -1,4 +1,4 @@
 resource "okta_group" "test" {
-  name        = "testAccDifferent"
+  name        = "testAcc_Different_replace_with_uuid"
   description = "testing, testing"
 }

--- a/okta/config.go
+++ b/okta/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -367,6 +368,10 @@ func oktaSDKClient(c *Config) (client *sdk.Client, err error) {
 	} else {
 		orgUrl = fmt.Sprintf("https://%v.%v", c.orgName, c.domain)
 	}
+	_, err = url.Parse(orgUrl)
+	if err != nil {
+		return nil, fmt.Errorf("malformed Okta API URL (org_name+base_url value, or http_proxy value): %+v", err)
+	}
 
 	setters := []sdk.ConfigSetter{
 		sdk.WithOrgUrl(orgUrl),
@@ -458,6 +463,10 @@ func oktaV3SDKClient(c *Config) (client *okta.APIClient, err error) {
 		disableHTTPS = strings.HasPrefix(orgUrl, "http://")
 	} else {
 		orgUrl = fmt.Sprintf("https://%v.%v", c.orgName, c.domain)
+	}
+	_, err = url.Parse(orgUrl)
+	if err != nil {
+		return nil, fmt.Errorf("malformed Okta API URL (org_name+base_url value, or http_proxy value): %+v", err)
 	}
 
 	setters := []okta.ConfigSetter{

--- a/okta/data_source_okta_group_test.go
+++ b/okta/data_source_okta_group_test.go
@@ -14,9 +14,9 @@ func TestAccDataSourceOktaGroup_read(t *testing.T) {
 	configInvalid := mgr.GetFixtures("datasource_not_found.tf", t)
 
 	oktaResourceTest(t, resource.TestCase{
-		PreCheck:          testAccPreCheck(t),
-		ErrorCheck:        testAccErrorChecks(t),
-		ProviderFactories: testAccProvidersFactories,
+		PreCheck:                 testAccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: testAccMergeProvidersFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: groupCreate,

--- a/okta/resource_okta_group_test.go
+++ b/okta/resource_okta_group_test.go
@@ -14,22 +14,25 @@ func TestAccResourceOktaGroup_crud(t *testing.T) {
 	mgr := newFixtureManager(group, t.Name())
 	config := mgr.GetFixtures("okta_group.tf", t)
 	updatedConfig := mgr.GetFixtures("okta_group_updated.tf", t)
+	buildResourceName(mgr.Seed)
 
 	oktaResourceTest(t, resource.TestCase{
-		PreCheck:          testAccPreCheck(t),
-		ErrorCheck:        testAccErrorChecks(t),
-		ProviderFactories: testAccProvidersFactories,
-		CheckDestroy:      checkResourceDestroy(group, doesGroupExist),
+		PreCheck:                 testAccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: testAccMergeProvidersFactories,
+		CheckDestroy:             checkResourceDestroy(group, doesGroupExist),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "testAcc")),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("testAcc", mgr.Seed)),
+				),
 			},
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "testAccDifferent")),
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("testAcc_Different", mgr.Seed)),
+				),
 			},
 		},
 	})

--- a/test/fixtures/vcr/TestAccDataSourceOktaGroup_read/classic-00.yaml
+++ b/test/fixtures/vcr/TestAccDataSourceOktaGroup_read/classic-00.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 64
+        content_length: 75
         transfer_encoding: []
         trailer: {}
         host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"profile":{"name":"testAcc","description":"testing, testing"}}
+            {"profile":{"name":"testAcc_3671860054","description":"testing, testing"}}
         form: {}
         headers:
             Accept:
@@ -32,15 +32,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:12.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:03 GMT
+                - Wed, 13 Sep 2023 21:44:12 GMT
         status: 200 OK
         code: 200
-        duration: 242.479951ms
+        duration: 281.93041ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -59,7 +59,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -69,15 +69,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:12.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:03 GMT
+                - Wed, 13 Sep 2023 21:44:12 GMT
         status: 200 OK
         code: 200
-        duration: 73.026634ms
+        duration: 71.201734ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,7 +96,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,15 +106,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:12.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:04 GMT
+                - Wed, 13 Sep 2023 21:44:12 GMT
         status: 200 OK
         code: 200
-        duration: 80.390035ms
+        duration: 58.251143ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -133,7 +133,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -143,15 +143,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:12.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:04 GMT
+                - Wed, 13 Sep 2023 21:44:12 GMT
         status: 200 OK
         code: 200
-        duration: 55.47639ms
+        duration: 79.142513ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -170,7 +170,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -180,16 +180,93 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:12.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:04 GMT
+                - Wed, 13 Sep 2023 21:44:13 GMT
         status: 200 OK
         code: 200
-        duration: 73.741818ms
+        duration: 66.009285ms
     - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 64
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"testAcc","description":"testing, testing"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:44:13 GMT
+        status: 200 OK
+        code: 200
+        duration: 84.872119ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:44:13 GMT
+        status: 200 OK
+        code: 200
+        duration: 61.110792ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -220,87 +297,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:05 GMT
+                - Wed, 13 Sep 2023 21:44:14 GMT
         status: 200 OK
         code: 200
-        duration: 267.743593ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:53:05 GMT
-        status: 200 OK
-        code: 200
-        duration: 79.719124ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users/00u9i7bdozJez6Ij11d7
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Date:
-                - Tue, 15 Aug 2023 23:53:05 GMT
-        status: 204 No Content
-        code: 204
-        duration: 72.593866ms
+        duration: 622.477665ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -319,7 +324,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7/groups
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -329,17 +334,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g5ptm04tzNvyznP1d7","created":"2022-10-04T23:20:18.000Z","lastUpdated":"2022-10-04T23:20:18.000Z","lastMembershipUpdated":"2023-08-15T23:52:27.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/apps"}}},{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}]'
+        body: '{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:05 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7/groups?limit=200>; rel="self"
+                - Wed, 13 Sep 2023 21:44:14 GMT
         status: 200 OK
         code: 200
-        duration: 71.544294ms
+        duration: 134.929105ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -358,25 +361,23 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users/00ua1vjhsvvvsPLtK1d7
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}]'
+        content_length: 0
+        uncompressed: false
+        body: ""
         headers:
-            Content-Type:
-                - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:05 GMT
-        status: 200 OK
-        code: 200
-        duration: 58.202378ms
+                - Wed, 13 Sep 2023 21:44:14 GMT
+        status: 204 No Content
+        code: 204
+        duration: 73.456228ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -395,7 +396,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/groups
         method: GET
       response:
         proto: HTTP/2.0
@@ -405,17 +406,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"}}}]'
+        body: '[{"id":"00g5ptm04tzNvyznP1d7","created":"2022-10-04T23:20:18.000Z","lastUpdated":"2022-10-04T23:20:18.000Z","lastMembershipUpdated":"2023-08-16T00:13:33.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/apps"}}},{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:05 GMT
+                - Wed, 13 Sep 2023 21:44:14 GMT
             Link:
-                - <https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/groups?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 60.704524ms
+        duration: 78.836012ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -444,15 +445,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}]'
+        body: '[{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
+                - Wed, 13 Sep 2023 21:44:14 GMT
         status: 200 OK
         code: 200
-        duration: 60.893381ms
+        duration: 93.162947ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -471,7 +472,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -481,131 +482,18 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"}}}]'
+        body: '[{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
+                - Wed, 13 Sep 2023 21:44:14 GMT
             Link:
-                - <https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 78.836409ms
+        duration: 89.766972ms
     - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
-        status: 200 OK
-        code: 200
-        duration: 45.160908ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
-        status: 200 OK
-        code: 200
-        duration: 77.488655ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7/groups
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"00g5ptm04tzNvyznP1d7","created":"2022-10-04T23:20:18.000Z","lastUpdated":"2022-10-04T23:20:18.000Z","lastMembershipUpdated":"2023-08-15T23:52:27.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/apps"}}},{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}]'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7/groups?limit=200>; rel="self"
-        status: 200 OK
-        code: 200
-        duration: 79.629105ms
-    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -633,15 +521,128 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}]'
+        body: '[{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
+                - Wed, 13 Sep 2023 21:44:14 GMT
         status: 200 OK
         code: 200
-        duration: 63.780538ms
+        duration: 64.271787ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:44:15 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 84.870001ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:44:15 GMT
+        status: 200 OK
+        code: 200
+        duration: 54.891615ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:44:15 GMT
+        status: 200 OK
+        code: 200
+        duration: 103.965274ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -660,7 +661,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/groups
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,17 +671,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"}}}]'
+        body: '[{"id":"00g5ptm04tzNvyznP1d7","created":"2022-10-04T23:20:18.000Z","lastUpdated":"2022-10-04T23:20:18.000Z","lastMembershipUpdated":"2023-08-16T00:13:33.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/apps"}}},{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
+                - Wed, 13 Sep 2023 21:44:15 GMT
             Link:
-                - <https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/groups?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 64.116732ms
+        duration: 78.874086ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -709,15 +710,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}]'
+        body: '[{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
+                - Wed, 13 Sep 2023 21:44:15 GMT
         status: 200 OK
         code: 200
-        duration: 55.60104ms
+        duration: 61.106914ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -736,7 +737,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -746,17 +747,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"}}}]'
+        body: '[{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:06 GMT
+                - Wed, 13 Sep 2023 21:44:15 GMT
             Link:
-                - <https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users?limit=200>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 81.491486ms
+        duration: 72.470107ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -775,7 +776,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
         method: GET
       response:
         proto: HTTP/2.0
@@ -785,15 +786,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '[{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
+                - Wed, 13 Sep 2023 21:44:15 GMT
         status: 200 OK
         code: 200
-        duration: 47.935016ms
+        duration: 62.534154ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -812,7 +813,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -822,15 +823,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00u9i7bdozJez6Ij11d7","status":"PROVISIONED","created":"2023-08-15T23:53:05.000Z","activated":"2023-08-15T23:53:05.000Z","statusChanged":"2023-08-15T23:53:05.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:53:05.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00u9i7bdozJez6Ij11d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '[{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
+                - Wed, 13 Sep 2023 21:44:15 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 77.417313ms
+        duration: 76.56595ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -849,7 +852,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7/groups
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -859,17 +862,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g5ptm04tzNvyznP1d7","created":"2022-10-04T23:20:18.000Z","lastUpdated":"2022-10-04T23:20:18.000Z","lastMembershipUpdated":"2023-08-15T23:52:27.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/apps"}}},{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:03.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}]'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7/groups?limit=200>; rel="self"
+                - Wed, 13 Sep 2023 21:44:16 GMT
         status: 200 OK
         code: 200
-        duration: 79.652769ms
+        duration: 54.588943ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -888,7 +889,83 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7/users/00u9i7bdozJez6Ij11d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/groups
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00g5ptm04tzNvyznP1d7","created":"2022-10-04T23:20:18.000Z","lastUpdated":"2022-10-04T23:20:18.000Z","lastMembershipUpdated":"2023-08-16T00:13:33.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g5ptm04tzNvyznP1d7/apps"}}},{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:13.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:44:16 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/groups?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 67.109095ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ua1vjhsvvvsPLtK1d7","status":"PROVISIONED","created":"2023-09-13T21:44:13.000Z","activated":"2023-09-13T21:44:14.000Z","statusChanged":"2023-09-13T21:44:14.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:44:14.000Z","passwordChanged":null,"type":{"id":"oty5ptm052JMcoADv1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.oktapreview.com/api/v1/meta/schemas/user/osc5ptm052JMcoADv1d7"},"resetPassword":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7"},"type":{"href":"https://classic-00.oktapreview.com/api/v1/meta/types/user/oty5ptm052JMcoADv1d7"},"deactivate":{"href":"https://classic-00.oktapreview.com/api/v1/users/00ua1vjhsvvvsPLtK1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:44:16 GMT
+        status: 200 OK
+        code: 200
+        duration: 100.796105ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7/users/00ua1vjhsvvvsPLtK1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -901,11 +978,46 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
+                - Wed, 13 Sep 2023 21:44:16 GMT
         status: 204 No Content
         code: 204
-        duration: 103.53098ms
-    - id: 24
+        duration: 127.223225ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 Sep 2023 21:44:16 GMT
+        status: 204 No Content
+        code: 204
+        duration: 116.132222ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -926,7 +1038,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -936,16 +1048,16 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:07.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:16.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
+                - Wed, 13 Sep 2023 21:44:16 GMT
         status: 200 OK
         code: 200
-        duration: 75.384981ms
-    - id: 25
+        duration: 116.234389ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -963,42 +1075,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
-        status: 204 No Content
-        code: 204
-        duration: 111.963182ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1008,16 +1085,16 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7ebfst82k4j41d7","created":"2023-08-15T23:53:03.000Z","lastUpdated":"2023-08-15T23:53:07.000Z","lastMembershipUpdated":"2023-08-15T23:53:03.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7ebfst82k4j41d7/apps"}}}'
+        body: '{"id":"00ga1vmsry0GE70491d7","created":"2023-09-13T21:44:12.000Z","lastUpdated":"2023-09-13T21:44:16.000Z","lastMembershipUpdated":"2023-09-13T21:44:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1vmsry0GE70491d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
+                - Wed, 13 Sep 2023 21:44:16 GMT
         status: 200 OK
         code: 200
-        duration: 52.000905ms
-    - id: 27
+        duration: 55.417434ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1050,11 +1127,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
+                - Wed, 13 Sep 2023 21:44:16 GMT
         status: 200 OK
         code: 200
-        duration: 46.870957ms
-    - id: 28
+        duration: 54.649141ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1072,7 +1149,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00u9i7bdozJez6Ij11d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00ua1vjhsvvvsPLtK1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1085,11 +1162,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:53:07 GMT
+                - Wed, 13 Sep 2023 21:44:17 GMT
         status: 204 No Content
         code: 204
-        duration: 169.882696ms
-    - id: 29
+        duration: 372.996731ms
+    - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1107,7 +1184,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7ebfst82k4j41d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1vmsry0GE70491d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1120,7 +1197,7 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:53:08 GMT
+                - Wed, 13 Sep 2023 21:44:17 GMT
         status: 204 No Content
         code: 204
-        duration: 144.896036ms
+        duration: 105.726603ms

--- a/test/fixtures/vcr/TestAccDataSourceOktaGroup_read/dev-org-oauth-00.yaml
+++ b/test/fixtures/vcr/TestAccDataSourceOktaGroup_read/dev-org-oauth-00.yaml
@@ -1,0 +1,1242 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/x-www-form-urlencoded
+        url: https://dev-org-oauth-00.dne-okta.com/oauth2/v1/token?client_assertion=abc123&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&grant_type=client_credentials&scope=okta.groups.read+okta.groups.manage+okta.users.read+okta.users.manage
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"token_type":"Bearer","expires_in":3600,"access_token":"eyJraWQiOiJKVGFSM1RQU1E5RGhha1BtdEx0c3I0ZzRsTUN2c1c0b3hQOXc5WnBZR01JIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULm12UVNkZnNKN2RmWFNWU1VJdVZ0SWc4SnhXTXA5cElnT0k5VmNPY2VjWEUiLCJpc3MiOiJodHRwczovL2Rldi1tb25kcmFnb24ub2t0YS5jb20iLCJhdWQiOiJodHRwczovL2Rldi1tb25kcmFnb24ub2t0YS5jb20iLCJzdWIiOiIwb2FiOHV1dnZ2aWt5RzZlczVkNyIsImlhdCI6MTY5NDY0MTY2MiwiZXhwIjoxNjk0NjQ1MjYyLCJjaWQiOiIwb2FiOHV1dnZ2aWt5RzZlczVkNyIsInNjcCI6WyJva3RhLmdyb3Vwcy5yZWFkIiwib2t0YS5ncm91cHMubWFuYWdlIiwib2t0YS51c2Vycy5yZWFkIiwib2t0YS51c2Vycy5tYW5hZ2UiXX0.cUE5NweR_joUa30Luyl0cEMKEsiuyxNkO0PwaZYC9cBMxj206bQfKuUT_DJuH3Ef02Y4QeIbTf9n5g8QqOumhHQMbX0sW3yU9Nl0jNLq_JvLv8NBxaW4pUbLwrlZaQFl7w05olttN7byKiNPuatf0SgrWBDIkrRZpXjL7_8mGyLrAhtCFffUse6lq9QwSIDNB0OU4FGc2rLzseFLNtJlY_jz-Ham3ho0ceSARycdYksf5wQVTr3Ee5eY3aNCqCrBMxnUcgQbiqx7hmK6FA12npaLiw0kRNaHwpGQyABStcV1mbCv9vJIb-orD0XJm73lOdnEemcBbAvqvSlNE8Iwfg","scope":"okta.groups.read okta.groups.manage okta.users.read okta.users.manage"}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:42 GMT
+        status: 200 OK
+        code: 200
+        duration: 487.710083ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 75
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"testAcc_3671860054","description":"testing, testing"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+            Content-Type:
+                - application/json
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:42.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:42 GMT
+        status: 200 OK
+        code: 200
+        duration: 372.425688ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:42.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:43 GMT
+        status: 200 OK
+        code: 200
+        duration: 396.376661ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:42.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:43 GMT
+        status: 200 OK
+        code: 200
+        duration: 279.780128ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:42.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:44 GMT
+        status: 200 OK
+        code: 200
+        duration: 366.231847ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:42.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:44 GMT
+            Report-To:
+                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
+        status: 200 OK
+        code: 200
+        duration: 88.019073ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 64
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"testAcc","description":"testing, testing"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+            Content-Type:
+                - application/json
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:45 GMT
+        status: 200 OK
+        code: 200
+        duration: 389.19852ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:45 GMT
+        status: 200 OK
+        code: 200
+        duration: 361.785193ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 190
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"john_3671860054@ledzeppelin.com","firstName":"TestAcc","lastName":"Jones","login":"john_3671860054@ledzeppelin.com","postalAddress":null}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+            Content-Type:
+                - application/json
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/schemas/user/oscddwaor9QioUpT65d6"},"resetPassword":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"},"resetFactors":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/types/user/otyddwaor9QioUpT65d6"},"deactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:45 GMT
+        status: 200 OK
+        code: 200
+        duration: 891.485933ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/schemas/user/oscddwaor9QioUpT65d6"},"resetPassword":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"},"resetFactors":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/types/user/otyddwaor9QioUpT65d6"},"deactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:46 GMT
+        status: 200 OK
+        code: 200
+        duration: 394.694332ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users/00ub8yrk1kvjI44Xh5d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 Sep 2023 21:47:46 GMT
+        status: 204 No Content
+        code: 204
+        duration: 92.30603ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/groups
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gddwaoiBgks4GAw5d6","created":"2021-03-26T17:30:35.000Z","lastUpdated":"2021-03-26T17:30:35.000Z","lastMembershipUpdated":"2022-08-24T16:32:35.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gddwaoiBgks4GAw5d6/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gddwaoiBgks4GAw5d6/apps"}}},{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:46 GMT
+            Link:
+                - <https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/groups?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 417.605671ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:42.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:47 GMT
+        status: 200 OK
+        code: 200
+        duration: 269.450833ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:47 GMT
+            Link:
+                - <https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 295.72695ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:47 GMT
+        status: 200 OK
+        code: 200
+        duration: 317.561539ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:48 GMT
+            Link:
+                - <https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 287.946947ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/schemas/user/oscddwaor9QioUpT65d6"},"resetPassword":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"},"resetFactors":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/types/user/otyddwaor9QioUpT65d6"},"deactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:48 GMT
+        status: 200 OK
+        code: 200
+        duration: 302.514742ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:48 GMT
+        status: 200 OK
+        code: 200
+        duration: 377.18616ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/groups
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gddwaoiBgks4GAw5d6","created":"2021-03-26T17:30:35.000Z","lastUpdated":"2021-03-26T17:30:35.000Z","lastMembershipUpdated":"2023-09-13T21:47:45.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gddwaoiBgks4GAw5d6/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gddwaoiBgks4GAw5d6/apps"}}},{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:49 GMT
+            Link:
+                - <https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/groups?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 368.446892ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:49 GMT
+        status: 200 OK
+        code: 200
+        duration: 266.259922ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:49 GMT
+            Link:
+                - <https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 373.983051ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:50 GMT
+        status: 200 OK
+        code: 200
+        duration: 330.114097ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:50 GMT
+            Link:
+                - <https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 398.543882ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/groups
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gddwaoiBgks4GAw5d6","created":"2021-03-26T17:30:35.000Z","lastUpdated":"2021-03-26T17:30:35.000Z","lastMembershipUpdated":"2023-09-13T21:47:45.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gddwaoiBgks4GAw5d6/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gddwaoiBgks4GAw5d6/apps"}}},{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:50 GMT
+            Link:
+                - <https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/groups?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 79.226062ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:45.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:51 GMT
+        status: 200 OK
+        code: 200
+        duration: 318.843384ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ub8yrk1kvjI44Xh5d7","status":"PROVISIONED","created":"2023-09-13T21:47:45.000Z","activated":"2023-09-13T21:47:45.000Z","statusChanged":"2023-09-13T21:47:45.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:47:45.000Z","passwordChanged":null,"type":{"id":"otyddwaor9QioUpT65d6"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/schemas/user/oscddwaor9QioUpT65d6"},"resetPassword":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7"},"resetFactors":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://dev-org-oauth-00.okta.com/api/v1/meta/types/user/otyddwaor9QioUpT65d6"},"deactivate":{"href":"https://dev-org-oauth-00.okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:51 GMT
+        status: 200 OK
+        code: 200
+        duration: 386.98829ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users/00ub8yrk1kvjI44Xh5d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 Sep 2023 21:47:51 GMT
+        status: 204 No Content
+        code: 204
+        duration: 401.107224ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 Sep 2023 21:47:52 GMT
+        status: 204 No Content
+        code: 204
+        duration: 220.64742ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 75
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"testAcc_3671860054","description":"testing, testing"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+            Content-Type:
+                - application/json
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:52.000Z","lastMembershipUpdated":"2023-09-13T21:47:46.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:52 GMT
+        status: 200 OK
+        code: 200
+        duration: 324.346892ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/users/00ub8yrk1kvjI44Xh5d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 Sep 2023 21:47:52 GMT
+        status: 204 No Content
+        code: 204
+        duration: 302.073644ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8yqojp69Y0BZH5d7","created":"2023-09-13T21:47:42.000Z","lastUpdated":"2023-09-13T21:47:52.000Z","lastMembershipUpdated":"2023-09-13T21:47:51.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:52 GMT
+        status: 200 OK
+        code: 200
+        duration: 385.069089ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups?filter=type+eq+%22APP_GROUP%22&limit=1&q=testAcc_3671860054
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:47:52 GMT
+        status: 200 OK
+        code: 200
+        duration: 71.717774ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8yqojp69Y0BZH5d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 Sep 2023 21:47:53 GMT
+        status: 204 No Content
+        code: 204
+        duration: 354.142192ms

--- a/test/fixtures/vcr/TestAccDataSourceOktaGroup_read/oie-00.yaml
+++ b/test/fixtures/vcr/TestAccDataSourceOktaGroup_read/oie-00.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 64
+        content_length: 75
         transfer_encoding: []
         trailer: {}
         host: oie-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"profile":{"name":"testAcc","description":"testing, testing"}}
+            {"profile":{"name":"testAcc_3671860054","description":"testing, testing"}}
         form: {}
         headers:
             Accept:
@@ -32,15 +32,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:41.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:37 GMT
+                - Wed, 13 Sep 2023 21:43:41 GMT
+            Report-To:
+                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
         status: 200 OK
         code: 200
-        duration: 221.11356ms
+        duration: 400.53181ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -59,7 +61,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -69,15 +71,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:41.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:37 GMT
+                - Wed, 13 Sep 2023 21:43:41 GMT
         status: 200 OK
         code: 200
-        duration: 66.921178ms
+        duration: 70.337077ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,7 +98,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,15 +108,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:41.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:37 GMT
+                - Wed, 13 Sep 2023 21:43:41 GMT
         status: 200 OK
         code: 200
-        duration: 57.464391ms
+        duration: 74.18308ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -133,7 +135,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -143,15 +145,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:41.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:38 GMT
+                - Wed, 13 Sep 2023 21:43:41 GMT
         status: 200 OK
         code: 200
-        duration: 55.783112ms
+        duration: 66.482983ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -170,7 +172,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -180,16 +182,93 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:41.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:38 GMT
+                - Wed, 13 Sep 2023 21:43:42 GMT
         status: 200 OK
         code: 200
-        duration: 56.991275ms
+        duration: 57.062725ms
     - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 64
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"testAcc","description":"testing, testing"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:42 GMT
+        status: 200 OK
+        code: 200
+        duration: 78.652799ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:42 GMT
+        status: 200 OK
+        code: 200
+        duration: 79.431286ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -220,87 +299,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:39 GMT
+                - Wed, 13 Sep 2023 21:43:43 GMT
         status: 200 OK
         code: 200
-        duration: 488.960923ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:29:39 GMT
-        status: 200 OK
-        code: 200
-        duration: 110.627977ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users/00u9i6pqgsR6gEYFw1d7
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Date:
-                - Tue, 15 Aug 2023 23:29:39 GMT
-        status: 204 No Content
-        code: 204
-        duration: 94.798003ms
+        duration: 671.810879ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -319,7 +326,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/groups
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -329,17 +336,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g5qwjvgrD3WR89l1d7","created":"2022-10-07T23:16:57.000Z","lastUpdated":"2022-10-07T23:16:57.000Z","lastMembershipUpdated":"2023-08-15T23:28:39.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/apps"}}},{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}]'
+        body: '{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:39 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/groups?limit=200>; rel="self"
+                - Wed, 13 Sep 2023 21:43:43 GMT
         status: 200 OK
         code: 200
-        duration: 88.733954ms
+        duration: 106.191768ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -358,25 +363,23 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users/00ua1vkg7euUofldZ1d7
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}]'
+        content_length: 0
+        uncompressed: false
+        body: ""
         headers:
-            Content-Type:
-                - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:39 GMT
-        status: 200 OK
-        code: 200
-        duration: 65.515961ms
+                - Wed, 13 Sep 2023 21:43:43 GMT
+        status: 204 No Content
+        code: 204
+        duration: 105.316828ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -395,7 +398,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7/groups
         method: GET
       response:
         proto: HTTP/2.0
@@ -405,17 +408,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"}}}]'
+        body: '[{"id":"00g5qwjvgrD3WR89l1d7","created":"2022-10-07T23:16:57.000Z","lastUpdated":"2022-10-07T23:16:57.000Z","lastMembershipUpdated":"2023-08-21T16:08:07.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/apps"}}},{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:39 GMT
+                - Wed, 13 Sep 2023 21:43:43 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200>; rel="self"
+                - <https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7/groups?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 56.516717ms
+        duration: 91.315394ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -444,15 +447,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}]'
+        body: '[{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:40 GMT
+                - Wed, 13 Sep 2023 21:43:43 GMT
         status: 200 OK
         code: 200
-        duration: 82.820578ms
+        duration: 142.504241ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -471,7 +474,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -481,131 +484,18 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"}}}]'
+        body: '[{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:40 GMT
+                - Wed, 13 Sep 2023 21:43:43 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200>; rel="self"
+                - <https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 60.383038ms
+        duration: 71.28149ms
     - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:29:40 GMT
-        status: 200 OK
-        code: 200
-        duration: 56.510148ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:29:40 GMT
-        status: 200 OK
-        code: 200
-        duration: 107.773142ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/groups
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"00g5qwjvgrD3WR89l1d7","created":"2022-10-07T23:16:57.000Z","lastUpdated":"2022-10-07T23:16:57.000Z","lastMembershipUpdated":"2023-08-15T23:28:39.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/apps"}}},{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}]'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:29:40 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/groups?limit=200>; rel="self"
-        status: 200 OK
-        code: 200
-        duration: 69.651136ms
-    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -633,15 +523,128 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}]'
+        body: '[{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:40 GMT
+                - Wed, 13 Sep 2023 21:43:44 GMT
         status: 200 OK
         code: 200
-        duration: 95.698821ms
+        duration: 66.884893ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:44 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 63.182764ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:44 GMT
+        status: 200 OK
+        code: 200
+        duration: 65.650197ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:44 GMT
+        status: 200 OK
+        code: 200
+        duration: 81.258929ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -660,7 +663,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7/groups
         method: GET
       response:
         proto: HTTP/2.0
@@ -670,17 +673,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"}}}]'
+        body: '[{"id":"00g5qwjvgrD3WR89l1d7","created":"2022-10-07T23:16:57.000Z","lastUpdated":"2022-10-07T23:16:57.000Z","lastMembershipUpdated":"2023-08-21T16:08:07.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/apps"}}},{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:40 GMT
+                - Wed, 13 Sep 2023 21:43:44 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200>; rel="self"
+                - <https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7/groups?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 58.528906ms
+        duration: 67.438026ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -709,17 +712,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}]'
+        body: '[{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
-            Report-To:
-                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
+                - Wed, 13 Sep 2023 21:43:44 GMT
         status: 200 OK
         code: 200
-        duration: 93.067545ms
+        duration: 68.925153ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -738,7 +739,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -748,17 +749,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"}}}]'
+        body: '[{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
+                - Wed, 13 Sep 2023 21:43:44 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users?limit=200>; rel="self"
+                - <https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 72.449554ms
+        duration: 80.142316ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -777,7 +778,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups?limit=1&q=testAcc
         method: GET
       response:
         proto: HTTP/2.0
@@ -787,15 +788,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
+        body: '[{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
+                - Wed, 13 Sep 2023 21:43:44 GMT
         status: 200 OK
         code: 200
-        duration: 73.475463ms
+        duration: 70.36297ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -814,7 +815,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/groups
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -824,17 +825,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00g5qwjvgrD3WR89l1d7","created":"2022-10-07T23:16:57.000Z","lastUpdated":"2022-10-07T23:16:57.000Z","lastMembershipUpdated":"2023-08-15T23:28:39.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/apps"}}},{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:37.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}]'
+        body: '[{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"}}}]'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
+                - Wed, 13 Sep 2023 21:43:44 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/groups?limit=200>; rel="self"
+                - <https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users?limit=200>; rel="self"
         status: 200 OK
         code: 200
-        duration: 80.662ms
+        duration: 71.295081ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -853,7 +854,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -863,15 +864,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00u9i6pqgsR6gEYFw1d7","status":"PROVISIONED","created":"2023-08-15T23:29:39.000Z","activated":"2023-08-15T23:29:39.000Z","statusChanged":"2023-08-15T23:29:39.000Z","lastLogin":null,"lastUpdated":"2023-08-15T23:29:39.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00u9i6pqgsR6gEYFw1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
+                - Wed, 13 Sep 2023 21:43:45 GMT
         status: 200 OK
         code: 200
-        duration: 97.402914ms
+        duration: 55.455427ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -890,7 +891,83 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users/00u9i6pqgsR6gEYFw1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7/groups
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00g5qwjvgrD3WR89l1d7","created":"2022-10-07T23:16:57.000Z","lastUpdated":"2022-10-07T23:16:57.000Z","lastMembershipUpdated":"2023-08-21T16:08:07.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g5qwjvgrD3WR89l1d7/apps"}}},{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:42.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}]'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:45 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7/groups?limit=200>; rel="self"
+        status: 200 OK
+        code: 200
+        duration: 71.018751ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ua1vkg7euUofldZ1d7","status":"PROVISIONED","created":"2023-09-13T21:43:42.000Z","activated":"2023-09-13T21:43:43.000Z","statusChanged":"2023-09-13T21:43:43.000Z","lastLogin":null,"lastUpdated":"2023-09-13T21:43:43.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc","lastName":"Jones","mobilePhone":null,"secondEmail":null,"login":"john_3671860054@ledzeppelin.com","email":"john_3671860054@ledzeppelin.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.oktapreview.com/api/v1/meta/schemas/user/osc5qwjvh0Vy1j8Kd1d7"},"resetPassword":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7"},"resetFactors":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.oktapreview.com/api/v1/meta/types/user/oty5qwjvh0Vy1j8Kd1d7"},"deactivate":{"href":"https://oie-00.oktapreview.com/api/v1/users/00ua1vkg7euUofldZ1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:45 GMT
+        status: 200 OK
+        code: 200
+        duration: 96.231411ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users/00ua1vkg7euUofldZ1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -903,11 +980,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
+                - Wed, 13 Sep 2023 21:43:45 GMT
         status: 204 No Content
         code: 204
-        duration: 110.732201ms
-    - id: 24
+        duration: 118.321458ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -928,7 +1005,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -938,16 +1015,16 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:41.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:45.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
+                - Wed, 13 Sep 2023 21:43:45 GMT
         status: 200 OK
         code: 200
-        duration: 80.552338ms
-    - id: 25
+        duration: 79.941035ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -965,44 +1042,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00g9i6x5ihNdWjNSh1d7","created":"2023-08-15T23:29:37.000Z","lastUpdated":"2023-08-15T23:29:41.000Z","lastMembershipUpdated":"2023-08-15T23:29:37.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7/apps"}}}'
-        headers:
-            Content-Type:
-                - application/json
-            Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
-        status: 200 OK
-        code: 200
-        duration: 58.548419ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1015,11 +1055,48 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:29:41 GMT
+                - Wed, 13 Sep 2023 21:43:45 GMT
         status: 204 No Content
         code: 204
-        duration: 191.657349ms
-    - id: 27
+        duration: 130.307656ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ga1vmeyuR8L3HAY1d7","created":"2023-09-13T21:43:41.000Z","lastUpdated":"2023-09-13T21:43:45.000Z","lastMembershipUpdated":"2023-09-13T21:43:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3671860054","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 21:43:45 GMT
+        status: 200 OK
+        code: 200
+        duration: 62.448186ms
+    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1052,11 +1129,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:29:42 GMT
+                - Wed, 13 Sep 2023 21:43:45 GMT
         status: 200 OK
         code: 200
-        duration: 52.481978ms
-    - id: 28
+        duration: 60.74721ms
+    - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1074,7 +1151,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00u9i6pqgsR6gEYFw1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00ua1vkg7euUofldZ1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1087,11 +1164,11 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:29:42 GMT
+                - Wed, 13 Sep 2023 21:43:45 GMT
         status: 204 No Content
         code: 204
-        duration: 213.794459ms
-    - id: 29
+        duration: 223.634581ms
+    - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1109,7 +1186,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i6x5ihNdWjNSh1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1vmeyuR8L3HAY1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1122,7 +1199,7 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:29:42 GMT
+                - Wed, 13 Sep 2023 21:43:46 GMT
         status: 204 No Content
         code: 204
-        duration: 139.238721ms
+        duration: 109.410774ms

--- a/test/fixtures/vcr/TestAccResourceOktaGroup_crud/classic-00.yaml
+++ b/test/fixtures/vcr/TestAccResourceOktaGroup_crud/classic-00.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 64
+        content_length: 74
         transfer_encoding: []
         trailer: {}
         host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"profile":{"name":"testAcc","description":"testing, testing"}}
+            {"profile":{"name":"testAcc_891989555","description":"testing, testing"}}
         form: {}
         headers:
             Accept:
@@ -32,15 +32,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:56.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:15.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:56 GMT
+                - Wed, 13 Sep 2023 18:54:15 GMT
         status: 200 OK
         code: 200
-        duration: 220.698434ms
+        duration: 231.53733ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -59,7 +59,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -69,15 +69,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:56.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:15.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:56 GMT
+                - Wed, 13 Sep 2023 18:54:15 GMT
         status: 200 OK
         code: 200
-        duration: 78.413228ms
+        duration: 59.971118ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,7 +96,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,15 +106,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:56.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:15.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:56 GMT
+                - Wed, 13 Sep 2023 18:54:15 GMT
+            Report-To:
+                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
         status: 200 OK
         code: 200
-        duration: 61.053196ms
+        duration: 80.068073ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -133,7 +135,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -143,17 +145,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:56.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:15.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:56 GMT
-            Report-To:
-                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
+                - Wed, 13 Sep 2023 18:54:16 GMT
         status: 200 OK
         code: 200
-        duration: 56.10743ms
+        duration: 74.362276ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -172,7 +172,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -182,28 +182,28 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:56.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:15.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:56 GMT
+                - Wed, 13 Sep 2023 18:54:16 GMT
         status: 200 OK
         code: 200
-        duration: 64.49315ms
+        duration: 59.855428ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 73
+        content_length: 84
         transfer_encoding: []
         trailer: {}
         host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"profile":{"name":"testAccDifferent","description":"testing, testing"}}
+            {"profile":{"name":"testAcc_Different_891989555","description":"testing, testing"}}
         form: {}
         headers:
             Accept:
@@ -212,7 +212,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -222,15 +222,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:57.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAccDifferent","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:17.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:57 GMT
+                - Wed, 13 Sep 2023 18:54:17 GMT
         status: 200 OK
         code: 200
-        duration: 78.527995ms
+        duration: 88.122546ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -249,7 +249,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -259,15 +259,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:57.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAccDifferent","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:17.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:57 GMT
+                - Wed, 13 Sep 2023 18:54:17 GMT
         status: 200 OK
         code: 200
-        duration: 61.811093ms
+        duration: 66.529605ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -286,7 +286,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -296,15 +296,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i7iavpqi0HcRF1d7","created":"2023-08-16T00:04:56.000Z","lastUpdated":"2023-08-16T00:04:57.000Z","lastMembershipUpdated":"2023-08-16T00:04:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAccDifferent","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00g9i7iavpqi0HcRF1d7/apps"}}}'
+        body: '{"id":"00ga1qd0xoyYMyCfv1d7","created":"2023-09-13T18:54:15.000Z","lastUpdated":"2023-09-13T18:54:17.000Z","lastMembershipUpdated":"2023-09-13T18:54:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/users"},"apps":{"href":"https://classic-00.oktapreview.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:57 GMT
+                - Wed, 13 Sep 2023 18:54:17 GMT
         status: 200 OK
         code: 200
-        duration: 64.023188ms
+        duration: 59.206235ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -323,7 +323,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -336,10 +336,10 @@ interactions:
         body: ""
         headers:
             Date:
-                - Wed, 16 Aug 2023 00:04:58 GMT
+                - Wed, 13 Sep 2023 18:54:18 GMT
         status: 204 No Content
         code: 204
-        duration: 98.135474ms
+        duration: 171.131111ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -358,7 +358,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00g9i7iavpqi0HcRF1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00ga1qd0xoyYMyCfv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -368,12 +368,12 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"errorCode":"E0000007","errorSummary":"Not found: Resource not found: 00g9i7iavpqi0HcRF1d7 (UserGroup)","errorLink":"E0000007","errorId":"oae1T8fy3qqTEmWlW-Be_p4Xw","errorCauses":[]}'
+        body: '{"errorCode":"E0000007","errorSummary":"Not found: Resource not found: 00ga1qd0xoyYMyCfv1d7 (UserGroup)","errorLink":"E0000007","errorId":"oaeRQ7FzM68QHGDCwo1QN9Bzg","errorCauses":[]}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 16 Aug 2023 00:04:58 GMT
+                - Wed, 13 Sep 2023 18:54:18 GMT
         status: 404 Not Found
         code: 404
-        duration: 47.445986ms
+        duration: 57.139244ms

--- a/test/fixtures/vcr/TestAccResourceOktaGroup_crud/dev-org-oauth-00.yaml
+++ b/test/fixtures/vcr/TestAccResourceOktaGroup_crud/dev-org-oauth-00.yaml
@@ -1,0 +1,414 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/x-www-form-urlencoded
+        url: https://dev-org-oauth-00.dne-okta.com/oauth2/v1/token?client_assertion=abc123&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&grant_type=client_credentials&scope=okta.groups.read+okta.groups.manage
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"token_type":"Bearer","expires_in":3600,"access_token":"eyJraWQiOiJKVGFSM1RQU1E5RGhha1BtdEx0c3I0ZzRsTUN2c1c0b3hQOXc5WnBZR01JIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULk5qclFScmliSG01ZmkxNGFHSHdwcDVITEFydlF4cmo0Y3NnbTFwVFh2X2MiLCJpc3MiOiJodHRwczovL2Rldi1tb25kcmFnb24ub2t0YS5jb20iLCJhdWQiOiJodHRwczovL2Rldi1tb25kcmFnb24ub2t0YS5jb20iLCJzdWIiOiIwb2FiOHV1dnZ2aWt5RzZlczVkNyIsImlhdCI6MTY5NDYzMTMxOCwiZXhwIjoxNjk0NjM0OTE4LCJjaWQiOiIwb2FiOHV1dnZ2aWt5RzZlczVkNyIsInNjcCI6WyJva3RhLmdyb3Vwcy5yZWFkIiwib2t0YS5ncm91cHMubWFuYWdlIl19.oxEunU2zM5uLXfx83lpXuMQ6Rd9qfG3ux0pWWGaJv64zo-sGUwzkend3g3MGUluPfXEWAtZzM6G8ZzSzkHo5W6pobmMs321f0jDH-kiHf-fwNpdNRLcYJl0w9ZXFglyzXK7Hy_pXqhrAT2Tob-i0OdP8mX7i9Ekh8JT0YrOQV17WN5ii21oMOZBCJrjWfQ8xieNOIGEKExVobn-FcAiCPJLMW-pXkO0Paa6zL-3df0cOPJj5WsmxH5UIqKL1SdeStqsRw6JCfhsJ6u9Ba5qWgw-Jo4jNuZlw5gHxKnDFeWyVA279eU-vTFX5IhiD5NhFvkxQbsUX-IFOV900J2dxww","scope":"okta.groups.read okta.groups.manage"}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:18 GMT
+        status: 200 OK
+        code: 200
+        duration: 636.72496ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 74
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"testAcc_891989555","description":"testing, testing"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+            Content-Type:
+                - application/json
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:19.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:19 GMT
+        status: 200 OK
+        code: 200
+        duration: 392.583661ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:19.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:19 GMT
+        status: 200 OK
+        code: 200
+        duration: 371.621854ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:19.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:20 GMT
+        status: 200 OK
+        code: 200
+        duration: 369.314772ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:19.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:20 GMT
+        status: 200 OK
+        code: 200
+        duration: 367.955366ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:19.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:21 GMT
+        status: 200 OK
+        code: 200
+        duration: 381.101856ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 84
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"testAcc_Different_891989555","description":"testing, testing"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+            Content-Type:
+                - application/json
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:22.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:22 GMT
+        status: 200 OK
+        code: 200
+        duration: 441.126122ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:22.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:22 GMT
+        status: 200 OK
+        code: 200
+        duration: 307.05172ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gb8vjl0uGldPEbc5d7","created":"2023-09-13T18:55:19.000Z","lastUpdated":"2023-09-13T18:55:22.000Z","lastMembershipUpdated":"2023-09-13T18:55:19.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/users"},"apps":{"href":"https://dev-org-oauth-00.okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7/apps"}}}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:23 GMT
+        status: 200 OK
+        code: 200
+        duration: 283.780511ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Date:
+                - Wed, 13 Sep 2023 18:55:23 GMT
+        status: 204 No Content
+        code: 204
+        duration: 116.148549ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: dev-org-oauth-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - Bearer REDACTED
+        url: https://dev-org-oauth-00.dne-okta.com/api/v1/groups/00gb8vjl0uGldPEbc5d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"errorCode":"E0000007","errorSummary":"Not found: Resource not found: 00gb8vjl0uGldPEbc5d7 (UserGroup)","errorLink":"E0000007","errorId":"oae94XflrmkRLGFxoYcMUBBAg","errorCauses":[]}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 13 Sep 2023 18:55:24 GMT
+        status: 404 Not Found
+        code: 404
+        duration: 459.553976ms

--- a/test/fixtures/vcr/TestAccResourceOktaGroup_crud/oie-00.yaml
+++ b/test/fixtures/vcr/TestAccResourceOktaGroup_crud/oie-00.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 64
+        content_length: 74
         transfer_encoding: []
         trailer: {}
         host: oie-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"profile":{"name":"testAcc","description":"testing, testing"}}
+            {"profile":{"name":"testAcc_891989555","description":"testing, testing"}}
         form: {}
         headers:
             Accept:
@@ -32,15 +32,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:30.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:53.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:30 GMT
+                - Wed, 13 Sep 2023 18:53:53 GMT
         status: 200 OK
         code: 200
-        duration: 152.603823ms
+        duration: 244.214249ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -59,7 +59,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -69,15 +69,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:30.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:53.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:30 GMT
+                - Wed, 13 Sep 2023 18:53:53 GMT
         status: 200 OK
         code: 200
-        duration: 62.223201ms
+        duration: 60.345281ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,7 +96,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,15 +106,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:30.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:53.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:30 GMT
+                - Wed, 13 Sep 2023 18:53:53 GMT
         status: 200 OK
         code: 200
-        duration: 65.950389ms
+        duration: 77.164042ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -133,7 +133,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -143,15 +143,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:30.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:53.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:31 GMT
+                - Wed, 13 Sep 2023 18:53:54 GMT
         status: 200 OK
         code: 200
-        duration: 59.046748ms
+        duration: 54.070039ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -170,7 +170,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -180,28 +180,28 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:30.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:53.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:31 GMT
+                - Wed, 13 Sep 2023 18:53:54 GMT
         status: 200 OK
         code: 200
-        duration: 58.573813ms
+        duration: 62.987725ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 73
+        content_length: 84
         transfer_encoding: []
         trailer: {}
         host: oie-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"profile":{"name":"testAccDifferent","description":"testing, testing"}}
+            {"profile":{"name":"testAcc_Different_891989555","description":"testing, testing"}}
         form: {}
         headers:
             Accept:
@@ -210,7 +210,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -220,15 +220,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:31.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAccDifferent","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:54.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:31 GMT
+                - Wed, 13 Sep 2023 18:53:55 GMT
         status: 200 OK
         code: 200
-        duration: 101.104826ms
+        duration: 80.120164ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -247,7 +247,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -257,15 +257,15 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:31.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAccDifferent","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:54.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:31 GMT
+                - Wed, 13 Sep 2023 18:53:55 GMT
         status: 200 OK
         code: 200
-        duration: 61.132549ms
+        duration: 64.765956ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -284,7 +284,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -294,15 +294,17 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g9i76ex80h4oNt81d7","created":"2023-08-15T23:44:30.000Z","lastUpdated":"2023-08-15T23:44:31.000Z","lastMembershipUpdated":"2023-08-15T23:44:30.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAccDifferent","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00g9i76ex80h4oNt81d7/apps"}}}'
+        body: '{"id":"00ga1qjjdvAXzEt8I1d7","created":"2023-09-13T18:53:53.000Z","lastUpdated":"2023-09-13T18:53:54.000Z","lastMembershipUpdated":"2023-09-13T18:53:53.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_Different_891989555","description":"testing, testing"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/users"},"apps":{"href":"https://oie-00.oktapreview.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7/apps"}}}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:32 GMT
+                - Wed, 13 Sep 2023 18:53:55 GMT
+            Report-To:
+                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
         status: 200 OK
         code: 200
-        duration: 56.398108ms
+        duration: 54.232711ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -321,7 +323,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -334,10 +336,10 @@ interactions:
         body: ""
         headers:
             Date:
-                - Tue, 15 Aug 2023 23:44:32 GMT
+                - Wed, 13 Sep 2023 18:53:55 GMT
         status: 204 No Content
         code: 204
-        duration: 97.676006ms
+        duration: 102.550938ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -356,7 +358,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g9i76ex80h4oNt81d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00ga1qjjdvAXzEt8I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -366,12 +368,12 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"errorCode":"E0000007","errorSummary":"Not found: Resource not found: 00g9i76ex80h4oNt81d7 (UserGroup)","errorLink":"E0000007","errorId":"oae_Qbo7v4PSGCw5uVhBjLDLA","errorCauses":[]}'
+        body: '{"errorCode":"E0000007","errorSummary":"Not found: Resource not found: 00ga1qjjdvAXzEt8I1d7 (UserGroup)","errorLink":"E0000007","errorId":"oaer9B3tv6VQ4mJCmOz9WMTbg","errorCauses":[]}'
         headers:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 15 Aug 2023 23:44:32 GMT
+                - Wed, 13 Sep 2023 18:53:56 GMT
         status: 404 Not Found
         code: 404
-        duration: 47.977058ms
+        duration: 68.270134ms


### PR DESCRIPTION
- Adds guards and useful error message if operator has fouled org_name + base_url or http_proxy values.
- Clean up ACC `TestAccResourceOktaGroup_crud` so group named in test has a unique name
- Clean up test harness for tests when SDK auth is done with a private key / OAuth
- Record a VCR cassette of TestAccResourceOktaGroup_crud when the provider is using OAuth authentication

Closes #1217