### PR TITLE
Fix rendering of user resource page

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -10,8 +10,9 @@ Creates an Okta User. This resource allows you to create and configure an Okta U
 
 ## Example Usage
 
+### Full profile
+
 ```terraform
-### Full profile:
 resource "okta_user" "example" {
   first_name         = "John"
   last_name          = "Smith"
@@ -45,8 +46,11 @@ resource "okta_user" "example" {
   user_type          = "Employee"
   zip_code           = "11111"
 }
+```
 
-### With Password Inline Hook:
+### With Password Inline Hook
+
+```
 resource "okta_user" "test2" {
   first_name           = "John"
   last_name            = "Smith"


### PR DESCRIPTION
Just a small adjustment to match the docs structure of other docs pages. It looks like the level 3 markdown heading was mistakenly embedded in the code block.