### PR TITLE
fix: revert PR #2053 missed a negation

### DIFF
--- a/okta/resource_okta_profile_mapping.go
+++ b/okta/resource_okta_profile_mapping.go
@@ -137,7 +137,7 @@ func resourceProfileMappingRead(ctx context.Context, d *schema.ResourceData, m i
 	_ = d.Set("target_type", mapping.Target.Type)
 	_ = d.Set("target_id", mapping.Target.Id)
 	_ = d.Set("target_name", mapping.Target.Name)
-	if d.Get("delete_when_absent").(bool) {
+	if !d.Get("delete_when_absent").(bool) {
 		current := buildMappingProperties(d.Get("mappings").(*schema.Set))
 		for k := range mapping.Properties {
 			if _, ok := current[k]; !ok {


### PR DESCRIPTION
#2053 missed the negation of the `d.Get("delete_when_absent").(bool)` which was present in provider version 4.8.1 https://github.com/okta/terraform-provider-okta/blob/c894ab5f3ab8485ace0035c7eea4acc450a37e7c/okta/resource_okta_profile_mapping.go#L139

With this fix an `okta_profile_mapping` resource created with version 4.8.1 and `delete_when_absent` attribute unset or set to `false` will not show any changes when upgrading the latest provider version.