### PR TITLE
Remove inactivity_period default value from app_signon_policy_rule

### DIFF
--- a/okta/resource_okta_app_signon_policy_rule.go
+++ b/okta/resource_okta_app_signon_policy_rule.go
@@ -180,7 +180,6 @@ The only difference is that these fields are immutable and can not be managed: '
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The inactivity duration after which the end user must re-authenticate. Use the ISO 8601 Period format for recurring time intervals.",
-				Default:     "PT1H",
 			},
 			"constraints": {
 				Type: schema.TypeList,

--- a/okta/resource_okta_app_signon_policy_rule_test.go
+++ b/okta/resource_okta_app_signon_policy_rule_test.go
@@ -46,7 +46,7 @@ func TestAccResourceOktaAppSignOnPolicyRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network_connection", "ANYWHERE"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "re_authentication_frequency", "PT2H"),
-					resource.TestCheckResourceAttr(resourceName, "inactivity_period", "PT1H"),
+					resource.TestCheckNoResourceAttr(resourceName, "inactivity_period"),
 					resource.TestCheckResourceAttr(resourceName, "risk_score", "LOW"),
 				),
 			},


### PR DESCRIPTION
This addresses #1573 which, even though closed as `stale`, I think should be fixed. 

For example, when creating a rule through the UI or when not explicitly setting this value through the API, the JSON that is returned when subsequently pulling the rule from the API will also not have a value for `inactivityPeriod`. The provider docs do not specify a default value either.

Note: I realize this could considered be a breaking change w.r.t. how the provider handled this value up until now 😬.