### PR TITLE
`max_api_capacity` provider argument is not experimental

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -133,6 +133,6 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
 
 - `request_timeout` - (Optional) Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `300`.
 
-- `max_api_capacity` - (Optional, experimental) sets what percentage of capacity the provider can use of the total
+- `max_api_capacity` - (Optional) sets what percentage of capacity the provider can use of the total
   rate limit capacity while making calls to the Okta management API endpoints. Okta API operates in one minute buckets.
   See Okta Management API Rate Limits: https://developer.okta.com/docs/reference/rl-global-mgmt. Can be set to a value between 1 and 100.

--- a/okta/config.go
+++ b/okta/config.go
@@ -58,7 +58,7 @@ type (
 		maxWait                 int
 		logLevel                int
 		requestTimeout          int
-		maxAPICapacity          int // experimental
+		maxAPICapacity          int
 		oktaSDKClientV2         *sdk.Client
 		oktaSDKClientV3         *okta.APIClient
 		oktaSDKClientV5         *v5okta.APIClient

--- a/okta/framework_provider.go
+++ b/okta/framework_provider.go
@@ -178,7 +178,7 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 			},
 			"max_api_capacity": schema.Int64Attribute{
 				Optional: true,
-				Description: "(Experimental) sets what percentage of capacity the provider can use of the total rate limit " +
+				Description: "Sets what percentage of capacity the provider can use of the total rate limit " +
 					"capacity while making calls to the Okta management API endpoints. Okta API operates in one minute buckets. " +
 					"See Okta Management API Rate Limits: https://developer.okta.com/docs/reference/rl-global-mgmt/",
 				Validators: []validator.Int64{

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -229,7 +229,7 @@ func Provider() *schema.Provider {
 				Type:             schema.TypeInt,
 				Optional:         true,
 				ValidateDiagFunc: intBetween(1, 100),
-				Description: "(Experimental) sets what percentage of capacity the provider can use of the total rate limit " +
+				Description: "Sets what percentage of capacity the provider can use of the total rate limit " +
 					"capacity while making calls to the Okta management API endpoints. Okta API operates in one minute buckets. " +
 					"See Okta Management API Rate Limits: https://developer.okta.com/docs/reference/rl-global-mgmt/",
 			},

--- a/templates/index.md
+++ b/templates/index.md
@@ -133,6 +133,6 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
 
 - `request_timeout` - (Optional) Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `300`.
 
-- `max_api_capacity` - (Optional, experimental) sets what percentage of capacity the provider can use of the total
+- `max_api_capacity` - (Optional) sets what percentage of capacity the provider can use of the total
   rate limit capacity while making calls to the Okta management API endpoints. Okta API operates in one minute buckets.
   See Okta Management API Rate Limits: https://developer.okta.com/docs/reference/rl-global-mgmt. Can be set to a value between 1 and 100.


### PR DESCRIPTION
Updating documentation that the `max_api_capacity` provider argument is not experimental, it is stable.