### PR TITLE
resource `okta_brand`'s `email_domain_id` is an attribute, not an argument

### DIFF
--- a/okta/resource_okta_brand.go
+++ b/okta/resource_okta_brand.go
@@ -67,7 +67,6 @@ func (r *brandResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"email_domain_id": schema.StringAttribute{
 				Description: "Email Domain ID tied to this brand",
-				Optional:    true,
 				Computed:    true,
 			},
 			"locale": schema.StringAttribute{
@@ -335,7 +334,6 @@ func buildUpdateBrandRequest(model brandResourceModel) (okta.BrandRequest, error
 		AgreeToCustomPrivacyPolicy: model.AgreeToCustomPrivacyPolicy.ValueBoolPointer(),
 		CustomPrivacyPolicyUrl:     model.CustomPrivacyPolicyURL.ValueStringPointer(),
 		DefaultApp:                 defaultApp,
-		EmailDomainId:              model.EmailDomainID.ValueStringPointer(),
 		Locale:                     model.Locale.ValueStringPointer(),
 		RemovePoweredByOkta:        model.RemovePoweredByOkta.ValueBoolPointer(),
 	}, nil

--- a/okta/resource_okta_brand.go
+++ b/okta/resource_okta_brand.go
@@ -68,6 +68,7 @@ func (r *brandResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"email_domain_id": schema.StringAttribute{
 				Description: "Email Domain ID tied to this brand",
 				Optional:    true,
+				Computed:    true,
 			},
 			"locale": schema.StringAttribute{
 				Description: "The language specified as an IETF BCP 47 language tag",

--- a/okta/resource_okta_brand_test.go
+++ b/okta/resource_okta_brand_test.go
@@ -1,49 +1,55 @@
 package okta
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccResourceOktaBrandCRUD(t *testing.T) {
+	mgr := newFixtureManager("resources", brand, t.Name())
+	resourceName := fmt.Sprintf("%s.test", brand)
+	step1 := `
+resource okta_brand test{
+	name = "testAcc-replace_with_uuid"
+	locale = "en"
+}`
+	step2 := `
+resource okta_brand test{
+	name = "testAcc-changed-replace_with_uuid"
+	agree_to_custom_privacy_policy = true
+	custom_privacy_policy_url = "https://example.com"
+	locale = "es"
+	remove_powered_by_okta = true
+}`
 	oktaResourceTest(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),
 		ErrorCheck:               testAccErrorChecks(t),
 		ProtoV5ProviderFactories: testAccMergeProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: `resource okta_brand test{
-					name = "test"
-					locale = "en"
-				}`,
+				Config: mgr.ConfigReplace(step1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("okta_brand.test", "name", "test"),
-					resource.TestCheckResourceAttr("okta_brand.test", "agree_to_custom_privacy_policy", "false"),
-					resource.TestCheckNoResourceAttr("okta_brand.test", "custom_privacy_policy_url"),
-					resource.TestCheckNoResourceAttr("okta_brand.test", "email_domain_id"),
-					resource.TestCheckResourceAttr("okta_brand.test", "is_default", "false"),
-					resource.TestCheckResourceAttr("okta_brand.test", "locale", "en"),
-					resource.TestCheckResourceAttr("okta_brand.test", "remove_powered_by_okta", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc-%d", mgr.Seed)),
+					resource.TestCheckResourceAttr(resourceName, "agree_to_custom_privacy_policy", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "custom_privacy_policy_url"),
+					resource.TestCheckNoResourceAttr(resourceName, "email_domain_id"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+					resource.TestCheckResourceAttr(resourceName, "locale", "en"),
+					resource.TestCheckResourceAttr(resourceName, "remove_powered_by_okta", "false"),
 				),
 			},
 			{
-				Config: `					
-				resource okta_brand test{
-					name = "test2"
-					agree_to_custom_privacy_policy = true
-					custom_privacy_policy_url = "https://example.com"
-					locale = "es"
-					remove_powered_by_okta = true
-				}`,
+				Config: mgr.ConfigReplace(step2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("okta_brand.test", "name", "test2"),
-					resource.TestCheckResourceAttr("okta_brand.test", "agree_to_custom_privacy_policy", "true"),
-					resource.TestCheckResourceAttr("okta_brand.test", "custom_privacy_policy_url", "https://example.com"),
-					resource.TestCheckResourceAttr("okta_brand.test", "locale", "es"),
-					resource.TestCheckNoResourceAttr("okta_brand.test", "email_domain_id"),
-					resource.TestCheckResourceAttr("okta_brand.test", "remove_powered_by_okta", "true"),
-					resource.TestCheckNoResourceAttr("okta_brand.test", "default_app_app_instance_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc-changed-%d", mgr.Seed)),
+					resource.TestCheckResourceAttr(resourceName, "agree_to_custom_privacy_policy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "custom_privacy_policy_url", "https://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "locale", "es"),
+					resource.TestCheckNoResourceAttr(resourceName, "email_domain_id"),
+					resource.TestCheckResourceAttr(resourceName, "remove_powered_by_okta", "true"),
+					resource.TestCheckNoResourceAttr(resourceName, "default_app_app_instance_id"),
 				),
 			},
 		},

--- a/website/docs/r/brand.html.markdown
+++ b/website/docs/r/brand.html.markdown
@@ -25,8 +25,6 @@ resource "okta_brand" "example" {
 
 - `name` - (Required) Name of the brand
 
-- `email_domain_id` - (Optional) Email Domain ID tied to this brand
-
 - `locale` - (Optional) The language specified as an IETF BCP 47 language tag
 
 
@@ -45,6 +43,8 @@ resource "okta_brand" "example" {
 - `default_app_classic_application_uri` - (Optional) Default app classic application uri
 
 ## Attributes Reference
+
+- `email_domain_id` - (Read-only) Email Domain ID tied to this brand
 
 - `id` - (Read-only) Brand ID
 


### PR DESCRIPTION
 `email_domain_id` is a computed attribute of resource `otka_brand`, not an argument.

Closes #1824