### PR TITLE
Update provider_test.go

### DIFF
--- a/okta/provider_test.go
+++ b/okta/provider_test.go
@@ -748,6 +748,9 @@ type vcrManager struct {
 }
 
 func skipVCRTest(t *testing.T) bool {
-	t.Skipf("test %q is not VCR compatible", t.Name())
-	return os.Getenv("OKTA_VCR_TF_ACC") != ""
+	skip := os.Getenv("OKTA_VCR_TF_ACC") != ""
+	if skip {
+		t.Skipf("test %q is not VCR compatible", t.Name())
+	}
+	return skip
 }


### PR DESCRIPTION
Logical path in the skip vcr test helper was not correct.