### PR TITLE
handle empty/missing okta_group_owners

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	OktaTerraformProviderVersion   = "4.11.0"
+	OktaTerraformProviderVersion   = "4.11.1"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )
 

--- a/okta/resource_okta_group_owner.go
+++ b/okta/resource_okta_group_owner.go
@@ -132,7 +132,6 @@ func (r *groupOwnerResource) Read(ctx context.Context, req resource.ReadRequest,
 	var err error
 
 	listGroupOwners, _, err := r.Config.oktaSDKClientV5.GroupOwnerAPI.ListGroupOwners(ctx, state.GroupID.ValueString()).Execute()
-
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error retrieving list group owners",
@@ -144,7 +143,14 @@ func (r *groupOwnerResource) Read(ctx context.Context, req resource.ReadRequest,
 	for _, groupOwner := range listGroupOwners {
 		if groupOwner.GetId() == state.ID.ValueString() {
 			grpOwner = &groupOwner
+			break
 		}
+	}
+
+	if grpOwner == nil {
+		// The resource no longer exists; remove it from state
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	resp.Diagnostics.Append(mapGroupOwnerToState(grpOwner, &state)...)


### PR DESCRIPTION
Fixes #2100

We currently make an assumption that there will be at least 1 group owner when reading the resource

When the list of group owners is empty, we attempt to access attributes anyway which seems to lead to the panic / crash outlined in #2100 