### PR TITLE
Correct form escaping with OAuth scopes

### DIFF
--- a/okta/framework_provider.go
+++ b/okta/framework_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -223,7 +224,9 @@ func (p *FrameworkProvider) Configure(ctx context.Context, req provider.Configur
 	p.logLevel = int(data.LogLevel.ValueInt64())
 	p.requestTimeout = int(data.RequestTimeout.ValueInt64())
 	for _, val := range data.Scopes.Elements() {
-		p.scopes = append(p.scopes, val.String())
+		var v types.String
+		tfsdk.ValueAs(ctx, val, &v)
+		p.scopes = append(p.scopes, v.ValueString())
 	}
 
 	if !data.HTTPProxy.IsNull() {

--- a/sdk/v2_requestExecutor.go
+++ b/sdk/v2_requestExecutor.go
@@ -293,6 +293,7 @@ func getAccessTokenForPrivateKey(httpClient *http.Client, orgURL, clientAssertio
 
 	tokenRequest.Header.Add("Accept", "application/json")
 	tokenRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	tokenRequest.Header.Add("User-Agent", NewUserAgent(&config{}).String())
 
 	bOff := &oktaBackoff{
 		ctx:             context.TODO(),


### PR DESCRIPTION
Use `tfsdk.ValueAs` to get the actual named value of the grant. Fixes scopes being double escaped in an HTTP call for an access token.

Closes #1744
Closes #1752

I checked this by hand to very the access token request was working correctly again. Will need to record a VCR test for it once we get VCR hooked up to the plugin framework resources.

```
$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestAccResourceOktaBrandCRUD$ ./okta 2>&1
=== RUN   TestAccResourceOktaBrandCRUD
--- PASS: TestAccResourceOktaBrandCRUD (6.79s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    7.249s
```