### PR TITLE
Implement proper error for incorrect compound import input

### DIFF
--- a/okta/utils.go
+++ b/okta/utils.go
@@ -175,6 +175,9 @@ func createCustomNestedResourceImporter(fields []string, errMessage string) *sch
 	return &schema.ResourceImporter{
 		StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 			parts := strings.Split(d.Id(), "/")
+			if len(parts) != len(fields) {
+				return nil, fmt.Errorf("expected %d import fields %q, got %d fields %q", len(fields), strings.Join(fields, "/"), len(parts), d.Id())
+			}
 			for i, field := range fields {
 				if field == "id" {
 					d.SetId(parts[i])


### PR DESCRIPTION
Incorrect compound import input correctly surfaces an error and doesn't result in a panic.

Closes #1759

This would cause a panic
```
# expected [auth server id]/[scope id]
tf import okta_auth_server_scope.example [scope id]
```
But now results in an informative error `expected 2 import fields "auth_server_id/id", got 1 fields "[scope id]"`
