### PR TITLE
fix(docs): Typos in input descriptions

### DIFF
--- a/docs/data-sources/app_saml.md
+++ b/docs/data-sources/app_saml.md
@@ -60,7 +60,7 @@ data "okta_app_saml" "example" {
 - `recipient` (String) The location where the app may present the SAML assertion
 - `response_signed` (Boolean) Determines whether the SAML auth response message is digitally signed
 - `saml_signed_request_enabled` (Boolean) SAML Signed Request enabled
-- `signature_algorithm` (String) Signature algorithm used ot digitally sign the assertion and response
+- `signature_algorithm` (String) Signature algorithm used to digitally sign the assertion and response
 - `single_logout_certificate` (String) x509 encoded certificate that the Service Provider uses to sign Single Logout requests
 - `single_logout_issuer` (String) The issuer of the Service Provider that generates the Single Logout request
 - `single_logout_url` (String) The location where the logout response is sent

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -42,7 +42,7 @@ data "okta_user" "example" {
 
 ### Optional
 
-- `compound_search_operator` (String) Search operator used when joining mulitple search clauses
+- `compound_search_operator` (String) Search operator used when joining multiple search clauses
 - `delay_read_seconds` (String) Force delay of the user read by N seconds. Useful when eventual consistency of user information needs to be allowed for.
 - `search` (Block Set) Filter to find user/users. Each filter will be concatenated with the compound search operator. Please be aware profile properties must match what is in Okta, which is likely camel case. Expression is a free form expression filter https://developer.okta.com/docs/reference/core-okta-api/#filter . The set name/value/comparison properties will be ignored if expression is present (see [below for nested schema](#nestedblock--search))
 - `skip_groups` (Boolean) Do not populate user groups information (prevents additional API call)

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -50,7 +50,7 @@ data "okta_users" "example" {
 
 ### Optional
 
-- `compound_search_operator` (String) Search operator used when joining mulitple search clauses
+- `compound_search_operator` (String) Search operator used when joining multiple search clauses
 - `delay_read_seconds` (String) Force delay of the users read by N seconds. Useful when eventual consistency of users information needs to be allowed for.
 - `group_id` (String) Find users based on group membership using the id of the group.
 - `include_groups` (Boolean) Fetch group memberships for each user

--- a/docs/resources/app_saml.md
+++ b/docs/resources/app_saml.md
@@ -51,7 +51,7 @@ description: |-
 - `response_signed` (Boolean) Determines whether the SAML auth response message is digitally signed
 - `saml_signed_request_enabled` (Boolean) SAML Signed Request enabled
 - `saml_version` (String) SAML version for the app's sign-on mode
-- `signature_algorithm` (String) Signature algorithm used ot digitally sign the assertion and response
+- `signature_algorithm` (String) Signature algorithm used to digitally sign the assertion and response
 - `single_logout_certificate` (String) x509 encoded certificate that the Service Provider uses to sign Single Logout requests
 - `single_logout_issuer` (String) The issuer of the Service Provider that generates the Single Logout request
 - `single_logout_url` (String) The location where the logout response is sent

--- a/docs/resources/policy_device_assurance_android.md
+++ b/docs/resources/policy_device_assurance_android.md
@@ -23,7 +23,7 @@ Manages device assurance on policy
 - `jailbreak` (Boolean) The device jailbreak. Only for android and iOS platform
 - `os_version` (String) The device os minimum version
 - `screenlock_type` (Set of String) List of screenlock type, can be BIOMETRIC or BIOMETRIC, PASSCODE
-- `secure_hardware_present` (Boolean) Indicates if the device constains a secure hardware functionality
+- `secure_hardware_present` (Boolean) Indicates if the device contains a secure hardware functionality
 
 ### Read-Only
 

--- a/docs/resources/policy_device_assurance_macos.md
+++ b/docs/resources/policy_device_assurance_macos.md
@@ -22,7 +22,7 @@ Manages device assurance on policy
 - `disk_encryption_type` (Set of String) List of disk encryption type, can be ALL_INTERNAL_VOLUMES
 - `os_version` (String) The device os minimum version
 - `screenlock_type` (Set of String) List of screenlock type, can be BIOMETRIC or BIOMETRIC, PASSCODE
-- `secure_hardware_present` (Boolean) Indicates if the device constains a secure hardware functionality
+- `secure_hardware_present` (Boolean) Indicates if the device contains a secure hardware functionality
 - `third_party_signal_providers` (Boolean) Check to include third party signal provider
 - `tpsp_browser_version` (String) Third party signal provider minimum browser version
 - `tpsp_builtin_dns_client_enabled` (Boolean) Third party signal provider builtin dns client enable

--- a/docs/resources/policy_device_assurance_windows.md
+++ b/docs/resources/policy_device_assurance_windows.md
@@ -22,7 +22,7 @@ Manages device assurance on policy
 - `disk_encryption_type` (Set of String) List of disk encryption type, can be ALL_INTERNAL_VOLUMES
 - `os_version` (String) The device os minimum version
 - `screenlock_type` (Set of String) List of screenlock type, can be BIOMETRIC or BIOMETRIC, PASSCODE
-- `secure_hardware_present` (Boolean) Indicates if the device constains a secure hardware functionality
+- `secure_hardware_present` (Boolean) Indicates if the device contains a secure hardware functionality
 - `third_party_signal_providers` (Boolean) Check to include third party signal provider
 - `tpsp_browser_version` (String) Third party signal provider minimum browser version
 - `tpsp_builtin_dns_client_enabled` (Boolean) Third party signal provider builtin dns client enable

--- a/okta/data_source_okta_app_saml.go
+++ b/okta/data_source_okta_app_saml.go
@@ -136,7 +136,7 @@ func dataSourceAppSaml() *schema.Resource {
 			"signature_algorithm": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Signature algorithm used ot digitally sign the assertion and response",
+				Description: "Signature algorithm used to digitally sign the assertion and response",
 			},
 			"digest_algorithm": {
 				Type:        schema.TypeString,

--- a/okta/data_source_okta_user.go
+++ b/okta/data_source_okta_user.go
@@ -64,7 +64,7 @@ func dataSourceUser() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "and",
-				Description: "Search operator used when joining mulitple search clauses",
+				Description: "Search operator used when joining multiple search clauses",
 			},
 			"delay_read_seconds": {
 				Type:        schema.TypeString,

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -62,7 +62,7 @@ func dataSourceUsers() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "and",
-				Description: "Search operator used when joining mulitple search clauses",
+				Description: "Search operator used when joining multiple search clauses",
 			},
 			"delay_read_seconds": {
 				Type:        schema.TypeString,

--- a/okta/resource_okta_app_saml.go
+++ b/okta/resource_okta_app_saml.go
@@ -257,7 +257,7 @@ func resourceAppSaml() *schema.Resource {
 			"signature_algorithm": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Signature algorithm used ot digitally sign the assertion and response",
+				Description: "Signature algorithm used to digitally sign the assertion and response",
 			},
 			"digest_algorithm": {
 				Type:        schema.TypeString,

--- a/okta/resource_okta_policy_device_assurance_android_os.go
+++ b/okta/resource_okta_policy_device_assurance_android_os.go
@@ -112,7 +112,7 @@ func (r *policyDeviceAssuranceAndroidResource) Schema(_ context.Context, _ resou
 				},
 			},
 			"secure_hardware_present": schema.BoolAttribute{
-				Description: "Indicates if the device constains a secure hardware functionality",
+				Description: "Indicates if the device contains a secure hardware functionality",
 				Optional:    true,
 				Validators: []validator.Bool{
 					boolvalidator.AtLeastOneOf(path.Expressions{

--- a/okta/resource_okta_policy_device_assurance_macos_os.go
+++ b/okta/resource_okta_policy_device_assurance_macos_os.go
@@ -111,7 +111,7 @@ func (r *policyDeviceAssuranceMacOSResource) Schema(_ context.Context, _ resourc
 				},
 			},
 			"secure_hardware_present": schema.BoolAttribute{
-				Description: "Indicates if the device constains a secure hardware functionality",
+				Description: "Indicates if the device contains a secure hardware functionality",
 				Optional:    true,
 				Validators: []validator.Bool{
 					boolvalidator.AtLeastOneOf(path.Expressions{

--- a/okta/resource_okta_policy_device_assurance_windows_os.go
+++ b/okta/resource_okta_policy_device_assurance_windows_os.go
@@ -117,7 +117,7 @@ func (r *policyDeviceAssuranceWindowsResource) Schema(_ context.Context, _ resou
 				},
 			},
 			"secure_hardware_present": schema.BoolAttribute{
-				Description: "Indicates if the device constains a secure hardware functionality",
+				Description: "Indicates if the device contains a secure hardware functionality",
 				Optional:    true,
 				Validators: []validator.Bool{
 					boolvalidator.AtLeastOneOf(path.Expressions{

--- a/website/docs/d/app_saml.html.markdown
+++ b/website/docs/d/app_saml.html.markdown
@@ -98,7 +98,7 @@ data "okta_app_saml" "example" {
 
 - `saml_signed_request_enabled` - SAML Signed Request enabled
 
-- `signature_algorithm` - Signature algorithm used ot digitally sign the assertion and response.
+- `signature_algorithm` - Signature algorithm used to digitally sign the assertion and response.
 
 - `single_logout_certificate` - x509 encoded certificate that the Service Provider uses to sign Single Logout requests.
 

--- a/website/docs/r/app_saml.html.markdown
+++ b/website/docs/r/app_saml.html.markdown
@@ -244,7 +244,7 @@ The following arguments are supported:
 
 - `saml_version` - (Optional) SAML version for the app's sign-on mode. Valid values are: `"2.0"` or `"1.1"`. Default is `"2.0"`.
 
-- `signature_algorithm` - (Optional) Signature algorithm used ot digitally sign the assertion and response.
+- `signature_algorithm` - (Optional) Signature algorithm used to digitally sign the assertion and response.
 
 - `single_logout_certificate` - (Optional) x509 encoded certificate that the Service Provider uses to sign Single Logout requests.  Note: should be provided without `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`, see [official documentation](https://developer.okta.com/docs/reference/api/apps/#service-provider-certificate).
 


### PR DESCRIPTION
This PR fixes multiple typos in provider resources.  I've supplied the fix both to the go, and the relevant generated Markdown files.

I do not see some of these resources in the published provider v4.7 in the TF registry (from [19 days ago](https://registry.terraform.io/providers/okta/okta/latest/docs)), so some may be pending or not ready yet?

A local make test for GoLang runs cleanly, though I've not fully previewed the docs locally.

This is my first contrib; welcome feedback!

PS: I've not signed the Okta CLA, but believe this falls in the ["obvious fix" (typo) category](https://developer.okta.com/cla/).