### PR TITLE
Fix typo on okta_brand resource

### DIFF
--- a/website/docs/r/brand.html.markdown
+++ b/website/docs/r/brand.html.markdown
@@ -27,9 +27,6 @@ resource "okta_brand" "example" {
 
 - `locale` - (Optional) The language specified as an IETF BCP 47 language tag
 
-
-- `name` - (Required) Name of the brand
-
 - `agree_to_custom_privacy_policy` - (Optional) Is a required input flag with when changing custom_privacy_url, shouldn't be considered as a readable property
 
 - `custom_privacy_policy_url` - (Optional) Custom privacy policy URL


### PR DESCRIPTION
- Remove the duplicated description of the input variable `name`.