### PR TITLE
Improve `limit` implementation on data_okta_groups

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -21,6 +21,7 @@ data "okta_groups" "example" {
 
 ### Optional
 
+- `limit` (Number) The maximum number of groups returned by the Okta API, between 1 and 10000.
 - `q` (String) Searches the name property of groups for matching value
 - `search` (String) Searches for groups with a supported filtering expression for all attributes except for '_embedded', '_links', and 'objectClass'
 - `type` (String) Type of the group. When specified in the terraform resource, will act as a filter when searching for the groups


### PR DESCRIPTION
We were previously only allowing for the use of a higher `limit` if the `q` parameter was used
This new implementation should allow the user to override the default page size when they need to
This should also improve the response time for queries that were seeking a small number of groups using the `q` parameter as the okta api returns results faster when the default page size is used
