### PR TITLE
Datasource `okta_org_metadata` incorrect value for `domains.organization`

### DIFF
--- a/okta/data_source_okta_org_metadata.go
+++ b/okta/data_source_okta_org_metadata.go
@@ -170,7 +170,7 @@ func (d *OrgMetadataDataSource) Read(ctx context.Context, req datasource.ReadReq
 		if ok {
 			href, ok := or.GetHrefOk()
 			if ok {
-				domains.Alternate = types.StringValue(*href)
+				domains.Organization = types.StringValue(*href)
 			}
 		}
 	}

--- a/okta/data_source_okta_org_metadata_test.go
+++ b/okta/data_source_okta_org_metadata_test.go
@@ -1,6 +1,8 @@
 package okta
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,6 +10,7 @@ import (
 
 func TestAccDataSourceOktaOrgMetadata_read(t *testing.T) {
 	mgr := newFixtureManager("data-sources", "okta_org_metadata", t.Name())
+	resourceName := fmt.Sprintf("data.%s.test", "okta_org_metadata")
 
 	oktaResourceTest(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),
@@ -17,9 +20,10 @@ func TestAccDataSourceOktaOrgMetadata_read(t *testing.T) {
 			{
 				Config: mgr.GetFixtures("datasource.tf", t),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.okta_org_metadata.test", "id"),
-					resource.TestCheckResourceAttrSet("data.okta_org_metadata.test", "pipeline"),
-					resource.TestCheckResourceAttrSet("data.okta_org_metadata.test", "settings.analytics_collection_enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "pipeline"),
+					resource.TestCheckResourceAttrSet(resourceName, "settings.analytics_collection_enabled"),
+					resource.TestCheckResourceAttr(resourceName, "domains.organization", fmt.Sprintf("https://%s.%s", os.Getenv("OKTA_ORG_NAME"), os.Getenv("OKTA_BASE_URL"))),
 				),
 			},
 		},

--- a/okta/data_source_okta_org_metadata_test.go
+++ b/okta/data_source_okta_org_metadata_test.go
@@ -11,6 +11,11 @@ import (
 func TestAccDataSourceOktaOrgMetadata_read(t *testing.T) {
 	mgr := newFixtureManager("data-sources", "okta_org_metadata", t.Name())
 	resourceName := fmt.Sprintf("data.%s.test", "okta_org_metadata")
+	var customDomain, customURI string
+	customDomain = os.Getenv("OKTA_ACC_TEST_CUSTOM_DOMAIN")
+	if customDomain != "" {
+		customURI = fmt.Sprintf("https://%s", customDomain)
+	}
 
 	oktaResourceTest(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),
@@ -24,6 +29,7 @@ func TestAccDataSourceOktaOrgMetadata_read(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "pipeline"),
 					resource.TestCheckResourceAttrSet(resourceName, "settings.analytics_collection_enabled"),
 					resource.TestCheckResourceAttr(resourceName, "domains.organization", fmt.Sprintf("https://%s.%s", os.Getenv("OKTA_ORG_NAME"), os.Getenv("OKTA_BASE_URL"))),
+					resource.TestCheckResourceAttr(resourceName, "domains.alternate", customURI),
 				),
 			},
 		},


### PR DESCRIPTION
Domain's organization value in org metadata was being set with the alternative value.

Closes #1804