### PR TITLE
okta_app_signon_policy_rule import tests for #1275

### DIFF
--- a/okta/resource_okta_app_signon_policy_rule_test.go
+++ b/okta/resource_okta_app_signon_policy_rule_test.go
@@ -102,6 +102,73 @@ func TestAccResourceOktaAppSignOnPolicyRule(t *testing.T) {
 	})
 }
 
+// TestAccResourceOktaAppSignOnPolicyRule_Issue_1275_default_conditions
+// https://github.com/okta/terraform-provider-okta/issues/1275
+func TestAccResourceOktaAppSignOnPolicyRule_Issue_1275_default_conditions(t *testing.T) {
+	mgr := newFixtureManager("resources", appSignOnPolicyRule, t.Name())
+	resourceName := fmt.Sprintf("%s.test", appSignOnPolicyRule)
+	config := `
+resource "okta_app_signon_policy" "test" {
+	name        = "testAcc_replace_with_uuid"
+	description = "Test App Signon Policy with updated Okta TF Provider"
+}
+resource "okta_app_signon_policy_rule" "test" {
+	name                        = "Catch-all Rule_replace_with_uuid"
+	policy_id                   = okta_app_signon_policy.test.id
+	access                      = "ALLOW"
+	priority                    = 89
+	inactivity_period           = "PT0S"
+	re_authentication_frequency = "PT12H"
+	constraints = [
+	  jsonencode({
+		"possession" : {
+		  "deviceBound" : "REQUIRED"
+		}
+	  })
+	]
+}
+`
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("Catch-all Rule", mgr.Seed)),
+					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
+					resource.TestCheckResourceAttr(resourceName, "priority", "89"),
+					resource.TestCheckResourceAttr(resourceName, "inactivity_period", "PT0S"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("failed to find app sign on policy rule %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["policy_id"], rs.Primary.Attributes["id"]), nil
+				},
+				ImportStateCheck: func(s []*terraform.InstanceState) (err error) {
+					if len(s) != 1 {
+						err = errors.New("failed to import into resource into state")
+						return
+					}
+
+					id := s[0].Attributes["id"]
+					if strings.Contains(id, "@") {
+						err = fmt.Errorf("resource id incorrectly set, %s", id)
+					}
+					return
+				},
+			},
+		},
+	})
+}
+
 func checkAppSignOnPolicyRuleDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != appSignOnPolicyRule {

--- a/okta/resource_okta_app_signon_policy_rule_test.go
+++ b/okta/resource_okta_app_signon_policy_rule_test.go
@@ -170,11 +170,11 @@ resource "okta_app_signon_policy_rule" "test" {
 	})
 }
 
-// TestAccResourceOktaAppSignOnPolicyRule_Issue_1242_possesion_constraint
+// TestAccResourceOktaAppSignOnPolicyRule_Issue_1242_possession_constraint
 // https://github.com/okta/terraform-provider-okta/issues/1242
 // Operator had a typo in the constraint, posession and not possession. We'll
 // still keep this ACC.
-func TestAccResourceOktaAppSignOnPolicyRule_Issue_1242_possesion_constraint(t *testing.T) {
+func TestAccResourceOktaAppSignOnPolicyRule_Issue_1242_possession_constraint(t *testing.T) {
 	mgr := newFixtureManager("resources", appSignOnPolicyRule, t.Name())
 	resourceName := fmt.Sprintf("%s.test", appSignOnPolicyRule)
 	constraints := []interface{}{

--- a/okta/resource_okta_auth_server_policy_rule.go
+++ b/okta/resource_okta_auth_server_policy_rule.go
@@ -39,6 +39,11 @@ func resourceAuthServerPolicyRule() *schema.Resource {
 				Required:    true,
 				Description: "Auth server policy ID",
 			},
+			"system": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "The rule is the system (default) rule for its associated policy",
+			},
 			"status": statusSchema,
 			"priority": {
 				Type:        schema.TypeInt,
@@ -136,6 +141,7 @@ func resourceAuthServerPolicyRuleRead(ctx context.Context, d *schema.ResourceDat
 		d.SetId("")
 		return nil
 	}
+	_ = d.Set("system", boolFromBoolPtr(authServerPolicyRule.System))
 	_ = d.Set("name", authServerPolicyRule.Name)
 	_ = d.Set("status", authServerPolicyRule.Status)
 	if authServerPolicyRule.PriorityPtr != nil {

--- a/okta/resource_okta_auth_server_policy_rule_test.go
+++ b/okta/resource_okta_auth_server_policy_rule_test.go
@@ -25,6 +25,7 @@ func TestAccResourceOktaAuthServerPolicyRule_create(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
 					resource.TestCheckResourceAttr(resourceName, "name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "system", "false"),
 				),
 			},
 			{
@@ -32,6 +33,7 @@ func TestAccResourceOktaAuthServerPolicyRule_create(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
 					resource.TestCheckResourceAttr(resourceName, "name", "test_updated"),
+					resource.TestCheckResourceAttr(resourceName, "system", "false"),
 				),
 			},
 		},

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -255,9 +255,18 @@ func getMapString(m map[string]interface{}, key string) string {
 	return ""
 }
 
+// boolPtr return bool pointer to b's value
 func boolPtr(b bool) (ptr *bool) {
 	ptr = &b
 	return
+}
+
+// boolFromBoolPtr if b is nil returns false, otherwise return boolean value of b
+func boolFromBoolPtr(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
 }
 
 func stringPtr(s string) (ptr *string) {

--- a/website/docs/r/app_signon_policy_rule.html.markdown
+++ b/website/docs/r/app_signon_policy_rule.html.markdown
@@ -338,6 +338,8 @@ The following arguments are supported:
 
 - `id` - ID of the sign-on policy rule.
 
+- `system` - Often the "Catch-all Rule" this rule is the system (default) rule for its associated policy.
+
 ## Import
 
 Okta app sign-on policy rule can be imported via the Okta ID.

--- a/website/docs/r/auth_server_policy_rule.html.markdown
+++ b/website/docs/r/auth_server_policy_rule.html.markdown
@@ -79,6 +79,8 @@ The following arguments are supported:
 
 - `type` - The type of the Auth Server Policy Rule.
 
+- `system` - The rule is the system (default) rule for its associated policy.
+
 ## Import
 
 Authorization Server Policy Rule can be imported via the Auth Server ID, Policy ID, and Policy Rule ID.


### PR DESCRIPTION
- Adds `system` attribute to resource `okta_app_signon_policy_rule` - an Okta API boolean marking this rule as the default for its policy
- Adds test demonstrating valid import of a default `okta_app_signon_policy_rule`
- Adds `system` attribute to resource `okta_auth_server_policy_rule` - an Okta API boolean marking this rule as the default for its policy
- Document `system` attributes in `okta_app_signon_policy_rule` and `okta_auth_server_policy_rule`

Closes #1242
Closes #1245
Closes #1275

