### PR TITLE
fix risk_score default broke customer without FF

### DIFF
--- a/examples/resources/okta_app_signon_policy_rule/default.tf
+++ b/examples/resources/okta_app_signon_policy_rule/default.tf
@@ -1,0 +1,34 @@
+resource "okta_app_saml" "test" {
+  label                     = "testAcc_replace_with_uuid"
+  sso_url                   = "http://google.com"
+  recipient                 = "http://here.com"
+  destination               = "http://its-about-the-journey.com"
+  audience                  = "http://audience.com"
+  subject_name_id_template  = "$${user.userName}"
+  subject_name_id_format    = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+  response_signed           = true
+  signature_algorithm       = "RSA_SHA256"
+  digest_algorithm          = "SHA256"
+  honor_force_authn         = false
+  authn_context_class_ref   = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+  single_logout_issuer      = "https://dunshire.okta.com"
+  single_logout_url         = "https://dunshire.okta.com/logout"
+  single_logout_certificate = "MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"
+
+  attribute_statements {
+    type         = "GROUP"
+    name         = "groups"
+    filter_type  = "REGEX"
+    filter_value = ".*"
+  }
+}
+
+data "okta_app_signon_policy" "test" {
+  app_id = okta_app_saml.test.id
+}
+
+resource "okta_app_signon_policy_rule" "test" {
+  policy_id = data.okta_app_signon_policy.test.id
+  name      = "testAcc_replace_with_uuid"
+}
+

--- a/okta/resource_okta_app_signon_policy_rule.go
+++ b/okta/resource_okta_app_signon_policy_rule.go
@@ -189,7 +189,7 @@ func resourceAppSignOnPolicyRule() *schema.Resource {
 			"risk_score": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "ANY",
+				Computed:    true,
 				Description: "The risk score specifies a particular level of risk to match on: ANY, LOW, MEDIUM, HIGH",
 			},
 		},
@@ -384,9 +384,12 @@ func buildAppSignOnPolicyRule(d *schema.ResourceData) sdk.AccessPolicyRule {
 		ElCondition: &sdk.AccessPolicyRuleCustomCondition{
 			Condition: d.Get("custom_expression").(string),
 		},
-		RiskScore: &sdk.RiskScorePolicyRuleCondition{
-			Level: d.Get("risk_score").(string),
-		},
+	}
+	riskScore, ok := d.GetOk("risk_score")
+	if ok {
+		rule.Conditions.RiskScore = &sdk.RiskScorePolicyRuleCondition{
+			Level: riskScore.(string),
+		}
 	}
 	isRegistered, ok := d.GetOk("device_is_registered")
 	if ok && isRegistered.(bool) {

--- a/okta/resource_okta_app_signon_policy_rule_test.go
+++ b/okta/resource_okta_app_signon_policy_rule_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// TODO unable to run the test due to conflict providerFactories between plugin and framework
 func TestAccResourceOktaAppSignOnPolicyRule(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.test", appSignOnPolicyRule)
 	mgr := newFixtureManager("resources", appSignOnPolicyRule, t.Name())
@@ -311,4 +310,43 @@ func validateOktaAppSignonPolicyRuleConstraintsAreSet(rule string, constraints [
 
 		return nil
 	}
+}
+
+func TestAccResourceOktaAppSignOnPolicyRuleDefault(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.test", appSignOnPolicyRule)
+	mgr := newFixtureManager("resources", appSignOnPolicyRule, t.Name())
+	config := mgr.GetFixtures("default.tf", t)
+
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: testAccMergeProvidersFactories,
+		CheckDestroy:             checkAppSignOnPolicyRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", buildResourceName(mgr.Seed)),
+					resource.TestCheckResourceAttr(resourceName, "status", statusActive),
+					resource.TestCheckResourceAttrSet(resourceName, "priority"),
+					resource.TestCheckResourceAttr(resourceName, "access", "ALLOW"),
+					resource.TestCheckResourceAttr(resourceName, "factor_mode", "2FA"),
+					resource.TestCheckResourceAttr(resourceName, "groups_excluded.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "groups_included.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "device_assurances_included.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "user_types_excluded.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "user_types_included.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "users_excluded.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "users_included.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_includes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_excludes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_connection", "ANYWHERE"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "re_authentication_frequency", "PT2H"),
+					resource.TestCheckResourceAttr(resourceName, "inactivity_period", "PT1H"),
+					resource.TestCheckResourceAttr(resourceName, "risk_score", "ANY"),
+				),
+			},
+		},
+	})
 }


### PR DESCRIPTION
The introduction of risk_score default value ANY in terraform provider has broken many customer who do not have that feature flag
The removal of the risk_score default in terraform provider will be compensated through the API default
Close #1802 