### PR TITLE
feat: add support for `permission_conditions` to `okta_admin_role_custom`

### DIFF
--- a/examples/resources/okta_admin_role_custom/basic_with_conditions.tf
+++ b/examples/resources/okta_admin_role_custom/basic_with_conditions.tf
@@ -1,0 +1,25 @@
+resource "okta_admin_role_custom" "test" {
+  label       = "testAcc_replace_with_uuid"
+  description = "Testing custom role with permission conditions"
+  permissions = ["okta.users.read"]
+
+  permission_conditions {
+    permission = "okta.users.read"
+    include = jsonencode({
+      "okta:ResourceAttribute/User/Profile" = ["department", "costCenter"]
+    })
+  }
+}
+
+resource "okta_admin_role_custom" "test1" {
+  label       = "testAcc_replace_with_uuid_1"
+  description = "Testing custom role with permission conditions"
+  permissions = ["okta.users.read"]
+
+  permission_conditions {
+    permission = "okta.users.read"
+    exclude = jsonencode({
+      "okta:ResourceAttribute/User/Profile" = ["title"]
+    })
+  }
+}

--- a/examples/resources/okta_admin_role_custom/unsupported_conditions.tf
+++ b/examples/resources/okta_admin_role_custom/unsupported_conditions.tf
@@ -1,0 +1,11 @@
+resource "okta_admin_role_custom" "test" {
+  label       = "testAcc_replace_with_uuid"
+  description = "Testing custom role with unsupported permission conditions"
+  permissions = ["okta.apps.manage"]
+  
+  permission_conditions {
+    permission = "okta.apps.manage"
+    include    = ["appId"]
+    exclude    = ["appType"]
+  }
+}

--- a/okta/services/idaas/resource_okta_admin_role_custom.go
+++ b/okta/services/idaas/resource_okta_admin_role_custom.go
@@ -2,14 +2,20 @@ package idaas
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/okta/terraform-provider-okta/okta/utils"
-	"github.com/okta/terraform-provider-okta/sdk"
+	"github.com/okta/okta-sdk-golang/v5/okta"
 )
+
+var permissionsWithConditionSupport = []string{
+	"okta.users.userprofile.manage",
+	"okta.users.read",
+}
 
 func resourceAdminRoleCustom() *schema.Resource {
 	return &schema.Resource{
@@ -17,12 +23,8 @@ func resourceAdminRoleCustom() *schema.Resource {
 		ReadContext:   resourceAdminRoleCustomRead,
 		UpdateContext: resourceAdminRoleCustomUpdate,
 		DeleteContext: resourceAdminRoleCustomDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Description: `Resource to manage administrative Role assignments for a User
-
-These operations allow the creation and manipulation of custom roles as custom collections of permissions.`,
+		Importer:      &schema.ResourceImporter{StateContext: schema.ImportStatePassthroughContext},
+		Description:   `Resource to create and manage a custom okta admin role that can be assigned to a user or group to grant a collection of permissions.`,
 		Schema: map[string]*schema.Schema{
 			"label": {
 				Type:        schema.TypeString,
@@ -36,188 +38,351 @@ These operations allow the creation and manipulation of custom roles as custom c
 				Description: "A human-readable description of the new Role",
 			},
 			"permissions": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The permissions granted by the custom admin role. At least one permission must be specified when creating a custom admin role. see: https://developer.okta.com/docs/api/openapi/okta-management/guides/permissions`,
+				MinItems:    1,
+			},
+			"permission_conditions": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				Set:      hashPermissionCondition,
+				Description: `Use a Condition object to further restrict a permission in a Custom Admin Role. 
+Permissions that support conditions:
+- okta.users.userprofile.manage
+- okta.users.read
+
+Note: support for new permission conditions may be added in the future.
+A permission condition can have either include or exclude, but not both.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"permission": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The Permission/Object to which the conditions apply",
+						},
+						"include": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "JSON-encoded map of references to attributes that are allowed.",
+						},
+						"exclude": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "JSON-encoded map of references to attributes that aren't allowed.",
+						},
+					},
 				},
-				Description: `The permissions that the new Role grants. At least one
-				permission must be specified when creating custom role. Valid values: "okta.users.manage",
-				"okta.users.create",
-				"okta.users.read",
-				"okta.users.credentials.manage",
-				"okta.users.credentials.resetFactors",
-				"okta.users.credentials.resetPassword",
-				"okta.users.credentials.expirePassword",
-				"okta.users.userprofile.manage",
-				"okta.users.lifecycle.manage",
-				"okta.users.lifecycle.activate",
-				"okta.users.lifecycle.deactivate",
-				"okta.users.lifecycle.suspend",
-				"okta.users.lifecycle.unsuspend",
-				"okta.users.lifecycle.delete",
-				"okta.users.lifecycle.unlock",
-				"okta.users.lifecycle.clearSessions",
-				"okta.users.groupMembership.manage",
-				"okta.users.appAssignment.manage",
-				"okta.users.apitokens.manage",
-				"okta.users.apitokens.read",
-				"okta.groups.manage",
-				"okta.groups.create",
-				"okta.groups.members.manage",
-				"okta.groups.read",
-				"okta.groups.appAssignment.manage",
-				"okta.apps.read",
-				"okta.apps.manage",
-				"okta.apps.assignment.manage",
-				"okta.profilesources.import.run",
-				"okta.authzServers.read",
-				"okta.users.userprofile.manage",
-				"okta.authzServers.manage",
-				"okta.customizations.read",
-				"okta.customizations.manage",
-				"okta.identityProviders.read",
-				"okta.identityProviders.manage",
-				"okta.workflows.read",
-				"okta.workflows.invoke".
-				"okta.governance.accessCertifications.manage",
-				"okta.governance.accessRequests.manage",
-				"okta.apps.manageFirstPartyApps",
-				"okta.agents.manage",
-				"okta.agents.register",
-				"okta.agents.view",
-				"okta.directories.manage",
-				"okta.directories.read",
-				"okta.devices.manage",
-				"okta.devices.lifecycle.manage",
-				"okta.devices.lifecycle.activate",
-				"okta.devices.lifecycle.deactivate",
-				"okta.devices.lifecycle.suspend",
-				"okta.devices.lifecycle.unsuspend",
-				"okta.devices.lifecycle.delete",
-				"okta.devices.read",
-				"okta.iam.read",
-				"okta.support.cases.manage".,`,
 			},
 		},
 	}
 }
 
-func resourceAdminRoleCustomCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cr, err := buildCustomAdminRole(d, true)
-	if err != nil {
-		return diag.Errorf("failed to create custom admin role: %v", err)
+func validatePermissionConditions(ctx context.Context, d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	var permissions []string
+	if permissionsRaw, ok := d.GetOk("permissions"); ok {
+		permissions = utils.ConvertInterfaceArrToStringArr(permissionsRaw.(*schema.Set).List())
 	}
-	role, _, err := getAPISupplementFromMetadata(meta).CreateCustomRole(ctx, *cr)
-	if err != nil {
-		return diag.Errorf("failed to create custom admin role: %v", err)
+
+	if conditions, ok := d.GetOk("permission_conditions"); ok {
+		for _, condition := range conditions.(*schema.Set).List() {
+			condMap := condition.(map[string]interface{})
+			permission := condMap["permission"].(string)
+
+			if !slices.Contains(permissions, permission) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  fmt.Sprintf("Permission %q is used in conditions but not present in permissions", permission),
+					Detail:   "Ensure that each permission referenced in a condition is also listed in the permissions block.",
+				})
+			}
+
+			if !slices.Contains(permissionsWithConditionSupport, permission) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  fmt.Sprintf("Permission %q might not currently support permission conditions", permission),
+					Detail:   "Terraform will attempt to apply this configuration, but it may fail if the specified permission does not currently support conditions. New permissions may support conditions in future Okta versions.",
+				})
+			}
+
+			// Check if both include and exclude have non-empty values
+			includeStr := condMap["include"].(string)
+			excludeStr := condMap["exclude"].(string)
+			if includeStr != "" && excludeStr != "" {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  fmt.Sprintf("Permission %q has both include and exclude conditions", permission),
+					Detail:   "A permission condition can only have either include or exclude, but not both. This is a limitation of the Okta API.",
+				})
+			}
+
+			// Validate JSON format for include and exclude
+			if includeStr != "" {
+				var includeMap map[string]interface{}
+				if err := json.Unmarshal([]byte(includeStr), &includeMap); err != nil {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  fmt.Sprintf("Invalid JSON in include condition for permission %q", permission),
+						Detail:   fmt.Sprintf("The include condition must be a valid JSON string: %v", err),
+					})
+				}
+			}
+
+			if excludeStr != "" {
+				var excludeMap map[string]interface{}
+				if err := json.Unmarshal([]byte(excludeStr), &excludeMap); err != nil {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  fmt.Sprintf("Invalid JSON in exclude condition for permission %q", permission),
+						Detail:   fmt.Sprintf("The exclude condition must be a valid JSON string: %v", err),
+					})
+				}
+			}
+		}
 	}
-	d.SetId(role.Id)
-	return nil
+
+	return diags
 }
 
-func resourceAdminRoleCustomRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	role, resp, err := getAPISupplementFromMetadata(meta).GetCustomRole(ctx, d.Id())
-	if err := utils.SuppressErrorOn404(resp, err); err != nil {
+func resourceAdminRoleCustomCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	diags := validatePermissionConditions(ctx, d)
+	if diags.HasError() {
+		return diags
+	}
+
+	client := getOktaV5ClientFromMetadata(m)
+
+	cr := &okta.CreateIamRoleRequest{
+		Label:       d.Get("label").(string),
+		Description: d.Get("description").(string),
+	}
+
+	// Convert permissions set to string array
+	if v, ok := d.GetOk("permissions"); ok && v != nil {
+		perms := make([]string, 0, v.(*schema.Set).Len())
+		for _, item := range v.(*schema.Set).List() {
+			perms = append(perms, item.(string))
+		}
+		cr.Permissions = perms
+	}
+
+	role, _, err := client.RoleAPI.CreateRole(ctx).Instance(*cr).Execute()
+	if err != nil {
+		return append(diags, diag.Errorf("failed to create custom admin role: %v", err)...)
+	}
+	d.SetId(role.GetId())
+
+	// Handle permission conditions
+	if conditions, ok := d.GetOk("permission_conditions"); ok {
+		err := managePermissionConditions(ctx, client, d.Id(), conditions.(*schema.Set).List())
+		if err != nil {
+			return append(diags, diag.Errorf("failed to update permission conditions for role %s: %v", d.Id(), err)...)
+		}
+	}
+
+	return diags
+}
+
+func resourceAdminRoleCustomRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := getOktaV5ClientFromMetadata(m)
+
+	role, resp, err := client.RoleAPI.GetRole(ctx, d.Id()).Execute()
+	if err := utils.SuppressErrorOn404_V5(resp, err); err != nil {
 		return diag.Errorf("failed to find custom admin role: %v", err)
 	}
 	if role == nil {
 		d.SetId("")
 		return nil
 	}
-	// is case role label was used instead of ID for the import
-	if role.Id != d.Id() {
-		d.SetId(role.Id)
+
+	// If role label was used instead of ID during import
+	if role.GetId() != d.Id() {
+		d.SetId(role.GetId())
 	}
-	_ = d.Set("label", role.Label)
-	_ = d.Set("description", role.Description)
-	perms, _, err := getAPISupplementFromMetadata(meta).ListCustomRolePermissions(ctx, d.Id())
+
+	if err := d.Set("label", role.GetLabel()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", role.GetDescription()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	perms, _, err := client.RoleAPI.ListRolePermissions(ctx, d.Id()).Execute()
 	if err != nil {
 		return diag.Errorf("failed to list permissions for custom admin role: %v", err)
 	}
-	_ = d.Set("permissions", flattenPermissions(perms.Permissions))
+
+	permList := make([]string, 0)
+	conditions := make([]map[string]interface{}, 0)
+
+	for _, perm := range perms.GetPermissions() {
+		permLabel := perm.GetLabel()
+		permList = append(permList, permLabel)
+
+		if perm.HasConditions() {
+			cond := map[string]interface{}{
+				"permission": permLabel,
+			}
+
+			if conditionMap, ok := perm.GetConditionsOk(); ok && conditionMap != nil {
+				// Handle include conditions
+				if includeMap, ok := conditionMap["include"].(map[string]interface{}); ok && len(includeMap) > 0 {
+					jsonInclude, err := json.Marshal(includeMap)
+					if err != nil {
+						return diag.Errorf("failed to marshal include conditions for permission %s: %v", permLabel, err)
+					}
+					cond["include"] = string(jsonInclude)
+				}
+
+				// Handle exclude conditions
+				if excludeMap, ok := conditionMap["exclude"].(map[string]interface{}); ok && len(excludeMap) > 0 {
+					jsonExclude, err := json.Marshal(excludeMap)
+					if err != nil {
+						return diag.Errorf("failed to marshal exclude conditions for permission %s: %v", permLabel, err)
+					}
+					cond["exclude"] = string(jsonExclude)
+				}
+
+				conditions = append(conditions, cond)
+			}
+		}
+	}
+
+	if err := d.Set("permissions", schema.NewSet(schema.HashString, utils.ConvertStringSliceToInterfaceSlice(permList))); err != nil {
+		return diag.FromErr(err)
+	}
+	condInterfaces := make([]interface{}, len(conditions))
+	for i, c := range conditions {
+		condInterfaces[i] = c
+	}
+	if err := d.Set("permission_conditions", schema.NewSet(hashPermissionCondition, condInterfaces)); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
-func resourceAdminRoleCustomUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := getAPISupplementFromMetadata(meta)
-	if d.HasChanges("label", "description") {
-		cr, _ := buildCustomAdminRole(d, false)
-		_, _, err := client.UpdateCustomRole(ctx, d.Id(), *cr)
+func resourceAdminRoleCustomUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	diags := validatePermissionConditions(ctx, d)
+	if diags.HasError() {
+		return diags
+	}
+
+	client := getOktaV5ClientFromMetadata(m)
+
+	if d.HasChange("description") || d.HasChange("label") {
+		ur := &okta.UpdateIamRoleRequest{
+			Description: d.Get("description").(string),
+			Label:       d.Get("label").(string),
+		}
+		_, _, err := client.RoleAPI.ReplaceRole(ctx, d.Id()).Instance(*ur).Execute()
 		if err != nil {
-			return diag.Errorf("failed to update custom admin role: %v", err)
+			return append(diags, diag.Errorf("failed to update custom admin role: %v", err)...)
 		}
 	}
-	if !d.HasChange("permissions") {
-		return nil
-	}
-	oldPermissions, newPermissions := d.GetChange("permissions")
-	oldSet := oldPermissions.(*schema.Set)
-	newSet := newPermissions.(*schema.Set)
+
+	if d.HasChange("permissions") {
+		oldPermissions, newPermissions := d.GetChange("permissions")
+		oldSet := oldPermissions.(*schema.Set)
+		newSet := newPermissions.(*schema.Set)
 
 	permissionsToAdd := utils.ConvertInterfaceArrToStringArr(newSet.Difference(oldSet).List())
 	permissionsToRemove := utils.ConvertInterfaceArrToStringArr(oldSet.Difference(newSet).List())
 
-	err := addCustomRolePermissions(ctx, client, d.Id(), permissionsToAdd)
-	if err != nil {
-		return diag.FromErr(err)
+		if err := addCustomRolePermissions(ctx, client, d.Id(), permissionsToAdd); err != nil {
+			return append(diags, err...)
+		}
+		if err := removeCustomRolePermissions(ctx, client, d.Id(), permissionsToRemove); err != nil {
+			return append(diags, err...)
+		}
 	}
-	err = removeCustomRolePermissions(ctx, client, d.Id(), permissionsToRemove)
-	if err != nil {
-		return diag.FromErr(err)
+
+	// Handle permission conditions update
+	if d.HasChange("permission_conditions") {
+		conditions := d.Get("permission_conditions").(*schema.Set).List()
+		if err := managePermissionConditions(ctx, client, d.Id(), conditions); err != nil {
+			return append(diags, diag.Errorf("failed to manage permission conditions: %v", err)...)
+		}
 	}
-	return nil
+
+	return resourceAdminRoleCustomRead(ctx, d, m)
 }
 
-func resourceAdminRoleCustomDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	resp, err := getAPISupplementFromMetadata(meta).DeleteCustomRole(ctx, d.Id())
-	if err := utils.SuppressErrorOn404(resp, err); err != nil {
+func resourceAdminRoleCustomDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := getOktaV5ClientFromMetadata(m)
+	resp, err := client.RoleAPI.DeleteRole(ctx, d.Id()).Execute()
+	if err := utils.SuppressErrorOn404_V5(resp, err); err != nil {
 		return diag.Errorf("failed to delete admin custom role: %v", err)
 	}
 	return nil
 }
 
-func buildCustomAdminRole(d *schema.ResourceData, isNew bool) (*sdk.CustomRole, error) {
-	cr := &sdk.CustomRole{
-		Label:       d.Get("label").(string),
-		Description: d.Get("description").(string),
-	}
-	if isNew {
-		cr.Permissions = utils.ConvertInterfaceToStringSetNullable(d.Get("permissions"))
-		if len(cr.Permissions) == 0 {
-			return nil, errors.New("at least one permission must be specified when creating custom role")
-		}
-	}
-	return cr, nil
-}
-
-func flattenPermissions(permissions []*sdk.Permission) interface{} {
-	if len(permissions) == 0 {
-		return nil
-	}
-	arr := make([]interface{}, len(permissions))
-	for i := range permissions {
-		arr[i] = permissions[i].Label
-	}
-	return schema.NewSet(schema.HashString, arr)
-}
-
-func addCustomRolePermissions(ctx context.Context, client *sdk.APISupplement, roleIdOrLabel string, permissions []string) error {
+func addCustomRolePermissions(ctx context.Context, client *okta.APIClient, roleIdOrLabel string, permissions []string) diag.Diagnostics {
 	for _, permission := range permissions {
-		_, _, err := client.AddCustomRolePermission(ctx, roleIdOrLabel, permission)
+		_, err := client.RoleAPI.CreateRolePermission(ctx, roleIdOrLabel, permission).Execute()
 		if err != nil {
-			return fmt.Errorf("failed to add %s permission to the custom role %s: %v", permission, roleIdOrLabel, err)
+			return diag.Errorf("failed to add %s permission to the custom role %s: %v", permission, roleIdOrLabel, err)
 		}
 	}
 	return nil
 }
 
-func removeCustomRolePermissions(ctx context.Context, client *sdk.APISupplement, roleIdOrLabel string, permissions []string) error {
+func removeCustomRolePermissions(ctx context.Context, client *okta.APIClient, roleIdOrLabel string, permissions []string) diag.Diagnostics {
 	for _, permission := range permissions {
-		_, err := client.DeleteCustomRolePermission(ctx, roleIdOrLabel, permission)
+		_, err := client.RoleAPI.DeleteRolePermission(ctx, roleIdOrLabel, permission).Execute()
 		if err != nil {
-			return fmt.Errorf("failed to remove %s permission from the custom role %s: %v", permission, roleIdOrLabel, err)
+			return diag.Errorf("failed to remove %s permission from the custom role %s: %v", permission, roleIdOrLabel, err)
 		}
 	}
 	return nil
+}
+
+func managePermissionConditions(ctx context.Context, client *okta.APIClient, roleIdOrLabel string, conditions []interface{}) diag.Diagnostics {
+	for _, condition := range conditions {
+		condMap := condition.(map[string]interface{})
+		permission := condMap["permission"].(string)
+
+		// Build conditions map in the format the API expects
+		conditionData := map[string]interface{}{
+			"conditions": map[string]interface{}{},
+		}
+
+		// Handle include conditions
+		if includeStr, ok := condMap["include"].(string); ok && includeStr != "" {
+			var includeMap map[string]interface{}
+			if err := json.Unmarshal([]byte(includeStr), &includeMap); err != nil {
+				return diag.Errorf("failed to parse include conditions JSON for permission %s: %v", permission, err)
+			}
+			conditionData["conditions"].(map[string]interface{})["include"] = includeMap
+		}
+
+		// Handle exclude conditions
+		if excludeStr, ok := condMap["exclude"].(string); ok && excludeStr != "" {
+			var excludeMap map[string]interface{}
+			if err := json.Unmarshal([]byte(excludeStr), &excludeMap); err != nil {
+				return diag.Errorf("failed to parse exclude conditions JSON for permission %s: %v", permission, err)
+			}
+			conditionData["conditions"].(map[string]interface{})["exclude"] = excludeMap
+		}
+
+		req := okta.CreateUpdateIamRolePermissionRequest{
+			Conditions: conditionData["conditions"].(map[string]interface{}),
+		}
+
+		_, _, err := client.RoleAPI.ReplaceRolePermission(ctx, roleIdOrLabel, permission).Instance(req).Execute()
+		if err != nil {
+			return diag.Errorf("failed to update permission condition for %s: %v", permission, err)
+		}
+	}
+	return nil
+}
+
+func hashPermissionCondition(v interface{}) int {
+	m := v.(map[string]interface{})
+	perm := m["permission"].(string)
+	key := fmt.Sprintf("perm:%s|include:%v|exclude:%v", perm, m["include"], m["exclude"])
+	return schema.HashString(key)
 }

--- a/okta/services/idaas/resource_okta_admin_role_custom_test.go
+++ b/okta/services/idaas/resource_okta_admin_role_custom_test.go
@@ -39,6 +39,56 @@ func TestAccResourceOktaAdminRoleCustom_crud(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
 					),
 				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+}
+
+
+func TestAccResourceOktaAdminRoleCustom_withConditions(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSAdminRoleCustom, t.Name())
+	config := mgr.GetFixtures("basic_with_conditions.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSAdminRoleCustom)
+	resourceName1 := fmt.Sprintf("%s.test1", resources.OktaIDaaSAdminRoleCustom)
+	acctest.OktaResourceTest(
+		t, resource.TestCase{
+			PreCheck:                 acctest.AccPreCheck(t),
+			ErrorCheck:               testAccErrorChecks(t),
+			ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+			CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSAdminRoleCustom, doesAdminRoleCustomExist),
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "label", acctest.BuildResourceName(mgr.Seed)),
+						resource.TestCheckResourceAttr(resourceName, "description", "Testing custom role with permission conditions"),
+						resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "permission_conditions.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "permission_conditions.0.permission", "okta.users.read"),
+						resource.TestCheckResourceAttr(resourceName, "permission_conditions.0.include", `{"okta:ResourceAttribute/User/Profile":["department","costCenter"]}`),
+
+						resource.TestCheckResourceAttr(resourceName1, "label", acctest.BuildResourceName(mgr.Seed)+"_1"),
+						resource.TestCheckResourceAttr(resourceName1, "description", "Testing custom role with permission conditions"),
+						resource.TestCheckResourceAttr(resourceName1, "permissions.#", "1"),
+						resource.TestCheckResourceAttr(resourceName1, "permission_conditions.#", "1"),
+						resource.TestCheckResourceAttr(resourceName1, "permission_conditions.0.permission", "okta.users.read"),
+						resource.TestCheckResourceAttr(resourceName1, "permission_conditions.0.exclude", `{"okta:ResourceAttribute/User/Profile":["title"]}`),
+					),
+				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      resourceName1,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
 		})
 }

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaAdminRoleCustom_withConditions/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaAdminRoleCustom_withConditions/oie-00.yaml
@@ -1,0 +1,495 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 130
+        host: oie-00.dne-okta.com
+        body: |
+            {"description":"Testing custom role with permission conditions","label":"testAcc_3035635720_1","permissions":["okta.users.read"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cr0tc4m9ghnP8gUjN697","label":"testAcc_3035635720_1","isCloneable":false,"description":"Testing custom role with permission conditions","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","_links":{"permissions":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:33 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 810.267041ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 128
+        host: oie-00.dne-okta.com
+        body: |
+            {"description":"Testing custom role with permission conditions","label":"testAcc_3035635720","permissions":["okta.users.read"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cr0tc4l4uhdx78Y86697","label":"testAcc_3035635720","isCloneable":false,"description":"Testing custom role with permission conditions","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","_links":{"permissions":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:33 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 811.581917ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 95
+        host: oie-00.dne-okta.com
+        body: |
+            {"conditions":{"include":{"okta:ResourceAttribute/User/Profile":["department","costCenter"]}}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions/okta.users.read
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"label":"okta.users.read","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","conditions":{"include":{"okta:ResourceAttribute/User/Profile":["department","costCenter"]}},"_links":{"role":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions/okta.users.read"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Disposition:
+                - inline;filename=f.txt
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:34 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions/okta.users.read>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 764.268333ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 77
+        host: oie-00.dne-okta.com
+        body: |
+            {"conditions":{"exclude":{"okta:ResourceAttribute/User/Profile":["title"]}}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions/okta.users.read
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"label":"okta.users.read","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","conditions":{"exclude":{"okta:ResourceAttribute/User/Profile":["title"]}},"_links":{"role":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions/okta.users.read"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Disposition:
+                - inline;filename=f.txt
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:34 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions/okta.users.read>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.176955958s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cr0tc4l4uhdx78Y86697","label":"testAcc_3035635720","isCloneable":false,"description":"Testing custom role with permission conditions","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","_links":{"permissions":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:35 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 675.94725ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cr0tc4m9ghnP8gUjN697","label":"testAcc_3035635720_1","isCloneable":false,"description":"Testing custom role with permission conditions","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","_links":{"permissions":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:35 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 677.120875ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"permissions":[{"label":"okta.users.read","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","conditions":{"include":{"okta:ResourceAttribute/User/Profile":["department","costCenter"]}},"_links":{"role":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions/okta.users.read"}}}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:36 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 658.677417ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"permissions":[{"label":"okta.users.read","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","conditions":{"exclude":{"okta:ResourceAttribute/User/Profile":["title"]}},"_links":{"role":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions/okta.users.read"}}}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:36 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 677.838667ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cr0tc4l4uhdx78Y86697","label":"testAcc_3035635720","isCloneable":false,"description":"Testing custom role with permission conditions","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","_links":{"permissions":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:37 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 674.191917ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"permissions":[{"label":"okta.users.read","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","conditions":{"include":{"okta:ResourceAttribute/User/Profile":["department","costCenter"]}},"_links":{"role":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697/permissions/okta.users.read"}}}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:38 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 680.277917ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cr0tc4m9ghnP8gUjN697","label":"testAcc_3035635720_1","isCloneable":false,"description":"Testing custom role with permission conditions","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","_links":{"permissions":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:39 GMT
+            Link:
+                - <https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 664.512167ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"permissions":[{"label":"okta.users.read","created":"2025-07-17T15:12:33.000Z","lastUpdated":"2025-07-17T15:12:33.000Z","conditions":{"exclude":{"okta:ResourceAttribute/User/Profile":["title"]}},"_links":{"role":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697"},"self":{"href":"https://oie-00-admin.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697/permissions/okta.users.read"}}}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 17 Jul 2025 15:12:40 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 672.259083ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4l4uhdx78Y86697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 17 Jul 2025 15:12:41 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 725.017792ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/roles/cr0tc4m9ghnP8gUjN697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 17 Jul 2025 15:12:41 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.159714792s


### PR DESCRIPTION
fixes: #1571

I'm still learning GoLang and thus this PR was heavily aided by Generative AI

I've not written any tests as yet
I would like to get some feedback on what i've done thus far before I write tests for behavior that is incorrect


```hcl
resource "okta_admin_role_custom" "limited_readonly" {
  label       = "limited readOnly"
  description = "readOnly access to apps, groups, and a subset of user profile attributes"
  permissions = [
    "okta.users.read",
    "okta.groups.read",
    "okta.apps.read",
    ]

  permission_conditions {
    permission = "okta:ResourceAttribute/User/Profile"
    include = ["city", "state", "zipCode"]
    exclude = ["secondEmail", "mobilePhone", "primaryPhone", "postalAddress"]
  }
}
```