### PR TITLE
Simple change detection of JSON resource arguments

### DIFF
--- a/okta/app.go
+++ b/okta/app.go
@@ -67,9 +67,7 @@ var (
 			Description:      "Displays specific appLinks for the app",
 			ValidateDiagFunc: stringIsJSON,
 			StateFunc:        normalizeDataJSON,
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				return new == ""
-			},
+			DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 		},
 		"accessibility_login_redirect_url": {
 			Type:        schema.TypeString,

--- a/okta/resource_okta_app_auto_login.go
+++ b/okta/resource_okta_app_auto_login.go
@@ -63,9 +63,7 @@ func resourceAppAutoLogin() *schema.Resource {
 				Description:      "Application settings in JSON format",
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 		}),
 		Timeouts: &schema.ResourceTimeout{

--- a/okta/resource_okta_app_group_assignment.go
+++ b/okta/resource_okta_app_group_assignment.go
@@ -64,10 +64,8 @@ func resourceAppGroupAssignment() *schema.Resource {
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
 				Optional:         true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
-				Description: "JSON document containing [application profile](https://developer.okta.com/docs/reference/api/apps/#profile-object)",
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
+				Description:      "JSON document containing [application profile](https://developer.okta.com/docs/reference/api/apps/#profile-object)",
 			},
 			"retain_assignment": {
 				Type:        schema.TypeBool,

--- a/okta/resource_okta_app_group_assignments.go
+++ b/okta/resource_okta_app_group_assignments.go
@@ -56,9 +56,7 @@ func resourceAppGroupAssignments() *schema.Resource {
 							ValidateDiagFunc: stringIsJSON,
 							StateFunc:        normalizeDataJSON,
 							Required:         true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return new == ""
-							},
+							DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 							DefaultFunc: func() (interface{}, error) {
 								return "{}", nil
 							},

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -299,6 +299,7 @@ func resourceAppOAuth() *schema.Resource {
 				StateFunc:        normalizeDataJSON,
 				Optional:         true,
 				Description:      "Custom JSON that represents an OAuth application's profile",
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 			"jwks": {
 				Type:     schema.TypeList,
@@ -356,9 +357,7 @@ func resourceAppOAuth() *schema.Resource {
 				Description:      "Application settings in JSON format",
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 			"authentication_policy": {
 				Type:        schema.TypeString,

--- a/okta/resource_okta_app_saml.go
+++ b/okta/resource_okta_app_saml.go
@@ -287,9 +287,7 @@ func resourceAppSaml() *schema.Resource {
 				Description:      "Application settings in JSON format",
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 			"inline_hook_id": {
 				Type:        schema.TypeString,

--- a/okta/resource_okta_app_saml_app_settings.go
+++ b/okta/resource_okta_app_saml_app_settings.go
@@ -32,6 +32,7 @@ func resourceAppSamlAppSettings() *schema.Resource {
 				Description:      "Application settings in JSON format",
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 		},
 	}

--- a/okta/resource_okta_app_signon_policy_rule.go
+++ b/okta/resource_okta_app_signon_policy_rule.go
@@ -176,6 +176,7 @@ func resourceAppSignOnPolicyRule() *schema.Resource {
 					Type:             schema.TypeString,
 					ValidateDiagFunc: stringIsJSON,
 					StateFunc:        normalizeDataJSON,
+					DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 				},
 				Optional:    true,
 				Description: "An array that contains nested Authenticator Constraint objects that are organized by the Authenticator class",

--- a/okta/resource_okta_app_user.go
+++ b/okta/resource_okta_app_user.go
@@ -74,10 +74,8 @@ func resourceAppUser() *schema.Resource {
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
 				Optional:         true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
-				Description: "The JSON profile of the App User.",
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
+				Description:      "The JSON profile of the App User.",
 			},
 			"retain_assignment": {
 				Type:        schema.TypeBool,

--- a/okta/resource_okta_authenticator.go
+++ b/okta/resource_okta_authenticator.go
@@ -41,9 +41,7 @@ func resourceAuthenticator() *schema.Resource {
 				Description:      "Authenticator settings in JSON format",
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 			"provider_json": {
 				Type:             schema.TypeString,
@@ -51,9 +49,7 @@ func resourceAuthenticator() *schema.Resource {
 				Description:      "Provider in JSON format",
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 				ConflictsWith: []string{
 					// general
 					"provider_auth_port",

--- a/okta/resource_okta_user.go
+++ b/okta/resource_okta_user.go
@@ -100,9 +100,7 @@ func resourceUser() *schema.Resource {
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        normalizeDataJSON,
 				Description:      "JSON formatted custom attributes for a user. It must be JSON due to various types Okta allows.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == ""
-				},
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 			"custom_profile_attributes_to_ignore": {
 				Type:        schema.TypeSet,

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"unicode"
@@ -533,4 +534,24 @@ func certNormalize(certContents string) (*x509.Certificate, error) {
 		return nil, err
 	}
 	return certDecoded, nil
+}
+
+// noChangeInObjectFromUnmarshaledJSON Intended for use by a DiffSuppressFunc,
+// returns true if old and new JSONs are equivalent object representations ...
+// It is true, there is no change!  Edge chase if newJSON is blank, will also
+// return true which cover the new resource case.
+func noChangeInObjectFromUnmarshaledJSON(k, oldJSON, newJSON string, d *schema.ResourceData) bool {
+	if newJSON == "" {
+		return true
+	}
+	var oldObj map[string]any
+	var newObj map[string]any
+	if err := json.Unmarshal([]byte(oldJSON), &oldObj); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(newJSON), &newObj); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldObj, newObj)
 }

--- a/okta/utils_test.go
+++ b/okta/utils_test.go
@@ -215,3 +215,118 @@ xqneNjZf70DMNAFNXG1VltldQ3hOnRML
 		t.Fatalf("certs do not match: A: %s, B: %s", cert.Issuer.CommonName, cert2.Issuer.CommonName)
 	}
 }
+
+func TestNoChangeInObjectUnmarshaledFromJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		oldJSON  string
+		newJSON  string
+		expected bool
+	}{
+		{
+			name: "there is no change - same same",
+			oldJSON: `{
+				"one": 1,
+				"some": [
+					1,
+					"a"
+				]
+			}`,
+			newJSON: `{
+				"one": 1,
+				"some": [
+					1,
+					"a"
+				]
+			}`,
+			expected: true,
+		},
+		{
+			name: "there is no change - same objects, different string formatting",
+			oldJSON: `{
+				"one": 1,
+				"some": [
+					1,
+					"a"
+				]
+			}`,
+			newJSON:  `{ "one": 1, "some": [ 1, "a" ] }`,
+			expected: true,
+		},
+		{
+			name: "there is no change - attributes in different order ",
+			oldJSON: `{
+				"one": 1,
+				"some": [
+					1,
+					"a"
+				]
+			}`,
+			newJSON: `{
+				"some": [
+					1,
+					"a"
+				],
+				"one": 1
+			}`,
+			expected: true,
+		},
+		{
+			name: "there is change - different values",
+			oldJSON: `{
+				"one": 1,
+				"some": [
+					1,
+					"a"
+				]
+			}`,
+			newJSON: `{
+				"one": 2,
+				"some": [
+					"a",
+					1
+				]
+			}`,
+			expected: false,
+		},
+		{
+			name: "there is change - slice out of order",
+			oldJSON: `{
+				"one": 1,
+				"some": [
+					1,
+					"a"
+				]
+			}`,
+			newJSON: `{
+				"one": 1,
+				"some": [
+					"a",
+					1
+				]
+			}`,
+			expected: false,
+		},
+		{
+			name: "there is no change - new resource value will be blank",
+			oldJSON: `{
+				"one": 1,
+				"some": [
+					1,
+					"a"
+				]
+			}`,
+			newJSON:  "",
+			expected: true,
+		},
+	}
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := noChangeInObjectFromUnmarshaledJSON("", tc.oldJSON, tc.newJSON, nil)
+			if tc.expected != result {
+				t.Errorf("expected %+v, got %+v", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Simple change detection of JSON resource arguments. Completely ignores string formatting and instead considers the actual object representation of the JSON. Intended for use by `DiffSuppressFunc`.

Closes #1633
Closes #1631
Closes #1565
Closes #1518
Closes #1454
Closes #891

```
$ TF_ACC=1 go test -tags unit -mod=readonly -test.v -run ^TestNoChangeInObjectUnmarshaledFromJSON$ ./okta 2>&1
=== RUN   TestNoChangeInObjectUnmarshaledFromJSON
=== PAUSE TestNoChangeInObjectUnmarshaledFromJSON
=== CONT  TestNoChangeInObjectUnmarshaledFromJSON
=== RUN   TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_same_same
=== RUN   TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_same_objects,_different_string_formatting
=== RUN   TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_attributes_in_different_order_
=== RUN   TestNoChangeInObjectUnmarshaledFromJSON/there_is_change_-_different_values
=== RUN   TestNoChangeInObjectUnmarshaledFromJSON/there_is_change_-_slice_out_of_order
=== RUN   TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_new_resource_value_will_be_blank
--- PASS: TestNoChangeInObjectUnmarshaledFromJSON (0.00s)
    --- PASS: TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_same_same (0.00s)
    --- PASS: TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_same_objects,_different_string_formatting (0.00s)
    --- PASS: TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_attributes_in_different_order_ (0.00s)
    --- PASS: TestNoChangeInObjectUnmarshaledFromJSON/there_is_change_-_different_values (0.00s)
    --- PASS: TestNoChangeInObjectUnmarshaledFromJSON/there_is_change_-_slice_out_of_order (0.00s)
    --- PASS: TestNoChangeInObjectUnmarshaledFromJSON/there_is_no_change_-_new_resource_value_will_be_blank (0.00s)
PASS
ok      github.com/okta/terraform-provider-okta/okta    0.696s
```