### PR TITLE
New data sources

### DIFF
--- a/okta/app_filter.go
+++ b/okta/app_filter.go
@@ -67,3 +67,17 @@ func getAppFilters(d *schema.ResourceData) (*appFilters, error) {
 	}
 	return filters, nil
 }
+
+func getAppsFilters(d *schema.ResourceData) (*appFilters, error) {
+	label := d.Get("label").(string)
+	labelPrefix := d.Get("label_prefix").(string)
+
+	filters := &appFilters{
+		Label:       label,
+		LabelPrefix: labelPrefix,
+	}
+	if d.Get("active_only").(bool) {
+		filters.Status = fmt.Sprintf(`status eq "%s"`, statusActive)
+	}
+	return filters, nil
+}

--- a/okta/data_source_okta_admin_role_custom.go
+++ b/okta/data_source_okta_admin_role_custom.go
@@ -1,0 +1,73 @@
+package okta
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAdminRoleCustom() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAdminRoleCustomRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"label"},
+			},
+			"label": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"permissions": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAdminRoleCustomRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	var identifier string
+	if d.Get("id") != "" {
+		identifier = d.Get("id").(string)
+	} else if d.Get("label") != "" {
+		identifier = d.Get("label").(string)
+	} else {
+		return diag.Errorf("you must provide either an 'id' or a 'label' to retrieve a custom admin role")
+	}
+
+	role, _, err := getOktaV3ClientFromMetadata(m).RoleApi.GetRole(ctx, identifier).Execute()
+	if err != nil {
+		return diag.Errorf("failed to find custom admin role: %v", err)
+	}
+
+	permissionsResp, _, err := getOktaV3ClientFromMetadata(m).RoleApi.ListRolePermissions(ctx, identifier).Execute()
+	if err != nil {
+		return diag.Errorf("failed to list permissions for custom admin role: %v", err)
+	}
+
+	permissions := make([]interface{}, len(permissionsResp.Permissions))
+	for i := range permissionsResp.Permissions {
+		permissions[i] = *permissionsResp.Permissions[i].Label
+	}
+
+	if *role.Id != d.Id() {
+		d.SetId(*role.Id)
+	}
+	_ = d.Set("label", role.Label)
+	_ = d.Set("description", role.Description)
+	_ = d.Set("permissions", schema.NewSet(schema.HashString, permissions))
+
+	return nil
+}

--- a/okta/data_source_okta_admin_role_custom_test.go
+++ b/okta/data_source_okta_admin_role_custom_test.go
@@ -1,0 +1,56 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaAdminRoleCustom_read(t *testing.T) {
+	mgr := newFixtureManager("datasources", adminRoleCustom, t.Name())
+	roleCreate := adminRoleCustomResource
+	roleRead := fmt.Sprintf("%s%s", adminRoleCustomResource, adminRoleCustomDataSources)
+	resourceName := fmt.Sprintf("%s.test", adminRoleCustom)
+	dataSourceName := fmt.Sprintf("data.%s.test", adminRoleCustom)
+
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(roleCreate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "label", buildResourceName(mgr.Seed)),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test admin role"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(roleRead),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "label", buildResourceName(mgr.Seed)),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "Test admin role"),
+					resource.TestCheckResourceAttr(dataSourceName, "permissions.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+const adminRoleCustomResource = `
+resource "okta_admin_role_custom" "test" {
+	label       = "testAcc_replace_with_uuid"
+	description = "Test admin role"
+	permissions = ["okta.users.read"]
+}
+`
+
+const adminRoleCustomDataSources = `
+data "okta_admin_role_custom" "test" {
+	label = "testRole_replace_with_uuid"
+}
+`

--- a/okta/data_source_okta_apps.go
+++ b/okta/data_source_okta_apps.go
@@ -1,0 +1,104 @@
+package okta
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceApps() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppsRead,
+		Schema: map[string]*schema.Schema{
+			"active_only": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Search only active applications.",
+			},
+			"label": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"label_prefix"},
+				Description:   "Searches for applications whose label or name property matches this value exactly",
+			},
+			"label_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"label"},
+				Description:   "Searches for applications whose label or name property begins with this value",
+			},
+			"apps": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"label": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"links": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAppsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	filters, err := getAppsFilters(d)
+	if err != nil {
+		return diag.Errorf("invalid apps filters: %v", err)
+	}
+
+	appsResponse, err := listApps(ctx, getOktaClientFromMetadata(m), filters, 200)
+	if err != nil {
+		return diag.Errorf("failed to list apps: %v", err)
+	}
+	d.SetId(fmt.Sprintf("%d", crc32.ChecksumIEEE([]byte(filters.String()))))
+
+	if len(appsResponse) > 0 {
+		appsArr := []map[string]interface{}{}
+		for _, app := range appsResponse {
+			// Okta API for list apps uses a starts with query on label and name.
+			// This can yield unexpected results if an exact match is desired.
+			// If requested, drop apps that don't match the exact value.
+			if filters.Label != "" && app.Label != filters.Label && app.Name != filters.Label {
+				continue
+			}
+			links, _ := json.Marshal(app.Links)
+			app := map[string]interface{}{
+				"id":     app.Id,
+				"name":   app.Name,
+				"label":  app.Label,
+				"status": app.Status,
+				"links":  string(links),
+			}
+			appsArr = append(appsArr, app)
+		}
+		_ = d.Set("apps", appsArr)
+	} else {
+		_ = d.Set("apps", make([]map[string]interface{}, 0))
+	}
+
+	return nil
+}

--- a/okta/data_source_okta_apps_test.go
+++ b/okta/data_source_okta_apps_test.go
@@ -1,0 +1,88 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaApps_read(t *testing.T) {
+	mgr := newFixtureManager("datasources", apps, t.Name())
+	appsCreate := appsResources
+	appsRead := fmt.Sprintf("%s%s", appsResources, appsDataSources)
+
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(appsCreate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("okta_app_oauth.test1", "id"),
+					resource.TestCheckResourceAttrSet("okta_app_oauth.test2", "id"),
+					resource.TestCheckResourceAttrSet("okta_app_oauth.test3", "id"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(appsRead),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.okta_apps.test_by_exact_match", "apps.#", "1"),
+					resource.TestCheckResourceAttrSet("data.okta_apps.test_by_exact_match", "apps.#.id"),
+					resource.TestCheckResourceAttr("data.okta_apps.test_by_exact_match", "apps.#.label", fmt.Sprintf("testApp_%s_one", buildResourceName(mgr.Seed))),
+					resource.TestCheckResourceAttr("data.okta_apps.test_by_exact_match", "apps.#.status", statusActive),
+
+					resource.TestCheckResourceAttr("data.okta_apps.test_by_prefix", "apps.#", "2"),
+
+					resource.TestCheckResourceAttr("data.okta_apps.test_by_no_match", "apps.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const appsResources = `
+resource "okta_app_oauth" "test1" {
+	label          = "testApp_testAcc_replace_with_uuid_one"
+	type           = "web"
+	grant_types    = ["implicit", "authorization_code"]
+	redirect_uris  = ["http://a.com/"]
+	response_types = ["code", "token", "id_token"]
+	issuer_mode    = "ORG_URL"
+	consent_method = "TRUSTED"
+}
+resource "okta_app_oauth" "test2" {
+	label          = "testApp_testAcc_replace_with_uuid_two"
+	type           = "web"
+	grant_types    = ["implicit", "authorization_code"]
+	redirect_uris  = ["http://b.com/"]
+	response_types = ["code", "token", "id_token"]
+	issuer_mode    = "ORG_URL"
+	consent_method = "TRUSTED"
+}
+resource "okta_app_oauth" "test3" {
+	label          = "testAppInvalid_testAcc_replace_with_uuid"
+	type           = "web"
+	grant_types    = ["implicit", "authorization_code"]
+	redirect_uris  = ["http://c.com/"]
+	response_types = ["code", "token", "id_token"]
+	issuer_mode    = "ORG_URL"
+	consent_method = "TRUSTED"
+}
+`
+
+const appsDataSources = `
+
+data "okta_apps" "test_by_exact_match" {
+	label = "testApp_testAcc_replace_with_uuid_one"
+}
+  
+data "okta_apps" "test_by_prefix" {
+	label_prefix = "testApp_testAcc_replace_with_uuid_"
+}
+
+data "okta_apps" "test_by_no_match" {
+	label = "invalidApp_replace_with_uuid"
+}
+`

--- a/okta/data_source_okta_group_rules.go
+++ b/okta/data_source_okta_group_rules.go
@@ -1,0 +1,110 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/terraform-provider-okta/sdk"
+	"github.com/okta/terraform-provider-okta/sdk/query"
+)
+
+func dataSourceGroupRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGroupRulesRead,
+		Schema: map[string]*schema.Schema{
+			"name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": statusSchema,
+						"group_assignments": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"expression_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expression_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"users_excluded": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGroupRulesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	ruleName, nameOk := d.GetOk("name_prefix")
+	searchParams := &query.Params{Limit: 200}
+	if nameOk {
+		searchParams.Search = ruleName.(string)
+	}
+
+	rules, resp, err := getOktaClientFromMetadata(m).Group.ListGroupRules(ctx, searchParams)
+	if err != nil {
+		return diag.Errorf("failed to list group rules: %v", err)
+	}
+
+	for {
+		if resp.HasNextPage() {
+			var nextRules []*sdk.GroupRule
+			resp, err = resp.Next(ctx, &nextRules)
+			if err != nil {
+				return diag.Errorf("failed to list group rules: %v", err)
+			}
+			rules = append(rules, nextRules...)
+		} else {
+			break
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%d", crc32.ChecksumIEEE([]byte(searchParams.String()))))
+	rulesArr := make([]map[string]interface{}, len(rules))
+	for i := range rules {
+		rule := map[string]interface{}{
+			"id":     rules[i].Id,
+			"name":   rules[i].Name,
+			"status": rules[i].Status,
+		}
+
+		if rules[i].Conditions != nil {
+			rule["expression_type"] = rules[i].Conditions.Expression.Type
+			rule["expression_value"] = rules[i].Conditions.Expression.Value
+		}
+
+		if rules[i].Conditions.People != nil && rules[i].Conditions.People.Users != nil {
+			rule["users_excluded"] = convertStringSliceToSet(rules[i].Conditions.People.Users.Exclude)
+		}
+
+		rule["group_assignments"] = convertStringSliceToSet(rules[i].Actions.AssignUserToGroups.GroupIds)
+
+		rulesArr[i] = rule
+	}
+	_ = d.Set("rules", rulesArr)
+	return nil
+}

--- a/okta/data_source_okta_group_rules_test.go
+++ b/okta/data_source_okta_group_rules_test.go
@@ -1,0 +1,79 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaGroupRules_read(t *testing.T) {
+	mgr := newFixtureManager("datasources", groupRules, t.Name())
+	rulesCreate := groupAndRules
+	rulesRead := fmt.Sprintf("%s%s", groupAndRule, groupRuleDataSources)
+
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(rulesCreate),
+			},
+			{
+				Config: mgr.ConfigReplace(rulesRead),
+				Check: resource.ComposeTestCheckFunc(
+					// hack for eventual consistency on the group rule creation on Okta API side
+					sleepInSecondsForTest(2),
+
+					resource.TestCheckResourceAttr("data.okta_group_rules.test_by_exact_match", "rules.#", "1"),
+					resource.TestCheckResourceAttrSet("data.okta_group_rules.test_by_exact_match", "rules.#.id"),
+					resource.TestCheckResourceAttr("data.okta_group_rules.test_by_exact_match", "name", fmt.Sprintf("testRule_%s_one", buildResourceName(mgr.Seed))),
+					resource.TestCheckResourceAttr("data.okta_group_rules.test_by_exact_match", "status", "ACTIVE"),
+
+					resource.TestCheckResourceAttr("data.okta_group_rules.test_by_prefix", "rules.#", "2"),
+
+					resource.TestCheckResourceAttr("data.okta_group_rules.test_by_no_match", "rules.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const groupAndRules = `
+resource "okta_group" "test" {
+  name = "testAcc_replace_with_uuid"
+}
+
+resource "okta_group_rule" "test1" {
+  name              = "testRule_testAcc_replace_with_uuid_one"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.firstName,\"andy\")"
+}
+
+resource "okta_group_rule" "test2" {
+  name              = "testRule_testAcc_replace_with_uuid_two"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.firstName,\"andy\")"
+  depends_on        = [okta_group_rule.test1]
+}
+`
+
+const groupRulesDataSources = `
+
+data "okta_group_rules" "test_by_exact_match" {
+  name_prefix = "testRule_testAcc_replace_with_uuid_one"
+}
+
+data "okta_group_rules" "test_by_prefix" {
+  name_prefix = "testRule_testAcc_replace_with_uuid_"
+}
+
+data "okta_group_rules" "test_by_no_match" {
+  name_prefix = "invalidRule_replace_with_uuid"
+}
+`

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -329,6 +329,7 @@ func Provider() *schema.Provider {
 			userType:                      resourceUserType(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			adminRoleCustom:          dataSourceAdminRoleCustom(),
 			app:                      dataSourceApp(),
 			appGroupAssignments:      dataSourceAppGroupAssignments(),
 			appMetadataSaml:          dataSourceAppMetadataSaml(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -81,6 +81,7 @@ const (
 	groupMemberships              = "okta_group_memberships"
 	groupRole                     = "okta_group_role"
 	groupRule                     = "okta_group_rule"
+	groupRules                    = "okta_group_rules"
 	groups                        = "okta_groups"
 	groupSchemaProperty           = "okta_group_schema_property"
 	idpMetadataSaml               = "okta_idp_metadata_saml"
@@ -356,6 +357,7 @@ func Provider() *schema.Provider {
 			group:                    dataSourceGroup(),
 			groupEveryone:            dataSourceEveryoneGroup(),
 			groupRule:                dataSourceGroupRule(),
+			groupRules:               dataSourceGroupRules(),
 			groups:                   dataSourceGroups(),
 			idpMetadataSaml:          dataSourceIdpMetadataSaml(),
 			idpOidc:                  dataSourceIdpOidc(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -21,6 +21,7 @@ const (
 	adminRoleCustomAssignments    = "okta_admin_role_custom_assignments"
 	adminRoleTargets              = "okta_admin_role_targets"
 	app                           = "okta_app"
+	apps                          = "okta_apps"
 	appAutoLogin                  = "okta_app_auto_login"
 	appBasicAuth                  = "okta_app_basic_auth"
 	appBookmark                   = "okta_app_bookmark"
@@ -332,6 +333,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			adminRoleCustom:          dataSourceAdminRoleCustom(),
 			app:                      dataSourceApp(),
+			apps:                     dataSourceApps(),
 			appGroupAssignments:      dataSourceAppGroupAssignments(),
 			appMetadataSaml:          dataSourceAppMetadataSaml(),
 			appOAuth:                 dataSourceAppOauth(),

--- a/website/docs/d/admin_role_custom.html.markdown
+++ b/website/docs/d/admin_role_custom.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: 'okta'
+page_title: 'Okta: okta_admin_role_custom'
+sidebar_current: 'docs-okta-datasource-okta-admin-role-custom'
+description: |-
+    Get a custom admin role from Okta.
+---
+
+# okta_admin_role_custom
+
+Use this data source to retrieve a custom admin role from Okta.
+
+## Example Usage
+
+```hcl
+data "okta_admin_role_custom" "example" {
+  label       = "ExampleRole"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `id` - (Optional) The ID of the custom role to retrieve, conflicts with `label`.
+
+- `label` - (Optional) The name of the custom role to retrieve, conflicts with `id`.
+
+## Attributes Reference
+
+- `id` - The ID of the custom role.
+
+- `label` - The name of the custom role.
+
+- `description` - The human-readable description of the custom role.
+
+- `permissions` - The list of permissions that the custom role grants.

--- a/website/docs/d/app.html.markdown
+++ b/website/docs/d/app.html.markdown
@@ -20,14 +20,14 @@ data "okta_app" "example" {
 
 ## Arguments Reference
 
-- `label` - (Optional) The label of the app to retrieve, conflicts with `label_prefix` and `id`. Label uses
+- `label` - (Optional) The label or name of the app to retrieve, conflicts with `label_prefix` and `id`. Label uses
   the `?q=<label>` query parameter exposed by Okta's API. It should be noted that at this time the API searches both `name`
   and `label` with a [starts with query](https://developer.okta.com/docs/reference/api/apps/#list-applications) which
-  may result in multiple apps being returned for the query. The data source further inspects the lables looking for
+  may result in multiple apps being returned for the query. The data source further inspects the labels looking for
   an exact match.
 
-- `label_prefix` - (Optional) Label prefix of the app to retrieve, conflicts with `label` and `id`. This will tell the
-  provider to do a `starts with` query as opposed to an `equals` query.
+- `label_prefix` - (Optional) The label or name prefix of the app to retrieve, conflicts with `label` and `id`.
+  This will tell the provider to do a `starts with` query as opposed to an `equals` query.
 
 - `id` - (Optional) `id` of application to retrieve, conflicts with `label` and `label_prefix`.
 
@@ -42,5 +42,5 @@ data "okta_app" "example" {
 - `name` - Application name.
 
 - `status` - Application status.
- 
+
 - `links` - Generic JSON containing discoverable resources related to the app.

--- a/website/docs/d/apps.html.markdown
+++ b/website/docs/d/apps.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: 'okta' 
+page_title: 'Okta: okta_apps' 
+sidebar_current: 'docs-okta-datasource-apps' 
+description: |- 
+  List applications of any kind from Okta.
+---
+
+# okta_app
+
+Use this data source to list applications from Okta.
+
+## Example Usage
+
+```hcl
+data "okta_apps" "example" {
+  label_prefix = "Example App"
+}
+```
+
+## Arguments Reference
+
+- `label` - (Optional) The label or name of the apps to retrieve, conflicts with `label_prefix`. Both `label` and `label_prefix`
+  use the `?q=<label>` query parameter exposed by Okta's API. It should be noted that at this time the API searches both `name`
+  and `label` with a [starts with query](https://developer.okta.com/docs/reference/api/apps/#list-applications).
+  The data source further inspects the labels looking for an exact match when the `label` parameter is set.
+
+- `label_prefix` - (Optional) The label or name prefix of the apps to retrieve, conflicts with `label`. It should be noted that
+  Okta's API searches both the `label` and `name` application properties.
+
+- `active_only` - (Optional) tells the provider to query for only `ACTIVE` applications.
+
+## Attributes Reference
+
+- `apps` - collection of applications retrieved from Okta with the following properties.
+
+  - `id` - Application ID.
+
+  - `label` - Application label.
+
+  - `name` - Application name.
+
+  - `status` - Application status.
+
+  - `links` - Generic JSON containing discoverable resources related to the app.

--- a/website/docs/d/group_rules.html.markdown
+++ b/website/docs/d/group_rules.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "okta"
+page_title: "Okta: okta_group_rules"
+sidebar_current: "docs-okta-datasource-group-rules"
+description: |- Get a list of group rules from Okta.
+---
+
+# okta_group_rules
+
+Use this data source to retrieve a list of group rules from Okta.
+
+## Example Usage
+
+```hcl
+data "okta_group_rules" "department_rules" {
+  name_prefix = "Rule-Department-"
+}
+```
+
+## Arguments Reference
+
+- `name_prefix` - (Optional) The name prefix of the target Group Rule(s).
+
+## Attributes Reference
+
+- `rules` - collection of group rules retrieved from Okta with the following properties.
+
+  - `id` - The ID of the Group Rule.
+
+  - `name` - The name of the Group Rule.
+
+  - `group_assignments` - The list of group ids to assign the users to.
+
+  - `expression_type` - The expression type to use to invoke the rule.
+
+  - `expression_value` - The expression value.
+
+  - `status` - The status of the group rule.
+
+  - `users_excluded` - The list of user IDs that would be excluded when rules are processed.


### PR DESCRIPTION
Sorry for the multiple resource PR, I caught that in the contribution guidelines when creating the PR, I'll keep that in mind for future contributions, and I can cherry pick these into three PRs if you prefer.

Adds the following data sources:

- `okta_apps` closes #1528  
  - Includes doc and ACC tests for 0/1/2 results.
- `okta_custom_admin_role` closes #1523 
  - Includes doc and ACC test.
- `okta_group_rules`
  - Includes doc and ACC tests for 0/1/2 results.
