### PR TITLE
Ensure `yubikey_token` authenticator on `okta_policy_mfa` is respected.

### DIFF
--- a/sdk/authenticators.go
+++ b/sdk/authenticators.go
@@ -15,5 +15,5 @@ var AuthenticatorProviders = []string{
 	RsaTokenFactor,
 	SecurityQuestionFactor,
 	WebauthnFactor,
-	// YubikeyTokenFactor, // NOTE: support upcoming when available in public API
+	YubikeyTokenFactor,
 }


### PR DESCRIPTION
Ensure `yubikey_token` authenticator on `okta_policy_mfa` is respected.

Closes #2139

Included acceptance test `TestAccResourceOktaMfaPolicy_Issue_2139_yubikey_token` demonstrating correct behavior.