### PR TITLE
Fix: typo in query parameter for Okta group rule deletion API

### DIFF
--- a/okta/resource_okta_group_rule.go
+++ b/okta/resource_okta_group_rule.go
@@ -176,7 +176,7 @@ func resourceGroupRuleDelete(ctx context.Context, d *schema.ResourceData, m inte
 		}
 	}
 	remove := d.Get("remove_assigned_users").(bool)
-	_, err := client.Group.DeleteGroupRule(ctx, d.Id(), &query.Params{RemoveUsers: &remove})
+	_, err := client.Group.DeleteGroupRule(ctx, d.Id(), &query.Params{removeUsers: &remove})
 	if err != nil {
 		return diag.Errorf("failed to delete group rule: %v", err)
 	}


### PR DESCRIPTION
Fixes [#2082](https://github.com/okta/terraform-provider-okta/issues/2082)

This PR fixes a typo found when calling Okta API to delete a group rule. Currently the `removeUsers` query parameter is set as `RemoveUsers` which causes users to not be removed from groups after rule deletion. 