### PR TITLE
Adding CHROMEOS to signon policy rule on docs

### DIFF
--- a/website/docs/r/app_signon_policy_rule.html.markdown
+++ b/website/docs/r/app_signon_policy_rule.html.markdown
@@ -238,6 +238,10 @@ resource "okta_app_signon_policy_rule" "test" {
     os_type = "WINDOWS"
     type    = "DESKTOP"
   }
+  platform_include {
+    os_type = "CHROMEOS"
+    type    = "DESKTOP"
+  }
   priority                               = 98
   re_authentication_frequency            = "PT43800H"
   type                                   = "ASSURANCE"
@@ -312,7 +316,7 @@ The following arguments are supported:
 - `platform_include` - (Optional) List of particular platforms or devices to match on.
     - `type` - (Optional) One of: `"ANY"`, `"MOBILE"`, `"DESKTOP"`
     - `os_expression` - (Optional) Only available and required when using `os_type = "OTHER"`
-    - `os_type` - (Optional) One of: `"ANY"`, `"IOS"`, `"WINDOWS"`, `"ANDROID"`, `"OTHER"`, `"OSX"`, `"MACOS"`
+    - `os_type` - (Optional) One of: `"ANY"`, `"IOS"`, `"WINDOWS"`, `"ANDROID"`, `"OTHER"`, `"OSX"`, `"MACOS"`, `"CHROMEOS"`
 
 - `custom_expression` - (Optional) This is an advanced optional setting. If the expression is formatted incorrectly or conflicts with conditions set above, the rule may not match any users.
 


### PR DESCRIPTION
CHROMEOS is not included on the platform_include stanza or Argument Reference section, yet it's supported by the API, and in the [examples file](https://github.com/okta/terraform-provider-okta/blob/edb27b546b8662b6458a5be896f87ff04de874bb/examples/resources/okta_app_signon_policy_rule/basic_updated.tf#L121)