### PR TITLE
fix crash when creating resource set from devices

### DIFF
--- a/okta/resource_okta_resource_set.go
+++ b/okta/resource_okta_resource_set.go
@@ -142,9 +142,12 @@ func flattenResourceSetResources(resources []*sdk.ResourceSetResource) *schema.S
 			links := res.Links.(map[string]interface{})
 			var url string
 			for _, v := range links {
-				for _, link := range v.(map[string]interface{}) {
-					url = link.(string)
-					break
+				_, ok := v.(map[string]interface{})
+				if ok {
+					for _, link := range v.(map[string]interface{}) {
+						url = link.(string)
+						break
+					}
 				}
 			}
 			arr = append(arr, url)


### PR DESCRIPTION
There is no links to self when create resource set from devices, causes the crash

```
"_links": {
   "self": null
}
```