### PR TITLE
Correctly set http proxy on v3 client

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -478,6 +478,26 @@ func oktaV3SDKClient(c *Config) (client *okta.APIClient, err error) {
 		okta.WithRateLimitMaxRetries(int32(c.retryCount)),
 		okta.WithUserAgentExtra(OktaTerraformProviderUserAgent),
 	}
+	// v3 client also needs http proxy explicitly set
+	if c.httpProxy != "" {
+		_url, err := url.Parse(c.httpProxy)
+		if err != nil {
+			return nil, err
+		}
+		host := okta.WithProxyHost(_url.Hostname())
+		setters = append(setters, host)
+
+		sPort := _url.Port()
+		if sPort == "" {
+			sPort = "80"
+		}
+		iPort, err := strconv.Atoi(sPort)
+		if err != nil {
+			return nil, err
+		}
+		port := okta.WithProxyPort(int32(iPort))
+		setters = append(setters, port)
+	}
 
 	switch {
 	case c.accessToken != "":

--- a/sdk/v2_okta.go
+++ b/sdk/v2_okta.go
@@ -14,8 +14,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const Version = "2.17.0"
-
 type Client struct {
 	config                     *config
 	requestExecutor            *RequestExecutor

--- a/sdk/v2_userAgent.go
+++ b/sdk/v2_userAgent.go
@@ -23,7 +23,7 @@ func NewUserAgent(config *config) UserAgent {
 }
 
 func (ua UserAgent) String() string {
-	userAgentString := "okta-sdk-golang/" + Version + " "
+	userAgentString := "local-v2-sdk/0.0.0 "
 	userAgentString += "golang/" + ua.goVersion + " "
 	userAgentString += ua.osName + "/" + ua.osVersion
 


### PR DESCRIPTION
Correctly set http proxy on v3 client.

I checked by hand that the v2 client doesn't have this same problem and honors the http proxy settings without intervention.

Closes #1723

cc: @robgero 