### PR TITLE
fix: unreliable resource deletion in `okta_resource_set`

### DIFF
--- a/examples/resources/okta_resource_set/resource.tf
+++ b/examples/resources/okta_resource_set/resource.tf
@@ -1,44 +1,31 @@
-locals {
-  org_url = "https://mycompany.okta.com"
-}
-
-resource "okta_resource_set" "test" {
-  label       = "UsersAppsAndGroups"
-  description = "All the users, app and groups"
-  resources = [
-    format("%s/api/v1/users", local.org_url),
-    format("%s/api/v1/apps", local.org_url),
-    format("%s/api/v1/groups", local.org_url)
-  ]
-}
-
-data "okta_org_metadata" "_" {}
-locals {
-  org_url = try(
-    data.okta_org_metadata._.alternate,
-    data.okta_org_metadata._.organization
-  )
-}
+# Example 1: Basic resource set with direct URLs
 resource "okta_resource_set" "example" {
-  label       = "UsersAppsAndGroups"
-  description = "All the users, app and groups"
+  label       = "Basic Resource Set"
+  description = "Resource set for managing API endpoints"
   resources = [
-    "${local.org_url}/api/v1/users",
-    "${local.org_url}/api/v1/apps",
-    "${local.org_url}/api/v1/groups"
+    "https://your-domain.okta.com/api/v1/users",
+    "https://your-domain.okta.com/api/v1/groups"
   ]
 }
 
-### To Provide permissions to specific Groups
+# Example 2: Using org metadata to get the correct domain
+data "okta_org_metadata" "org" {}
 
-locals {
-  org_url = "https://mycompany.okta.com"
-}
-resource "okta_resource_set" "test" {
-  label       = "Specific Groups"
-  description = "Only Specific Group"
+resource "okta_resource_set" "dynamic" {
+  label       = "Dynamic Resource Set"
+  description = "Resource set using org metadata"
   resources = [
-    format("%s/api/v1/groups/groupid1", local.org_url),
-    format("%s/api/v1/groups/groupid2", local.org_url)
+    "${data.okta_org_metadata.org.organization}/api/v1/users",
+    "${data.okta_org_metadata.org.organization}/api/v1/groups"
+  ]
+}
+
+# Example 3: Specific group access using ORN format
+resource "okta_resource_set" "specific_groups" {
+  label       = "Specific Groups"
+  description = "Access to specific groups only"
+  resources_orn = [
+    "orn:okta:directory:${data.okta_org_metadata.org.id}:group:groupid1",
+    "orn:okta:directory:${data.okta_org_metadata.org.id}:group:groupid2"
   ]
 }

--- a/examples/resources/okta_resource_set/resource.tf
+++ b/examples/resources/okta_resource_set/resource.tf
@@ -1,44 +1,17 @@
-locals {
-  org_url = "https://mycompany.okta.com"
-}
-
-resource "okta_resource_set" "test" {
-  label       = "UsersAppsAndGroups"
-  description = "All the users, app and groups"
-  resources = [
-    format("%s/api/v1/users", local.org_url),
-    format("%s/api/v1/apps", local.org_url),
-    format("%s/api/v1/groups", local.org_url)
-  ]
-}
-
-data "okta_org_metadata" "_" {}
-locals {
-  org_url = try(
-    data.okta_org_metadata._.alternate,
-    data.okta_org_metadata._.organization
-  )
-}
+# Create a resource set to manage collections of Okta resources
 resource "okta_resource_set" "example" {
-  label       = "UsersAppsAndGroups"
-  description = "All the users, app and groups"
+  label       = "My Resource Set"
+  description = "Resource set for managing API endpoints"
+  
+  # Use URL-based resources
   resources = [
-    "${local.org_url}/api/v1/users",
-    "${local.org_url}/api/v1/apps",
-    "${local.org_url}/api/v1/groups"
+    "https://your-domain.okta.com/api/v1/users",
+    "https://your-domain.okta.com/api/v1/groups"
   ]
-}
-
-### To Provide permissions to specific Groups
-
-locals {
-  org_url = "https://mycompany.okta.com"
-}
-resource "okta_resource_set" "test" {
-  label       = "Specific Groups"
-  description = "Only Specific Group"
-  resources = [
-    format("%s/api/v1/groups/groupid1", local.org_url),
-    format("%s/api/v1/groups/groupid2", local.org_url)
-  ]
+  
+  # Alternatively, use ORN-based resources
+  # resources_orn = [
+  #   "orn:okta:directory:123:users",
+  #   "orn:okta:directory:123:groups"
+  # ]
 }

--- a/examples/resources/okta_resource_set/resource.tf
+++ b/examples/resources/okta_resource_set/resource.tf
@@ -1,17 +1,31 @@
-# Create a resource set to manage collections of Okta resources
+# Example 1: Basic resource set with direct URLs
 resource "okta_resource_set" "example" {
-  label       = "My Resource Set"
+  label       = "Basic Resource Set"
   description = "Resource set for managing API endpoints"
-  
-  # Use URL-based resources
   resources = [
     "https://your-domain.okta.com/api/v1/users",
     "https://your-domain.okta.com/api/v1/groups"
   ]
-  
-  # Alternatively, use ORN-based resources
-  # resources_orn = [
-  #   "orn:okta:directory:123:users",
-  #   "orn:okta:directory:123:groups"
-  # ]
+}
+
+# Example 2: Using org metadata to get the correct domain
+data "okta_org_metadata" "org" {}
+
+resource "okta_resource_set" "dynamic" {
+  label       = "Dynamic Resource Set"
+  description = "Resource set using org metadata"
+  resources = [
+    "${data.okta_org_metadata.org.organization}/api/v1/users",
+    "${data.okta_org_metadata.org.organization}/api/v1/groups"
+  ]
+}
+
+# Example 3: Specific group access using ORN format
+resource "okta_resource_set" "specific_groups" {
+  label       = "Specific Groups"
+  description = "Access to specific groups only"
+  resources_orn = [
+    "orn:okta:directory:${data.okta_org_metadata.org.id}:group:groupid1",
+    "orn:okta:directory:${data.okta_org_metadata.org.id}:group:groupid2"
+  ]
 }

--- a/examples/resources/okta_resource_set/resource.tf
+++ b/examples/resources/okta_resource_set/resource.tf
@@ -1,31 +1,44 @@
-# Example 1: Basic resource set with direct URLs
+locals {
+  org_url = "https://mycompany.okta.com"
+}
+
+resource "okta_resource_set" "test" {
+  label       = "UsersAppsAndGroups"
+  description = "All the users, app and groups"
+  resources = [
+    format("%s/api/v1/users", local.org_url),
+    format("%s/api/v1/apps", local.org_url),
+    format("%s/api/v1/groups", local.org_url)
+  ]
+}
+
+data "okta_org_metadata" "_" {}
+locals {
+  org_url = try(
+    data.okta_org_metadata._.alternate,
+    data.okta_org_metadata._.organization
+  )
+}
 resource "okta_resource_set" "example" {
-  label       = "Basic Resource Set"
-  description = "Resource set for managing API endpoints"
+  label       = "UsersAppsAndGroups"
+  description = "All the users, app and groups"
   resources = [
-    "https://your-domain.okta.com/api/v1/users",
-    "https://your-domain.okta.com/api/v1/groups"
+    "${local.org_url}/api/v1/users",
+    "${local.org_url}/api/v1/apps",
+    "${local.org_url}/api/v1/groups"
   ]
 }
 
-# Example 2: Using org metadata to get the correct domain
-data "okta_org_metadata" "org" {}
+### To Provide permissions to specific Groups
 
-resource "okta_resource_set" "dynamic" {
-  label       = "Dynamic Resource Set"
-  description = "Resource set using org metadata"
-  resources = [
-    "${data.okta_org_metadata.org.organization}/api/v1/users",
-    "${data.okta_org_metadata.org.organization}/api/v1/groups"
-  ]
+locals {
+  org_url = "https://mycompany.okta.com"
 }
-
-# Example 3: Specific group access using ORN format
-resource "okta_resource_set" "specific_groups" {
+resource "okta_resource_set" "test" {
   label       = "Specific Groups"
-  description = "Access to specific groups only"
-  resources_orn = [
-    "orn:okta:directory:${data.okta_org_metadata.org.id}:group:groupid1",
-    "orn:okta:directory:${data.okta_org_metadata.org.id}:group:groupid2"
+  description = "Only Specific Group"
+  resources = [
+    format("%s/api/v1/groups/groupid1", local.org_url),
+    format("%s/api/v1/groups/groupid2", local.org_url)
   ]
 }

--- a/examples/resources/okta_resource_set/test_basic.tf
+++ b/examples/resources/okta_resource_set/test_basic.tf
@@ -1,11 +1,11 @@
-variable "hostname" { type = string }
+data "okta_org_metadata" "org" {}
 
 resource "okta_resource_set" "test" {
   label       = "testAcc_replace_with_uuid"
   description = "testing, testing"
   resources = [
-    "https://${var.hostname}/api/v1/users",
-    "https://${var.hostname}/api/v1/apps",
-    "https://${var.hostname}/api/v1/groups"
+    "https://${data.okta_org_metadata.org.organization}/api/v1/users",
+    "https://${data.okta_org_metadata.org.organization}/api/v1/apps",
+    "https://${data.okta_org_metadata.org.organization}/api/v1/groups"
   ]
 }

--- a/examples/resources/okta_resource_set/test_basic.tf
+++ b/examples/resources/okta_resource_set/test_basic.tf
@@ -1,0 +1,11 @@
+variable "hostname" { type = string }
+
+resource "okta_resource_set" "test" {
+  label       = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+  resources = [
+    "https://${var.hostname}/api/v1/users",
+    "https://${var.hostname}/api/v1/apps",
+    "https://${var.hostname}/api/v1/groups"
+  ]
+}

--- a/examples/resources/okta_resource_set/test_basic_updated.tf
+++ b/examples/resources/okta_resource_set/test_basic_updated.tf
@@ -1,10 +1,10 @@
-variable "hostname" { type = string }
+data "okta_org_metadata" "org" {}
 
 resource "okta_resource_set" "test" {
   label       = "testAcc_replace_with_uuid updated"
   description = "testing, testing updated"
   resources = [
-    "https://${var.hostname}/api/v1/users",
-    "https://${var.hostname}/api/v1/apps"
+    "https://${data.okta_org_metadata.org.organization}/api/v1/users",
+    "https://${data.okta_org_metadata.org.organization}/api/v1/apps"
   ]
 }

--- a/examples/resources/okta_resource_set/test_basic_updated.tf
+++ b/examples/resources/okta_resource_set/test_basic_updated.tf
@@ -1,0 +1,10 @@
+variable "hostname" { type = string }
+
+resource "okta_resource_set" "test" {
+  label       = "testAcc_replace_with_uuid updated"
+  description = "testing, testing updated"
+  resources = [
+    "https://${var.hostname}/api/v1/users",
+    "https://${var.hostname}/api/v1/apps"
+  ]
+}

--- a/examples/resources/okta_resource_set/test_drift_detection.tf
+++ b/examples/resources/okta_resource_set/test_drift_detection.tf
@@ -1,0 +1,10 @@
+variable "hostname" { type = string }
+
+resource "okta_resource_set" "test" {
+  label       = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+  resources = [
+    "https://${var.hostname}/api/v1/users",
+    "https://${var.hostname}/api/v1/groups"
+  ]
+}

--- a/examples/resources/okta_resource_set/test_drift_detection.tf
+++ b/examples/resources/okta_resource_set/test_drift_detection.tf
@@ -1,10 +1,10 @@
-variable "hostname" { type = string }
+data "okta_org_metadata" "org" {}
 
 resource "okta_resource_set" "test" {
   label       = "testAcc_replace_with_uuid"
   description = "testing, testing"
   resources = [
-    "https://${var.hostname}/api/v1/users",
-    "https://${var.hostname}/api/v1/groups"
+    "https://${data.okta_org_metadata.org.organization}/api/v1/users",
+    "https://${data.okta_org_metadata.org.organization}/api/v1/groups"
   ]
 }

--- a/examples/resources/okta_resource_set/test_drift_detection_updated.tf
+++ b/examples/resources/okta_resource_set/test_drift_detection_updated.tf
@@ -1,11 +1,11 @@
-variable "hostname" { type = string }
+data "okta_org_metadata" "org" {}
 
 resource "okta_resource_set" "test" {
   label       = "testAcc_replace_with_uuid"
   description = "testing, testing"
   resources = [
-    "https://${var.hostname}/api/v1/users",
-    "https://${var.hostname}/api/v1/groups",
-    "https://${var.hostname}/api/v1/apps"
+    "https://${data.okta_org_metadata.org.organization}/api/v1/users",
+    "https://${data.okta_org_metadata.org.organization}/api/v1/groups",
+    "https://${data.okta_org_metadata.org.organization}/api/v1/apps"
   ]
 }

--- a/examples/resources/okta_resource_set/test_drift_detection_updated.tf
+++ b/examples/resources/okta_resource_set/test_drift_detection_updated.tf
@@ -1,0 +1,11 @@
+variable "hostname" { type = string }
+
+resource "okta_resource_set" "test" {
+  label       = "testAcc_replace_with_uuid"
+  description = "testing, testing"
+  resources = [
+    "https://${var.hostname}/api/v1/users",
+    "https://${var.hostname}/api/v1/groups",
+    "https://${var.hostname}/api/v1/apps"
+  ]
+}

--- a/examples/resources/okta_resource_set/test_orn_handling.tf
+++ b/examples/resources/okta_resource_set/test_orn_handling.tf
@@ -1,0 +1,10 @@
+variable "id" { type = string }
+
+resource "okta_resource_set" "test" {
+  label         = "testAcc_replace_with_uuid"
+  description   = "testing, testing"
+  resources_orn = [
+    "orn:okta:directory:${var.id}:users",
+    "orn:okta:directory:${var.id}:groups"
+  ]
+}

--- a/examples/resources/okta_resource_set/test_orn_handling.tf
+++ b/examples/resources/okta_resource_set/test_orn_handling.tf
@@ -1,10 +1,10 @@
-variable "id" { type = string }
+data "okta_org_metadata" "org" {}
 
 resource "okta_resource_set" "test" {
-  label         = "testAcc_replace_with_uuid"
-  description   = "testing, testing"
+  label       = "testAcc_replace_with_uuid"
+  description = "testing, testing"
   resources_orn = [
-    "orn:okta:directory:${var.id}:users",
-    "orn:okta:directory:${var.id}:groups"
+    "orn:okta:directory:${data.okta_org_metadata.org.id}:groups",
+    "orn:okta:directory:${data.okta_org_metadata.org.id}:users"
   ]
 }

--- a/examples/resources/okta_resource_set/test_pagination.tf
+++ b/examples/resources/okta_resource_set/test_pagination.tf
@@ -1,0 +1,12 @@
+variable "hostname" { type = string }
+
+resource "okta_group" "test" {
+  count = 101
+  name  = "testAcc_${count.index}"
+}
+
+resource "okta_resource_set" "test" {
+  label       = "testAcc_replace_with_uuid"
+  description = "testing pagination with large resource set"
+  resources   = [ for g in okta_group.test[*] : "https://${var.hostname}/api/v1/groups/${g.id}" ]
+}

--- a/examples/resources/okta_resource_set/test_pagination.tf
+++ b/examples/resources/okta_resource_set/test_pagination.tf
@@ -1,7 +1,7 @@
 variable "hostname" { type = string }
 
 resource "okta_group" "test" {
-  count = 101
+  count = 201  # Test pagination across 200-item boundary
   name  = "testAcc_${count.index}"
 }
 

--- a/examples/resources/okta_resource_set/test_pagination.tf
+++ b/examples/resources/okta_resource_set/test_pagination.tf
@@ -1,12 +1,15 @@
-variable "hostname" { type = string }
+data "okta_org_metadata" "org" {}
 
 resource "okta_group" "test" {
-  count = 201  # Test pagination across 200-item boundary
+  count = 201 # Test pagination across 200-item boundary
   name  = "testAcc_${count.index}"
 }
 
 resource "okta_resource_set" "test" {
   label       = "testAcc_replace_with_uuid"
   description = "testing pagination with large resource set"
-  resources   = [ for g in okta_group.test[*] : "https://${var.hostname}/api/v1/groups/${g.id}" ]
+  resources = [
+    for g in okta_group.test[*] :
+    "https://${data.okta_org_metadata.org.organization}/api/v1/groups/${g.id}"
+  ]
 }

--- a/okta/acctest/acctest.go
+++ b/okta/acctest/acctest.go
@@ -206,6 +206,7 @@ func newVCRRecorder(mgr *vcrManager, transport http.RoundTripper) (rec *recorder
 	vcrOpts := []recorder.Option{
 		recorder.WithMatcher(vcrMatcher()),
 		recorder.WithHook(vcrHook(mgr), recorder.AfterCaptureHook),
+		recorder.WithHook(vcrSaveHook(mgr), recorder.BeforeSaveHook),
 		recorder.WithMode(mgr.VCRMode()),
 		recorder.WithSkipRequestLatency(true),
 		recorder.WithRealTransport(transport),
@@ -343,12 +344,105 @@ func replaceHeaderValues(currentValues []string, oldValue, newValue string) []st
 	return result
 }
 
+// compareJSONWithUnorderedArrays compares two JSON objects, treating arrays as unordered
+// when they contain primitive values (strings, numbers, booleans)
+func compareJSONWithUnorderedArrays(reqJson, cassetteJson interface{}) bool {
+	switch req := reqJson.(type) {
+	case map[string]interface{}:
+		cassette, ok := cassetteJson.(map[string]interface{})
+		if !ok {
+			return false
+		}
+
+		// Check if all keys in request exist in cassette
+		for key, reqValue := range req {
+			cassetteValue, exists := cassette[key]
+			if !exists {
+				return false
+			}
+			if !compareJSONWithUnorderedArrays(reqValue, cassetteValue) {
+				return false
+			}
+		}
+
+		// Check if all keys in cassette exist in request
+		for key := range cassette {
+			if _, exists := req[key]; !exists {
+				return false
+			}
+		}
+		return true
+
+	case []interface{}:
+		cassette, ok := cassetteJson.([]interface{})
+		if !ok {
+			return false
+		}
+
+		if len(req) != len(cassette) {
+			return false
+		}
+
+		// If all elements are primitive types, treat as unordered
+		if isPrimitiveArray(req) && isPrimitiveArray(cassette) {
+			return compareUnorderedArrays(req, cassette)
+		}
+
+		// Otherwise, compare in order
+		for i, reqValue := range req {
+			if !compareJSONWithUnorderedArrays(reqValue, cassette[i]) {
+				return false
+			}
+		}
+		return true
+
+	default:
+		return reflect.DeepEqual(reqJson, cassetteJson)
+	}
+}
+
+// isPrimitiveArray checks if all elements in the array are primitive types
+func isPrimitiveArray(arr []interface{}) bool {
+	for _, item := range arr {
+		switch item.(type) {
+		case string, float64, int, int64, bool, nil:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// compareUnorderedArrays compares two arrays as unordered sets
+func compareUnorderedArrays(req, cassette []interface{}) bool {
+	if len(req) != len(cassette) {
+		return false
+	}
+
+	// Convert to sets for comparison
+	reqSet := make(map[string]bool)
+	cassetteSet := make(map[string]bool)
+
+	for _, item := range req {
+		reqSet[fmt.Sprintf("%v", item)] = true
+	}
+
+	for _, item := range cassette {
+		cassetteSet[fmt.Sprintf("%v", item)] = true
+	}
+
+	return reflect.DeepEqual(reqSet, cassetteSet)
+}
+
 func vcrMatcher() func(*http.Request, cassette.Request) bool {
 	return func(r *http.Request, i cassette.Request) bool {
 		if r.Method != i.Method {
+			log.Printf("[DEBUG] VCR matcher: method mismatch - request: %s, cassette: %s", r.Method, i.Method)
 			return false
 		}
 		if r.URL.String() != i.URL {
+			log.Printf("[DEBUG] VCR matcher: URL mismatch - request: %s, cassette: %s", r.URL.String(), i.URL)
 			return false
 		}
 		// TODO: there might be header information we could inspect to make this more precise
@@ -380,10 +474,21 @@ func vcrMatcher() func(*http.Request, cassette.Request) bool {
 				log.Printf("[DEBUG] Failed to unmarshall cassette json: %v", err)
 				return false
 			}
-			return reflect.DeepEqual(reqJson, cassetteJson)
+			if reflect.DeepEqual(reqJson, cassetteJson) {
+				return true
+			}
+
+			// Try comparing with unordered array handling
+			if compareJSONWithUnorderedArrays(reqJson, cassetteJson) {
+				return true
+			}
+
+			log.Printf("[DEBUG] VCR matcher: JSON body mismatch - request: %s, cassette: %s", reqBody, i.Body)
+			return false
 		}
 
-		return true
+		log.Printf("[DEBUG] VCR matcher: body mismatch - request: %s, cassette: %s", reqBody, i.Body)
+		return false
 	}
 }
 
@@ -472,6 +577,37 @@ func vcrHook(mgr *vcrManager) func(*cassette.Interaction) error {
 		// %s/example/test/
 		i.Request.Body = strings.ReplaceAll(i.Request.Body, orgName, vcrOrgName)
 
+		// Note: Response body and header sanitization is now handled in vcrSaveHook
+		// to avoid causing Terraform drift detection during recording.
+
+		return nil
+	}
+}
+
+// vcrSaveHook sanitizes response bodies before saving the cassette to disk.
+// This ensures that sensitive domain information is replaced with sanitized values
+// while preserving the original response during the test execution.
+func vcrSaveHook(mgr *vcrManager) func(*cassette.Interaction) error {
+	return func(i *cassette.Interaction) error {
+		// test-admin.dne-okta.com
+		vcrAdminHostname := fmt.Sprintf("%s-admin.%s", mgr.CurrentCassette, TestDomainName)
+		// test.dne-okta.com
+		vcrHostname := fmt.Sprintf("%s.%s", mgr.CurrentCassette, TestDomainName)
+		// example-admin.okta.com
+		orgAdminHostname := fmt.Sprintf("%s-admin.%s", os.Getenv("OKTA_ORG_NAME"), os.Getenv("OKTA_BASE_URL"))
+		// example.okta.com
+		orgHostname := fmt.Sprintf("%s.%s", os.Getenv("OKTA_ORG_NAME"), os.Getenv("OKTA_BASE_URL"))
+
+		// test-admin
+		vcrAdminOrgName := fmt.Sprintf("%s-admin", mgr.CurrentCassette)
+		// test
+		vcrOrgName := mgr.CurrentCassette
+		// example-admin
+		adminOrgName := fmt.Sprintf("%s-admin", os.Getenv("OKTA_ORG_NAME"))
+		// example
+		orgName := os.Getenv("OKTA_ORG_NAME")
+
+		// Sanitize response body - replace real domain names with sanitized ones
 		// %s/example-admin.okta.com/test-admin.dne-okta.com/
 		i.Response.Body = strings.ReplaceAll(i.Response.Body, orgAdminHostname, vcrAdminHostname)
 		// %s/example.okta.com/test.dne-okta.com/
@@ -482,6 +618,7 @@ func vcrHook(mgr *vcrManager) func(*cassette.Interaction) error {
 		// %s/example/test/
 		i.Response.Body = strings.ReplaceAll(i.Response.Body, orgName, vcrOrgName)
 
+		// Sanitize response headers that might contain domain information
 		// %s/example-admin.okta.com/test-admin.dne-okta.com/
 		headerLinks := replaceHeaderValues(i.Response.Headers["Link"], orgAdminHostname, vcrAdminHostname)
 		// %s/example.okta.com/test.dne-okta.com/

--- a/okta/services/idaas/idaas_test.go
+++ b/okta/services/idaas/idaas_test.go
@@ -660,7 +660,7 @@ func sweepResourceSets(client api.OktaIDaaSClient) error {
 		return err
 	}
 	for _, b := range resourceSets.ResourceSets {
-		if !strings.HasPrefix(b.Label, "testAcc_") {
+		if strings.HasPrefix(b.Label, "testAcc_") {
 			if _, err := client.OktaSDKSupplementClient().DeleteResourceSet(context.Background(), b.Id); err != nil {
 				errorList = append(errorList, err)
 				continue

--- a/okta/services/idaas/resource_okta_resource_set_test.go
+++ b/okta/services/idaas/resource_okta_resource_set_test.go
@@ -49,14 +49,11 @@ func TestAccResourceOktaResourceSet_crud(t *testing.T) {
 
 // TestAccResourceOktaResourceSet_Issue1097_Pagination tests the fix for
 // https://github.com/okta/terraform-provider-okta/issues/1097
-// where pagination would fail with more than 100 resources.
+// where pagination would fail with more than 200 resources.
 //
-// Originally tested with 201 resources, but reduced to 101 as we only need
-// to verify pagination works beyond the first page (100 items). This reduces
-// test execution time while still validating the pagination functionality.
-//
-// The issue manifested as:
-// - Resources beyond the first 100 would be lost
+// Uses 201 resources to specifically test handling across Okta's 200-item
+// page boundary. The issue manifested as:
+// - Resources beyond the first 200 would be lost
 // - State refresh would fail to capture all resources
 // - Plan would show phantom changes
 func TestAccResourceOktaResourceSet_Issue1097_Pagination(t *testing.T) {
@@ -77,7 +74,7 @@ func TestAccResourceOktaResourceSet_Issue1097_Pagination(t *testing.T) {
 				{
 					Config: mgr.GetFixtures("test_pagination.tf", t),
 					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(stateAddress, "resources.#", "101"),
+						resource.TestCheckResourceAttr(stateAddress, "resources.#", "201"),
 					),
 				},
 			},

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaResourceSet_Issue_1735_drift_detection/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaResourceSet_Issue_1735_drift_detection/oie-00.yaml
@@ -1,0 +1,797 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 171
+        host: oie-00.dne-okta.com
+        body: |
+            {"label":"testAcc_2808315154","description":"testing, testing","resources":["https://oie-00.dne-okta.com/api/v1/groups","https://oie-00.dne-okta.com/api/v1/users"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:58 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 672.561417ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:58 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 661.523042ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:59 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 659.973417ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:00 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 672.189625ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:01 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 676.116166ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:02 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 661.604875ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:02 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 681.552084ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:04 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 655.90975ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}},{"id":"iretf8bnlz5h1AwfT697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:53:03.000Z","lastUpdated":"2025-07-21T01:53:03.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf8bnlz5h1AwfT697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:05 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 682.981208ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:06 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 666.417166ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}},{"id":"iretf8bnlz5h1AwfT697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:53:03.000Z","lastUpdated":"2025-07-21T01:53:03.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf8bnlz5h1AwfT697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:07 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 668.598125ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:08 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 639.045334ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}},{"id":"iretf8bnlz5h1AwfT697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:53:03.000Z","lastUpdated":"2025-07-21T01:53:03.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf8bnlz5h1AwfT697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:09 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 657.86075ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:10 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 682.721417ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}},{"id":"iretf8bnlz5h1AwfT697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:53:03.000Z","lastUpdated":"2025-07-21T01:53:03.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf8bnlz5h1AwfT697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:10 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 655.888ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}},{"id":"iretf8bnlz5h1AwfT697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:53:03.000Z","lastUpdated":"2025-07-21T01:53:03.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf8bnlz5h1AwfT697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:11 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 711.808167ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf8bnlz5h1AwfT697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 21 Jul 2025 01:53:12 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 677.413375ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:13 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 670.536292ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:13 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 687.007625ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf879ceBBMtFSq697","label":"testAcc_2808315154","description":"testing, testing","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:14 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 693.077875ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf879cfV0MjNc0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cfV0MjNc0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf879cgtCBm1el697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:58.000Z","lastUpdated":"2025-07-21T01:52:58.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources/iretf879cgtCBm1el697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:15 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 651.889291ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf879ceBBMtFSq697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 21 Jul 2025 01:53:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 673.200667ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaResourceSet_Issue_1991_orn_handling/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaResourceSet_Issue_1991_orn_handling/oie-00.yaml
@@ -1,0 +1,378 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/.well-known/okta-organization
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"id":"00osd501x0KyUtOul697","cell":"ok14","_links":{"organization":{"href":"https://oie-00.dne-okta.com"}},"pipeline":"idx","settings":{"analyticsCollectionEnabled":true,"bugReportingEnabled":true,"omEnabled":false,"pssoEnabled":false,"desktopMFAEnabled":false,"itpEnabled":true}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:17 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 663.156667ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/.well-known/okta-organization
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"id":"00osd501x0KyUtOul697","cell":"ok14","_links":{"organization":{"href":"https://oie-00.dne-okta.com"}},"pipeline":"idx","settings":{"analyticsCollectionEnabled":true,"bugReportingEnabled":true,"omEnabled":false,"pssoEnabled":false,"desktopMFAEnabled":false,"itpEnabled":true}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:18 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 640.165ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 174
+        host: oie-00.dne-okta.com
+        body: |
+            {"label":"testAcc_511152788","description":"testing, testing","resources":["orn:okta:directory:00osd501x0KyUtOul697:groups","orn:okta:directory:00osd501x0KyUtOul697:users"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf8aemqZm7xt8b697","label":"testAcc_511152788","description":"testing, testing","created":"2025-07-21T01:53:19.000Z","lastUpdated":"2025-07-21T01:53:19.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:19 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 694.114292ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf8aemqZm7xt8b697","label":"testAcc_511152788","description":"testing, testing","created":"2025-07-21T01:53:19.000Z","lastUpdated":"2025-07-21T01:53:19.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:19 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 644.686625ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf8aemrnZv89l0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:53:19.000Z","lastUpdated":"2025-07-21T01:53:19.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources/iretf8aemrnZv89l0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf8aemsDS0dZdT697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:53:19.000Z","lastUpdated":"2025-07-21T01:53:19.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources/iretf8aemsDS0dZdT697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:20 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 677.768458ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/.well-known/okta-organization
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"id":"00osd501x0KyUtOul697","cell":"ok14","_links":{"organization":{"href":"https://oie-00.dne-okta.com"}},"pipeline":"idx","settings":{"analyticsCollectionEnabled":true,"bugReportingEnabled":true,"omEnabled":false,"pssoEnabled":false,"desktopMFAEnabled":false,"itpEnabled":true}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:21 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 651.506959ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/.well-known/okta-organization
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"id":"00osd501x0KyUtOul697","cell":"ok14","_links":{"organization":{"href":"https://oie-00.dne-okta.com"}},"pipeline":"idx","settings":{"analyticsCollectionEnabled":true,"bugReportingEnabled":true,"omEnabled":false,"pssoEnabled":false,"desktopMFAEnabled":false,"itpEnabled":true}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:22 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 650.975542ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf8aemqZm7xt8b697","label":"testAcc_511152788","description":"testing, testing","created":"2025-07-21T01:53:19.000Z","lastUpdated":"2025-07-21T01:53:19.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:22 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 670.557791ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf8aemrnZv89l0697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:53:19.000Z","lastUpdated":"2025-07-21T01:53:19.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources/iretf8aemrnZv89l0697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf8aemsDS0dZdT697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:53:19.000Z","lastUpdated":"2025-07-21T01:53:19.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources/iretf8aemsDS0dZdT697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:23 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 672.220833ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/.well-known/okta-organization
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"id":"00osd501x0KyUtOul697","cell":"ok14","_links":{"organization":{"href":"https://oie-00.dne-okta.com"}},"pipeline":"idx","settings":{"analyticsCollectionEnabled":true,"bugReportingEnabled":true,"omEnabled":false,"pssoEnabled":false,"desktopMFAEnabled":false,"itpEnabled":true}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:53:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 648.430875ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf8aemqZm7xt8b697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 21 Jul 2025 01:53:25 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 667.634ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaResourceSet_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaResourceSet_crud/oie-00.yaml
@@ -1,0 +1,544 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 215
+        host: oie-00.dne-okta.com
+        body: |
+            {"label":"testAcc_263495486","description":"testing, testing","resources":["https://oie-00.dne-okta.com/api/v1/groups","https://oie-00.dne-okta.com/api/v1/apps","https://oie-00.dne-okta.com/api/v1/users"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486","description":"testing, testing","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:45 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 669.935542ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486","description":"testing, testing","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:46 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 643.652833ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf83iuxPeJJEWL697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuxPeJJEWL697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf83iuyrYA6xzl697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuyrYA6xzl697"}}},{"id":"iretf83iuz3lYWLV1697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuz3lYWLV1697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:47 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 661.464916ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486","description":"testing, testing","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:48 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 658.361583ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf83iuxPeJJEWL697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuxPeJJEWL697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf83iuyrYA6xzl697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuyrYA6xzl697"}}},{"id":"iretf83iuz3lYWLV1697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuz3lYWLV1697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:48 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 670.062083ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486","description":"testing, testing","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:49 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 667.108375ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf83iuxPeJJEWL697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuxPeJJEWL697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf83iuyrYA6xzl697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuyrYA6xzl697"}}},{"id":"iretf83iuz3lYWLV1697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:45.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuz3lYWLV1697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:50 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 657.114ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 107
+        host: oie-00.dne-okta.com
+        body: |
+            {"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486 updated","description":"testing, testing updated"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486 updated","description":"testing, testing updated","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:51 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 697.467833ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf83iuxPeJJEWL697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuxPeJJEWL697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf83iuyrYA6xzl697","orn":"orn:okta:directory:00osd501x0KyUtOul697:groups","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"groups":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/groups"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuyrYA6xzl697"}}},{"id":"iretf83iuz3lYWLV1697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuz3lYWLV1697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:52 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 645.205292ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuyrYA6xzl697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 21 Jul 2025 01:52:52 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 687.573458ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486 updated","description":"testing, testing updated","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:53 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 681.947458ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf83iuxPeJJEWL697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuxPeJJEWL697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf83iuz3lYWLV1697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuz3lYWLV1697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:54 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 713.539917ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"iamtf83iuwvpJpJcz697","label":"testAcc_263495486 updated","description":"testing, testing updated","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"bindings":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/bindings"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"resources":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:55 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 661.532666ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resources":[{"id":"iretf83iuxPeJJEWL697","orn":"orn:okta:directory:00osd501x0KyUtOul697:users","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuxPeJJEWL697"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/users"}}},{"id":"iretf83iuz3lYWLV1697","orn":"orn:okta:idp:00osd501x0KyUtOul697:apps","created":"2025-07-21T01:52:45.000Z","lastUpdated":"2025-07-21T01:52:51.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps"},"resource":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources/iretf83iuz3lYWLV1697"}}}],"_links":{"resource-set":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 21 Jul 2025 01:52:55 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697/resources>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 700.44425ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/iam/resource-sets/iamtf83iuwvpJpJcz697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 21 Jul 2025 01:52:56 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 694.7935ms


### PR DESCRIPTION
fixes #2220


---
[decouple tests from examples to fix tests](https://github.com/okta/terraform-provider-okta/commit/b3a2deb1ef37fa46e84befc03033faf262a6c314)
At some point one of the examples was changed in a way that broke the
tests for okta_resource_set
by inlining our test config, we can avoid this in the future and write
more useful example code

---
[fix silent resource deletion failure](https://github.com/okta/terraform-provider-okta/commit/96161c01eaa8dfb80855015c3e689cde6459625c) 

okta_resource_set would previously fail to remove entries under certain
circumstances, i'm not entirely clear what the root cause is here, but
updating to V5 of the GoLang SDK seems to have resolved the issue