### PR TITLE
Correct change detection on resources `okta_app_oauth_post_logout_redirect_uri` and `okta_app_oauth_redirect_uri` 

### DIFF
--- a/examples/resources/okta_app_oauth_post_logout_redirect_uri/basic.tf
+++ b/examples/resources/okta_app_oauth_post_logout_redirect_uri/basic.tf
@@ -11,7 +11,9 @@ resource "okta_app_oauth" "test" {
   // After logout, Okta redirects users to one of these URIs
   post_logout_redirect_uris = ["https://www.example.com"]
 
-  // Since Okta forces us to create it with a redirect URI we have to ignore future changes, they will be detected as config drift.
+  // Ignore post logout redirect uris if you are going to manage them with the
+  // okta_app_oauth_post_logout_redirect_uri resource and not have change
+  // detection on the app for that value.
   lifecycle {
     ignore_changes = [post_logout_redirect_uris]
   }

--- a/examples/resources/okta_app_oauth_post_logout_redirect_uri/basic_updated.tf
+++ b/examples/resources/okta_app_oauth_post_logout_redirect_uri/basic_updated.tf
@@ -12,7 +12,9 @@ resource "okta_app_oauth" "test" {
   post_logout_redirect_uris = ["https://www.example.com"]
 
 
-  // Since Okta forces us to create it with a redirect URI we have to ignore future changes, they will be detected as config drift.
+  // Ignore post logout redirect uris if you are going to manage them with the
+  // okta_app_oauth_post_logout_redirect_uri resource and not have change
+  // detection on the app for that value.
   lifecycle {
     ignore_changes = [post_logout_redirect_uris]
   }
@@ -20,5 +22,5 @@ resource "okta_app_oauth" "test" {
 
 resource "okta_app_oauth_post_logout_redirect_uri" "test" {
   app_id = okta_app_oauth.test.id
-  uri    = "https://www.example-updated.com"
+  uri    = "https://www.google-updated.com"
 }

--- a/examples/resources/okta_app_oauth_redirect_uri/basic.tf
+++ b/examples/resources/okta_app_oauth_redirect_uri/basic.tf
@@ -8,7 +8,9 @@ resource "okta_app_oauth" "test" {
   // Okta requires at least one redirect URI to create an app
   redirect_uris = ["myapp://callback"]
 
-  // Since Okta forces us to create it with a redirect URI we have to ignore future changes, they will be detected as config drift.
+  // Ignore redirect uris if you are going to manage them with the
+  // okta_app_oauth_redirect_uri resource and not have change detection on the
+  // app for that value.
   lifecycle {
     ignore_changes = [redirect_uris]
   }

--- a/examples/resources/okta_app_oauth_redirect_uri/basic_updated.tf
+++ b/examples/resources/okta_app_oauth_redirect_uri/basic_updated.tf
@@ -8,7 +8,9 @@ resource "okta_app_oauth" "test" {
   // Okta requires at least one redirect URI to create an app
   redirect_uris = ["myapp://callback"]
 
-  // Since Okta forces us to create it with a redirect URI we have to ignore future changes, they will be detected as config drift.
+  // Ignore redirect uris if you are going to manage them with the
+  // okta_app_oauth_redirect_uri resource and not have change detection on the
+  // app for that value.
   lifecycle {
     ignore_changes = [redirect_uris]
   }

--- a/okta/resource_okta_app_oauth_post_logout_redirect_uri.go
+++ b/okta/resource_okta_app_oauth_post_logout_redirect_uri.go
@@ -1,22 +1,16 @@
 package okta
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/okta/terraform-provider-okta/sdk"
 )
 
 func resourceAppOAuthPostLogoutRedirectURI() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAppOAuthPostLogoutRedirectURICreate,
-		ReadContext:   resourceFuncNoOp,
-		UpdateContext: resourceAppOAuthPostLogoutRedirectURIUpdate,
-		DeleteContext: resourceAppOAuthPostLogoutRedirectURIDelete,
-		// The id for this is the uri
-		Importer: createCustomNestedResourceImporter([]string{"app_id", "id"}, "Expecting the following format: <app_id>/<uri>"),
+		CreateContext: resourceAppOAuthRedirectURICreate("okta_app_oauth_post_logout_redirect_uri"),
+		ReadContext:   resourceAppOAuthRedirectURIRead("okta_app_oauth_post_logout_redirect_uri"),
+		UpdateContext: resourceAppOAuthRedirectURIUpdate("okta_app_oauth_post_logout_redirect_uri"),
+		DeleteContext: resourceAppOAuthRedirectURIDelete("okta_app_oauth_post_logout_redirect_uri"),
+		Importer:      createCustomNestedResourceImporter([]string{"app_id", "id"}, "Expecting the following format: <app_id>/<uri>"),
 		Schema: map[string]*schema.Schema{
 			"app_id": {
 				Required:    true,
@@ -31,70 +25,4 @@ func resourceAppOAuthPostLogoutRedirectURI() *schema.Resource {
 			},
 		},
 	}
-}
-
-func resourceAppOAuthPostLogoutRedirectURICreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	err := appendPostLogoutRedirectURI(ctx, d, m)
-	if err != nil {
-		return diag.Errorf("failed to create post logout redirect URI: %v", err)
-	}
-	d.SetId(d.Get("uri").(string))
-	return resourceFuncNoOp(ctx, d, m)
-}
-
-func resourceAppOAuthPostLogoutRedirectURIUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	if err := appendPostLogoutRedirectURI(ctx, d, m); err != nil {
-		return diag.Errorf("failed to update post logout redirect URI: %v", err)
-	}
-	// Normally not advisable, but ForceNew generated unnecessary calls
-	d.SetId(d.Get("uri").(string))
-	return resourceFuncNoOp(ctx, d, m)
-}
-
-func resourceAppOAuthPostLogoutRedirectURIDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	appID := d.Get("app_id").(string)
-
-	oktaMutexKV.Lock(appID)
-	defer oktaMutexKV.Unlock(appID)
-
-	app := sdk.NewOpenIdConnectApplication()
-	err := fetchAppByID(ctx, appID, m, app)
-	if err != nil {
-		return diag.Errorf("failed to get application: %v", err)
-	}
-	if app.Id == "" {
-		return diag.Errorf("application with id %s does not exist", appID)
-	}
-	if !contains(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id()) {
-		logger(m).Info(fmt.Sprintf("application with appID %s does not have post logout redirect URI %s", appID, d.Id()))
-		return nil
-	}
-	app.Settings.OauthClient.PostLogoutRedirectUris = remove(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id())
-	err = updateAppByID(ctx, appID, m, app)
-	if err != nil {
-		return diag.Errorf("failed to delete post logout redirect URI: %v", err)
-	}
-	return nil
-}
-
-func appendPostLogoutRedirectURI(ctx context.Context, d *schema.ResourceData, m interface{}) error {
-	appID := d.Get("app_id").(string)
-
-	oktaMutexKV.Lock(appID)
-	defer oktaMutexKV.Unlock(appID)
-
-	app := sdk.NewOpenIdConnectApplication()
-	if err := fetchAppByID(ctx, appID, m, app); err != nil {
-		return err
-	}
-	if app.Id == "" {
-		return fmt.Errorf("application with id %s does not exist", appID)
-	}
-	if contains(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id()) {
-		logger(m).Info(fmt.Sprintf("application with appID %s already has post logout redirect URI %s", appID, d.Id()))
-		return nil
-	}
-	uri := d.Get("uri").(string)
-	app.Settings.OauthClient.PostLogoutRedirectUris = append(app.Settings.OauthClient.PostLogoutRedirectUris, uri)
-	return updateAppByID(ctx, appID, m, app)
 }

--- a/okta/resource_okta_app_oauth_post_logout_redirect_uri.go
+++ b/okta/resource_okta_app_oauth_post_logout_redirect_uri.go
@@ -6,11 +6,12 @@ import (
 
 func resourceAppOAuthPostLogoutRedirectURI() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAppOAuthRedirectURICreate("okta_app_oauth_post_logout_redirect_uri"),
-		ReadContext:   resourceAppOAuthRedirectURIRead("okta_app_oauth_post_logout_redirect_uri"),
-		UpdateContext: resourceAppOAuthRedirectURIUpdate("okta_app_oauth_post_logout_redirect_uri"),
-		DeleteContext: resourceAppOAuthRedirectURIDelete("okta_app_oauth_post_logout_redirect_uri"),
-		Importer:      createCustomNestedResourceImporter([]string{"app_id", "id"}, "Expecting the following format: <app_id>/<uri>"),
+		DeprecationMessage: "managing the post logout redirect URI should be done directly on an oauth app resource",
+		CreateContext:      resourceAppOAuthRedirectURICreate("okta_app_oauth_post_logout_redirect_uri"),
+		ReadContext:        resourceAppOAuthRedirectURIRead("okta_app_oauth_post_logout_redirect_uri"),
+		UpdateContext:      resourceAppOAuthRedirectURIUpdate("okta_app_oauth_post_logout_redirect_uri"),
+		DeleteContext:      resourceAppOAuthRedirectURIDelete("okta_app_oauth_post_logout_redirect_uri"),
+		Importer:           createCustomNestedResourceImporter([]string{"app_id", "id"}, "Expecting the following format: <app_id>/<uri>"),
 		Schema: map[string]*schema.Schema{
 			"app_id": {
 				Required:    true,

--- a/okta/resource_okta_app_oauth_post_logout_redirect_uri_test.go
+++ b/okta/resource_okta_app_oauth_post_logout_redirect_uri_test.go
@@ -35,8 +35,8 @@ func TestAccResourceOktaAppOAuthApplication_postLogoutRedirectCrud(t *testing.T)
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
 					createPostLogoutRedirectURIExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "id", "https://www.example-updated.com"),
-					resource.TestCheckResourceAttr(resourceName, "uri", "https://www.example-updated.com"),
+					resource.TestCheckResourceAttr(resourceName, "id", "https://www.google-updated.com"),
+					resource.TestCheckResourceAttr(resourceName, "uri", "https://www.google-updated.com"),
 					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
 				),
 			},

--- a/okta/resource_okta_app_oauth_redirect_uri.go
+++ b/okta/resource_okta_app_oauth_redirect_uri.go
@@ -11,6 +11,7 @@ import (
 
 func resourceAppOAuthRedirectURI() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "managing the redirect URI should be done directly on an oauth app resource",
 		// NOTE: These CRUD contexts are flexible for use with resources
 		// okta_app_oauth_redirect_uri and
 		// okta_app_oauth_post_logout_redirect_uri

--- a/okta/resource_okta_app_oauth_redirect_uri.go
+++ b/okta/resource_okta_app_oauth_redirect_uri.go
@@ -11,12 +11,14 @@ import (
 
 func resourceAppOAuthRedirectURI() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAppOAuthRedirectURICreate,
-		ReadContext:   resourceFuncNoOp,
-		UpdateContext: resourceAppOAuthRedirectURIUpdate,
-		DeleteContext: resourceAppOAuthRedirectURIDelete,
-		// The id for this is the uri
-		Importer: createCustomNestedResourceImporter([]string{"app_id", "id"}, "Expecting the following format: <app_id>/<uri>"),
+		// NOTE: These CRUD contexts are flexible for use with resources
+		// okta_app_oauth_redirect_uri and
+		// okta_app_oauth_post_logout_redirect_uri
+		CreateContext: resourceAppOAuthRedirectURICreate("okta_app_oauth_redirect_uri"),
+		ReadContext:   resourceAppOAuthRedirectURIRead("okta_app_oauth_redirect_uri"),
+		UpdateContext: resourceAppOAuthRedirectURIUpdate("okta_app_oauth_redirect_uri"),
+		DeleteContext: resourceAppOAuthRedirectURIDelete("okta_app_oauth_redirect_uri"),
+		Importer:      createCustomNestedResourceImporter([]string{"app_id", "id"}, "Expecting the following format: <app_id>/<uri>"),
 		Schema: map[string]*schema.Schema{
 			"app_id": {
 				Required:    true,
@@ -33,51 +35,117 @@ func resourceAppOAuthRedirectURI() *schema.Resource {
 	}
 }
 
-func resourceAppOAuthRedirectURICreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	err := appendRedirectURI(ctx, d, m)
-	if err != nil {
-		return diag.Errorf("failed to create redirect URI: %v", err)
+func resourceAppOAuthRedirectURICreate(kind string) func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		d.SetId(d.Get("uri").(string))
+		err := appendRedirectURI(ctx, d, m, kind)
+		if err != nil {
+			return diag.Errorf("failed to create %q: %v", kind, err)
+		}
+		return resourceFuncNoOp(ctx, d, m)
 	}
-	d.SetId(d.Get("uri").(string))
-	return resourceFuncNoOp(ctx, d, m)
 }
 
-func resourceAppOAuthRedirectURIUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	if err := appendRedirectURI(ctx, d, m); err != nil {
-		return diag.Errorf("failed to update redirect URI: %v", err)
+func resourceAppOAuthRedirectURIRead(kind string) func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		aid, ok := d.GetOk("app_id")
+		if !ok || aid.(string) == "" {
+			return diag.Errorf("app_id not set on resource")
+
+		}
+		appID := aid.(string)
+
+		app := sdk.NewOpenIdConnectApplication()
+		if err := fetchAppByID(ctx, appID, m, app); err != nil {
+			return diag.Errorf("application %q not found: %q", appID, err)
+		}
+		if app.Id == "" {
+			return diag.Errorf("application with id %s does not exist", appID)
+		}
+
+		switch kind {
+		case "okta_app_oauth_redirect_uri":
+			if !contains(app.Settings.OauthClient.RedirectUris, d.Id()) {
+				return diag.Errorf("application %q does not have redirect uri %q", appID, d.Id())
+			}
+		case "okta_app_oauth_post_logout_redirect_uri":
+			if !contains(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id()) {
+				return diag.Errorf("application %q does not have post logout redirect uri %q", appID, d.Id())
+			}
+		default:
+			return diag.Errorf("unknown resource type %q", kind)
+		}
+
+		return resourceFuncNoOp(ctx, d, m)
 	}
-	// Normally not advisable, but ForceNew generated unnecessary calls
-	d.SetId(d.Get("uri").(string))
-	return resourceFuncNoOp(ctx, d, m)
 }
 
-func resourceAppOAuthRedirectURIDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	appID := d.Get("app_id").(string)
+func resourceAppOAuthRedirectURIUpdate(kind string) func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		if d.HasChange("app_id") {
+			return diag.Errorf("it is invalid to change the app_id of this resource once set")
+		}
+		if !d.HasChange("uri") {
+			return resourceFuncNoOp(ctx, d, m)
+		}
 
-	oktaMutexKV.Lock(appID)
-	defer oktaMutexKV.Unlock(appID)
+		o, n := d.GetChange("uri")
+		oldURI := o.(string)
+		newURI := n.(string)
 
-	app := sdk.NewOpenIdConnectApplication()
-	err := fetchAppByID(ctx, appID, m, app)
-	if err != nil {
-		return diag.Errorf("failed to get application: %v", err)
+		if newURI == "" {
+			return diag.Errorf("it is invalid to change uri to a blank value")
+		}
+		if err := changeOauthAppRedirectURI(ctx, d, m, kind, oldURI, newURI); err != nil {
+			return diag.Errorf("failed to update %q's uri: %v", kind, err)
+		}
+		d.SetId(newURI)
+		return resourceFuncNoOp(ctx, d, m)
 	}
-	if app.Id == "" {
-		return diag.Errorf("application with id %s does not exist", appID)
-	}
-	if !contains(app.Settings.OauthClient.RedirectUris, d.Id()) {
-		logger(m).Info(fmt.Sprintf("application with appID %s does not have redirect URI %s", appID, d.Id()))
-		return nil
-	}
-	app.Settings.OauthClient.RedirectUris = remove(app.Settings.OauthClient.RedirectUris, d.Id())
-	err = updateAppByID(ctx, appID, m, app)
-	if err != nil {
-		return diag.Errorf("failed to delete redirect URI: %v", err)
-	}
-	return nil
 }
 
-func appendRedirectURI(ctx context.Context, d *schema.ResourceData, m interface{}) error {
+func resourceAppOAuthRedirectURIDelete(kind string) func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		appID := d.Get("app_id").(string)
+
+		oktaMutexKV.Lock(appID)
+		defer oktaMutexKV.Unlock(appID)
+
+		app := sdk.NewOpenIdConnectApplication()
+		err := fetchAppByID(ctx, appID, m, app)
+		if err != nil {
+			return diag.Errorf("failed to get application: %v", err)
+		}
+		if app.Id == "" {
+			return diag.Errorf("application with id %s does not exist", appID)
+		}
+
+		switch kind {
+		case "okta_app_oauth_redirect_uri":
+			if !contains(app.Settings.OauthClient.RedirectUris, d.Id()) {
+				logger(m).Info(fmt.Sprintf("application with appID %s does not have redirect URI %s", appID, d.Id()))
+				return resourceFuncNoOp(ctx, d, m)
+			}
+			app.Settings.OauthClient.RedirectUris = remove(app.Settings.OauthClient.RedirectUris, d.Id())
+		case "okta_app_oauth_post_logout_redirect_uri":
+			if !contains(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id()) {
+				logger(m).Info(fmt.Sprintf("application with appID %s does not have post logout redirect URI %s", appID, d.Id()))
+				return resourceFuncNoOp(ctx, d, m)
+			}
+			app.Settings.OauthClient.PostLogoutRedirectUris = remove(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id())
+		default:
+			return diag.Errorf("unknown resource type %q", kind)
+		}
+
+		err = updateAppByID(ctx, appID, m, app)
+		if err != nil {
+			return diag.Errorf("failed to delete uri for %q: %v", kind, err)
+		}
+		return resourceFuncNoOp(ctx, d, m)
+	}
+}
+
+func appendRedirectURI(ctx context.Context, d *schema.ResourceData, m interface{}, uriType string) error {
 	appID := d.Get("app_id").(string)
 
 	oktaMutexKV.Lock(appID)
@@ -90,11 +158,57 @@ func appendRedirectURI(ctx context.Context, d *schema.ResourceData, m interface{
 	if app.Id == "" {
 		return fmt.Errorf("application with id %s does not exist", appID)
 	}
-	if contains(app.Settings.OauthClient.RedirectUris, d.Id()) {
-		logger(m).Info(fmt.Sprintf("application with appID %s already has redirect URI %s", appID, d.Id()))
-		return nil
-	}
+
 	uri := d.Get("uri").(string)
-	app.Settings.OauthClient.RedirectUris = append(app.Settings.OauthClient.RedirectUris, uri)
+	switch uriType {
+	case "okta_app_oauth_redirect_uri":
+		if contains(app.Settings.OauthClient.RedirectUris, d.Id()) {
+			logger(m).Info(fmt.Sprintf("application with appID %s already has redirect URI %s", appID, d.Id()))
+			return nil
+		}
+		app.Settings.OauthClient.RedirectUris = append(app.Settings.OauthClient.RedirectUris, uri)
+	case "okta_app_oauth_post_logout_redirect_uri":
+		if contains(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id()) {
+			logger(m).Info(fmt.Sprintf("application with appID %s already has post logout redirect URI %s", appID, d.Id()))
+			return nil
+		}
+		app.Settings.OauthClient.PostLogoutRedirectUris = append(app.Settings.OauthClient.PostLogoutRedirectUris, d.Id())
+	default:
+		return fmt.Errorf("unknown resource type %q", uriType)
+	}
+
+	return updateAppByID(ctx, appID, m, app)
+}
+
+// changeOauthAppRedirectURI will update the redirect uris on the given
+// application. toRemoveURI will be removed if it exists as a redirect uri on
+// the app and add toAddURI if it doesn't already exist as a redirect URI on the
+// app. Blank values are ignored. This function is intended for resources
+// okta_app_oauth_redirect_uri and okta_app_oauth_post_logout_redirect_uri
+func changeOauthAppRedirectURI(ctx context.Context, d *schema.ResourceData, m interface{}, uriType, toRemoveURI, toAddURI string) error {
+	appID := d.Get("app_id").(string)
+
+	oktaMutexKV.Lock(appID)
+	defer oktaMutexKV.Unlock(appID)
+
+	app := sdk.NewOpenIdConnectApplication()
+	if err := fetchAppByID(ctx, appID, m, app); err != nil {
+		return err
+	}
+	if app.Id == "" {
+		return fmt.Errorf("application with id %s does not exist", appID)
+	}
+
+	switch uriType {
+	case "okta_app_oauth_redirect_uri":
+		app.Settings.OauthClient.RedirectUris = appendUnique(app.Settings.OauthClient.RedirectUris, toAddURI)
+		app.Settings.OauthClient.RedirectUris = remove(app.Settings.OauthClient.RedirectUris, toRemoveURI)
+	case "okta_app_oauth_post_logout_redirect_uri":
+		app.Settings.OauthClient.PostLogoutRedirectUris = appendUnique(app.Settings.OauthClient.PostLogoutRedirectUris, toAddURI)
+		app.Settings.OauthClient.PostLogoutRedirectUris = remove(app.Settings.OauthClient.PostLogoutRedirectUris, toRemoveURI)
+	default:
+		return fmt.Errorf("unknown resource type %q", uriType)
+	}
+
 	return updateAppByID(ctx, appID, m, app)
 }

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -394,6 +394,21 @@ func remove(arr []string, el string) []string {
 	return newArr
 }
 
+// appendUnique appends el to arr if el isn't already present in arr
+func appendUnique(arr []string, el string) []string {
+	found := false
+	for _, item := range arr {
+		if item == el {
+			found = true
+			break
+		}
+	}
+	if found {
+		return arr
+	}
+	return append(arr, el)
+}
+
 // The best practices states that aggregate types should have error handling (think non-primitive). This will not attempt to set nil values.
 func setNonPrimitives(d *schema.ResourceData, valueMap map[string]interface{}) error {
 	for k, v := range valueMap {

--- a/okta/utils_test.go
+++ b/okta/utils_test.go
@@ -8,9 +8,45 @@ import (
 
 	"github.com/okta/terraform-provider-okta/sdk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func TestRemove(t *testing.T) {
+	tests := []struct {
+		elements []string
+		toRemove string
+		expected []string
+	}{
+		{[]string{"one", "two", "three"}, "dne", []string{"one", "two", "three"}},
+		{[]string{"one", "two", "three"}, "", []string{"one", "two", "three"}},
+		{[]string{"one", "two", "three"}, "one", []string{"two", "three"}},
+		{[]string{"one", "two", "three"}, "two", []string{"one", "three"}},
+		{[]string{"one", "two", "three"}, "three", []string{"one", "two"}},
+	}
+
+	for _, test := range tests {
+		result := remove(test.elements, test.toRemove)
+		require.Equal(t, test.expected, result)
+	}
+}
+
+func TestAppendUnique(t *testing.T) {
+	tests := []struct {
+		elements []string
+		toAdd    string
+		expected []string
+	}{
+		{[]string{"one", "two"}, "one", []string{"one", "two"}},
+		{[]string{"one", "two"}, "three", []string{"one", "two", "three"}},
+	}
+
+	for _, test := range tests {
+		result := appendUnique(test.elements, test.toAdd)
+		require.Equal(t, test.expected, result)
+	}
+}
 
 func TestContainsOne(t *testing.T) {
 	testArr := []string{"1", "2", "3"}

--- a/website/docs/r/app_oauth_post_logout_redirect_uri.html.markdown
+++ b/website/docs/r/app_oauth_post_logout_redirect_uri.html.markdown
@@ -38,7 +38,7 @@ resource "okta_app_oauth_post_logout_redirect_uri" "test" {
 
 ## Argument Reference
 
-- `app_id` - (Required) OAuth application ID.
+- `app_id` - (Required) OAuth application ID. Note: `app_id` can not be changed once set.
 
 - `uri` - (Required) Post Logout Redirect URI to append to Okta OIDC application.
 

--- a/website/docs/r/app_oauth_post_logout_redirect_uri.html.markdown
+++ b/website/docs/r/app_oauth_post_logout_redirect_uri.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 This resource allows you to manage post logout redirection URI for use in redirect-based flows.
 
+~> `okta_app_oauth_post_logout_redirect_uri` has been marked deprecated and will
+be removed in the v5 release of the provider. Operators should manage the post
+logout redirect URIs for an oauth app directly on that resource.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/app_oauth_redirect_uri.html.markdown
+++ b/website/docs/r/app_oauth_redirect_uri.html.markdown
@@ -36,7 +36,7 @@ resource "okta_app_oauth_redirect_uri" "test" {
 
 ## Argument Reference
 
-- `app_id` - (Required) OAuth application ID.
+- `app_id` - (Required) OAuth application ID. Note: `app_id` can not be changed once set.
 
 - `uri` - (Required) Redirect URI to append to Okta OIDC application.
 

--- a/website/docs/r/app_oauth_redirect_uri.html.markdown
+++ b/website/docs/r/app_oauth_redirect_uri.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 This resource allows you to manage redirection URI for use in redirect-based flows.
 
+~> `okta_app_oauth_redirect_uri` has been marked deprecated and will be removed
+in the v5 release of the provider. Operators should manage the redirect URIs for
+an oauth app directly on that resource.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Correcting resources `okta_app_oauth_post_logout_redirect_uri` and `okta_app_oauth_redirect_uri` which did not implement correct create/read/update/delete contexts for proper Terraform change detection.  DRY up common code between these two resources.

`okta_app_oauth_post_logout_redirect_uri` and `okta_app_oauth_redirect_uri` have been marked as deprecated. These convenience resources are outside of good design principles for Terraform plugins. The desired behavior exists on the owning oauth app resource and reduces potential for change drift side effects.

Closes #1283