### PR TITLE
Update api management role_type documentation

### DIFF
--- a/website/docs/d/role_subscription.html.markdown
+++ b/website/docs/d/role_subscription.html.markdown
@@ -22,7 +22,7 @@ data "okta_role_subscription" "example" {
 ## Arguments Reference
 
 - `role_type` - (Required) Type of the role. Valid values:
-  `"API_ADMIN"`,
+  `"API_ACCESS_MANAGEMENT_ADMIN"`,
   `"APP_ADMIN"`,
   `"CUSTOM"`,
   `"GROUP_MEMBERSHIP_ADMIN"`,

--- a/website/docs/r/group_role.html.markdown
+++ b/website/docs/r/group_role.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 - `group_id` - (Required) The ID of group to attach admin roles to.
 
 - `role_type` - (Required) Admin role assigned to the group. It can be any one of the following values:
-  `"API_ADMIN"`,
+  `"API_ACCESS_MANAGEMENT_ADMIN"`,
   `"APP_ADMIN"`,
   `"CUSTOM"`,
   `"GROUP_MEMBERSHIP_ADMIN"`,

--- a/website/docs/r/role_subscription.html.markdown
+++ b/website/docs/r/role_subscription.html.markdown
@@ -25,7 +25,7 @@ resource "okta_role_subscription" "test" {
 ## Argument Reference
 
 - `role_type` - (Required) Type of the role. Valid values:
-  `"API_ADMIN"`,
+  `"API_ACCESS_MANAGEMENT_ADMIN"`,
   `"APP_ADMIN"`,
   `"CUSTOM"`,
   `"GROUP_MEMBERSHIP_ADMIN"`,


### PR DESCRIPTION
Based on this documentation https://developer.okta.com/docs/reference/api/roles/#role-types The role_type for API admin is now called `API_ACCESS_MANAGEMENT_ADMIN` instead of `API_ADMIN`