### PR TITLE
Improve `app_oauth` docs for "token_endpoint_auth_method"

### DIFF
--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -107,7 +107,7 @@ resource "okta_app_oauth" "example" {
 - `response_types` (Set of String) List of OAuth 2.0 response type strings.
 - `status` (String) Status of application. By default, it is `ACTIVE`
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `token_endpoint_auth_method` (String) Requested authentication method for the token endpoint.
+- `token_endpoint_auth_method` (String) Requested authentication method for the token endpoint, valid values include:  'client_secret_basic', 'client_secret_post', 'client_secret_jwt', 'private_key_jwt', 'none', etc.
 - `tos_uri` (String) URI to web page providing client tos (terms of service).
 - `user_name_template` (String) Username template. Default: `${source.login}`
 - `user_name_template_push_status` (String) Push username on update. Valid values: `PUSH` and `DONT_PUSH`

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -182,7 +182,7 @@ other arguments that changed will be applied.`,
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "client_secret_basic",
-				Description: "Requested authentication method for the token endpoint.",
+				Description: "Requested authentication method for the token endpoint, valid values include:  'client_secret_basic', 'client_secret_post', 'client_secret_jwt', 'private_key_jwt', 'none', etc.",
 			},
 			// API docs say that auto_key_rotation will alwas be set true if it
 			// is missing on input therefore we can declare it's default to be


### PR DESCRIPTION
Update description for "token_endpoint_auth_method" to include a non-exhaustive list of values that are **_**currently_** valid

Values may be added or removed in the future which is why I didn't add a schema validator here