### PR TITLE
Add resource for email template settings

### DIFF
--- a/examples/resources/okta_email_template_settings/README.md
+++ b/examples/resources/okta_email_template_settings/README.md
@@ -1,0 +1,6 @@
+# okta_email_template_settings
+
+Use this resource to set the [email template settings](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/CustomTemplates/#tag/CustomTemplates/operation/replaceEmailSettings)
+of an email template belonging to a brand in an Okta organization.
+
+- Example [basic.tf](./basic.tf)

--- a/examples/resources/okta_email_template_settings/basic.tf
+++ b/examples/resources/okta_email_template_settings/basic.tf
@@ -1,0 +1,8 @@
+data "okta_brands" "test" {
+}
+
+resource "okta_email_template_settings" "test" {
+  brand_id      = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "UserActivation"
+  recipients    = "NO_USERS"
+}

--- a/examples/resources/okta_email_template_settings/import.sh
+++ b/examples/resources/okta_email_template_settings/import.sh
@@ -1,0 +1,1 @@
+terraform import okta_email_template_settings.example <brand_id>/<template_name>

--- a/examples/resources/okta_email_template_settings/resource.tf
+++ b/examples/resources/okta_email_template_settings/resource.tf
@@ -1,0 +1,5 @@
+resource "okta_email_template_settings" "example" {
+  brand_id      = "<brand id>"
+  template_name = "ForgotPassword"
+  recipients    = "ADMINS_ONLY"
+}

--- a/examples/resources/okta_email_template_settings/updated.tf
+++ b/examples/resources/okta_email_template_settings/updated.tf
@@ -1,0 +1,8 @@
+data "okta_brands" "test" {
+}
+
+resource "okta_email_template_settings" "test" {
+  brand_id      = tolist(data.okta_brands.test.brands)[0].id
+  template_name = "UserActivation"
+  recipients    = "ADMINS_ONLY"
+}

--- a/okta/framework_provider.go
+++ b/okta/framework_provider.go
@@ -276,6 +276,7 @@ func (p *FrameworkProvider) Resources(_ context.Context) []func() resource.Resou
 		NewPreviewSigninResource,
 		NewGroupOwnerResource,
 		NewAppSignOnPolicyResource,
+		NewEmailTemplateSettingsResource,
 	}
 }
 

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -73,7 +73,6 @@ const (
 	emailCustomizations           = "okta_email_customizations"
 	emailTemplate                 = "okta_email_template"
 	emailTemplates                = "okta_email_templates"
-	emailTemplateSettings         = "okta_email_template_settings"
 	eventHook                     = "okta_event_hook"
 	eventHookVerification         = "okta_event_hook_verification"
 	factor                        = "okta_factor"
@@ -283,7 +282,6 @@ func Provider() *schema.Provider {
 			emailDomainVerification:       resourceEmailDomainVerification(),
 			emailSender:                   resourceEmailSender(),
 			emailSenderVerification:       resourceEmailSenderVerification(),
-			emailTemplateSettings:         resourceEmailTemplateSettings(),
 			eventHook:                     resourceEventHook(),
 			eventHookVerification:         resourceEventHookVerification(),
 			factor:                        resourceFactor(),

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -73,6 +73,7 @@ const (
 	emailCustomizations           = "okta_email_customizations"
 	emailTemplate                 = "okta_email_template"
 	emailTemplates                = "okta_email_templates"
+	emailTemplateSettings         = "okta_email_template_settings"
 	eventHook                     = "okta_event_hook"
 	eventHookVerification         = "okta_event_hook_verification"
 	factor                        = "okta_factor"
@@ -282,6 +283,7 @@ func Provider() *schema.Provider {
 			emailDomainVerification:       resourceEmailDomainVerification(),
 			emailSender:                   resourceEmailSender(),
 			emailSenderVerification:       resourceEmailSenderVerification(),
+			emailTemplateSettings:         resourceEmailTemplateSettings(),
 			eventHook:                     resourceEventHook(),
 			eventHookVerification:         resourceEventHookVerification(),
 			factor:                        resourceFactor(),

--- a/okta/resource_okta_email_template_settings.go
+++ b/okta/resource_okta_email_template_settings.go
@@ -1,0 +1,104 @@
+package okta
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/okta-sdk-golang/v4/okta"
+)
+
+func resourceEmailTemplateSettings() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEmailTemplateSettingsPut,
+		ReadContext:   resourceEmailTemplateSettingsRead,
+		UpdateContext: resourceEmailTemplateSettingsPut,
+		DeleteContext: resourceFuncNoOp,
+		Importer:      createNestedResourceImporter([]string{"brand_id", "template_name"}),
+		Description: `Update settings for an email template belonging to a brand in an Okta organization.
+		Use this resource to get and set the [settings for an email template](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/CustomTemplates/#tag/CustomTemplates/operation/getEmailSettings) 
+        belonging to a brand in an Okta organization.`,
+		Schema: map[string]*schema.Schema{
+			"brand_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Brand ID",
+			},
+			"template_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Email template name - Example values: `AccountLockout`,`ADForgotPassword`,`ADForgotPasswordDenied`,`ADSelfServiceUnlock`,`ADUserActivation`,`AuthenticatorEnrolled`,`AuthenticatorReset`,`ChangeEmailConfirmation`,`EmailChallenge`,`EmailChangeConfirmation`,`EmailFactorVerification`,`ForgotPassword`,`ForgotPasswordDenied`,`IGAReviewerEndNotification`,`IGAReviewerNotification`,`IGAReviewerPendingNotification`,`IGAReviewerReassigned`,`LDAPForgotPassword`,`LDAPForgotPasswordDenied`,`LDAPSelfServiceUnlock`,`LDAPUserActivation`,`MyAccountChangeConfirmation`,`NewSignOnNotification`,`OktaVerifyActivation`,`PasswordChanged`,`PasswordResetByAdmin`,`PendingEmailChange`,`RegistrationActivation`,`RegistrationEmailVerification`,`SelfServiceUnlock`,`SelfServiceUnlockOnUnlockedAccount`,`UserActivation`",
+			},
+			"recipients": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The recipients the emails of this template will be sent to - Valid values: `ALL_USERS`, `ADMINS_ONLY`, `NO_USERS`",
+			},
+		},
+	}
+}
+
+func resourceEmailTemplateSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	ets, diagErr := etsValues("read", d)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	emailTemplateSettings, resp, err := getOktaV3ClientFromMetadata(m).CustomizationAPI.GetEmailSettings(ctx, ets.brandID, ets.templateName).Execute()
+	if err := v3suppressErrorOn404(resp, err); err != nil {
+		return diag.Errorf("failed to get email template settings: %v", err)
+	}
+	if emailTemplateSettings == nil {
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("brand_id", ets.brandID)
+	_ = d.Set("template_name", ets.templateName)
+	_ = d.Set("recipients", emailTemplateSettings.GetRecipients())
+
+	return nil
+}
+
+func resourceEmailTemplateSettingsPut(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	ets, diagErr := etsValues("update", d)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	es := okta.EmailSettings{}
+	if recipients, ok := d.GetOk("recipients"); ok {
+		es.Recipients = recipients.(string)
+	}
+
+	_, err := getOktaV3ClientFromMetadata(m).CustomizationAPI.ReplaceEmailSettings(ctx, ets.brandID, ets.templateName).EmailSettings(es).Execute()
+	if err != nil {
+		return diag.Errorf("failed to update email template settings: %v", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", ets.brandID, ets.templateName))
+	return resourceEmailTemplateSettingsRead(ctx, d, m)
+}
+
+type etsHelper struct {
+	brandID      string
+	templateName string
+}
+
+func etsValues(action string, d *schema.ResourceData) (*etsHelper, diag.Diagnostics) {
+	brandID, ok := d.GetOk("brand_id")
+	if !ok {
+		return nil, diag.Errorf("brand_id required to %s email template settings", action)
+	}
+
+	templateName, ok := d.GetOk("template_name")
+	if !ok {
+		return nil, diag.Errorf("template name required to %s email template settings", action)
+	}
+
+	return &etsHelper{
+		brandID:      brandID.(string),
+		templateName: templateName.(string),
+	}, nil
+}

--- a/okta/resource_okta_email_template_settings_test.go
+++ b/okta/resource_okta_email_template_settings_test.go
@@ -8,15 +8,16 @@ import (
 )
 
 func TestAccResourceOktaEmailTemplateSettings(t *testing.T) {
-	resourceName := fmt.Sprintf("%s.test", emailTemplateSettings)
-	mgr := newFixtureManager("resources", emailTemplateSettings, t.Name())
+	_resource := "okta_email_template_settings"
+	resourceName := fmt.Sprintf("%s.test", _resource)
+	mgr := newFixtureManager("resources", _resource, t.Name())
 	config := mgr.GetFixtures("basic.tf", t)
 	updated := mgr.GetFixtures("updated.tf", t)
 	oktaResourceTest(t, resource.TestCase{
-		PreCheck:          testAccPreCheck(t),
-		ErrorCheck:        testAccErrorChecks(t),
-		ProviderFactories: testAccProvidersFactories,
-		CheckDestroy:      nil,
+		PreCheck:                 testAccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: testAccMergeProvidersFactories,
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/okta/resource_okta_email_template_settings_test.go
+++ b/okta/resource_okta_email_template_settings_test.go
@@ -1,0 +1,37 @@
+package okta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceOktaEmailTemplateSettings(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.test", emailTemplateSettings)
+	mgr := newFixtureManager("resources", emailTemplateSettings, t.Name())
+	config := mgr.GetFixtures("basic.tf", t)
+	updated := mgr.GetFixtures("updated.tf", t)
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "recipients", "NO_USERS"),
+					resource.TestCheckResourceAttr(resourceName, "template_name", "UserActivation"),
+				),
+			},
+			{
+				Config: updated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "recipients", "ADMINS_ONLY"),
+					resource.TestCheckResourceAttr(resourceName, "template_name", "UserActivation"),
+				),
+			},
+		},
+	})
+}

--- a/test/fixtures/vcr/TestAccResourceOktaEmailTemplateSettings/oie-00.yaml
+++ b/test/fixtures/vcr/TestAccResourceOktaEmailTemplateSettings/oie-00.yaml
@@ -1,0 +1,728 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:26 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 827.838833ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:27 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 211.120083ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 26
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"recipients":"NO_USERS"}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 217.09175ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 216.942792ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:28 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 209.947375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:29 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 201.047625ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:29 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 209.483958ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:30 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 205.380708ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:31 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 205.542125ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:31 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
+        status: 200 OK
+        code: 200
+        duration: 209.529333ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:31 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 204.005334ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 29
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"recipients":"ADMINS_ONLY"}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"recipients":"ADMINS_ONLY","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:32 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 214.825416ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"recipients":"ADMINS_ONLY","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 223.335917ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:33 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 216.586583ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:34 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 204.095709ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"recipients":"ADMINS_ONLY","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:34 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 216.833833ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:05:35 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 207.300333ms

--- a/test/fixtures/vcr/TestAccResourceOktaEmailTemplateSettings/oie-00.yaml
+++ b/test/fixtures/vcr/TestAccResourceOktaEmailTemplateSettings/oie-00.yaml
@@ -29,21 +29,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:26 GMT
+                - Wed, 15 Jan 2025 03:34:21 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 827.838833ms
+        duration: 831.296667ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -72,44 +72,41 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:27 GMT
+                - Wed, 15 Jan 2025 03:34:21 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 211.120083ms
+        duration: 201.454167ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 26
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: oie-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"recipients":"NO_USERS"}
+        body: ""
         form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
-        method: PUT
+        url: https://oie-00.dne-okta.com/api/v1/brands
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -118,19 +115,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:28 GMT
+                - Wed, 15 Jan 2025 03:34:23 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 217.09175ms
+        duration: 204.642333ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -149,7 +148,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        url: https://oie-00.dne-okta.com/api/v1/brands
         method: GET
       response:
         proto: HTTP/2.0
@@ -159,19 +158,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:28 GMT
+                - Wed, 15 Jan 2025 03:34:24 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 216.942792ms
+        duration: 209.575208ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -200,21 +201,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:28 GMT
+                - Wed, 15 Jan 2025 03:34:25 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 209.947375ms
+        duration: 198.362458ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -243,21 +244,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:29 GMT
+                - Wed, 15 Jan 2025 03:34:26 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 201.047625ms
+        duration: 198.914334ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -276,7 +277,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
+        url: https://oie-00.dne-okta.com/api/v1/brands
         method: GET
       response:
         proto: HTTP/2.0
@@ -286,19 +287,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:29 GMT
+                - Wed, 15 Jan 2025 03:34:27 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 209.483958ms
+        duration: 211.648583ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -327,21 +330,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:30 GMT
+                - Wed, 15 Jan 2025 03:34:30 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 205.380708ms
+        duration: 205.258167ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -370,21 +373,21 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:31 GMT
+                - Wed, 15 Jan 2025 03:34:31 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 205.542125ms
+        duration: 208.121333ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -403,49 +406,6 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"recipients":"NO_USERS","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 10 Jan 2025 06:05:31 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"csp","max_age":31536000,"endpoints":[{"url":"https://oktacsp.report-uri.com/a/t/g"}],"include_subdomains":true}'
-        status: 200 OK
-        code: 200
-        duration: 209.529333ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
         url: https://oie-00.dne-okta.com/api/v1/brands
         method: GET
       response:
@@ -456,273 +416,18 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
+        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Foo","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 10 Jan 2025 06:05:31 GMT
+                - Wed, 15 Jan 2025 03:34:32 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 204.005334ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 29
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"recipients":"ADMINS_ONLY"}
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"recipients":"ADMINS_ONLY","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 10 Jan 2025 06:05:32 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 214.825416ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"recipients":"ADMINS_ONLY","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 10 Jan 2025 06:05:33 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 223.335917ms
-    - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 10 Jan 2025 06:05:33 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 216.586583ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 10 Jan 2025 06:05:34 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 204.095709ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"recipients":"ADMINS_ONLY","_links":{"template":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/templates/email/UserActivation/settings","hints":{"allow":["GET","PUT"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 10 Jan 2025 06:05:34 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 216.833833ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/brands
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"bndj6aib7aQzEPT6y1d7","name":"oie-00","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":true,"emailDomainId":"OeDjl12acmIcI5J5B1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6aib7aQzEPT6y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjl12acmIcI5J5B1d7","hints":{"allow":["GET","PUT"]}}}},{"id":"bndj6db8gaBx3uAL41d7","name":"Elastic.co (External)","removePoweredByOkta":false,"customPrivacyPolicyUrl":null,"agreeToCustomPrivacyPolicy":false,"isDefault":false,"emailDomainId":"OeDjjwmc37W56NbwV1d7","defaultApp":{"appInstanceId":"0oaj6aib9keq33lPY1d7","appLinkName":null,"classicApplicationUri":null},"_links":{"themes":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7/themes","hints":{"allow":["GET"]}},"self":{"href":"https://oie-00.oktapreview.com/api/v1/brands/bndj6db8gaBx3uAL41d7","hints":{"allow":["GET","PUT","DELETE"]}},"emailDomain":{"href":"https://oie-00.oktapreview.com/api/v1/email-domains/OeDjjwmc37W56NbwV1d7","hints":{"allow":["GET","PUT"]}}}}]'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 10 Jan 2025 06:05:35 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/brands?limit=20>; rel="self"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 207.300333ms
+        duration: 201.535334ms

--- a/test/fixtures/vcr/TestAppUpdateStatus_all_apps/update_basic_auth_app/oie-with-feature-x.yaml
+++ b/test/fixtures/vcr/TestAppUpdateStatus_all_apps/update_basic_auth_app/oie-with-feature-x.yaml
@@ -1,0 +1,47 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 336
+        transfer_encoding: []
+        trailer: {}
+        host: oie-with-feature-x.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"accessibility":{"selfService":false},"label":"testAcc_2676871584","name":"template_basic_auth","settings":{"app":{"authURL":"https://example.com/login-1","url":"https://example.com/login.html"},"notes":{"admin":null,"enduser":null}},"signOnMode":"BASIC_AUTH","visibility":{"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false}}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-with-feature-x.dne-okta.com/api/v1/apps?activate=true
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"errorCode":"E0000001","errorSummary":"Api validation failed: generalSettings","errorLink":"E0000001","errorId":"oaeDbxh2tq6THy2iM3OZPbxug","errorCauses":[{"errorSummary":"Cannot create application instance template_basic_auth."}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 10 Jan 2025 06:04:32 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 400 Bad Request
+        code: 400
+        duration: 816.454709ms


### PR DESCRIPTION
This PR adds a TF resource to manage Okta email template settings (API docs [here](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/CustomTemplates/#tag/CustomTemplates/operation/getEmailSettings)). The email template settings can be used to control the recipients of different emails.

This is my first time writing a resource, so please review thoroughly 😁

Fixes: #2169