### PR TITLE
feat: data_okta_groups: add `source` application Id

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -21,6 +21,7 @@ data "okta_groups" "example" {
 
 ### Optional
 
+- `limit` (Number) The maximum number of groups returned by the Okta API, between 1 and 10000.
 - `q` (String) Searches the name property of groups for matching value
 - `search` (String) Searches for groups with a supported filtering expression for all attributes except for '_embedded', '_links', and 'objectClass'
 - `type` (String) Type of the group. When specified in the terraform resource, will act as a filter when searching for the groups

--- a/examples/data-sources/okta_groups/datasource.tf
+++ b/examples/data-sources/okta_groups/datasource.tf
@@ -8,12 +8,16 @@ resource "okta_group" "test_2" {
   description = "testing, testing"
 }
 
-data "okta_groups" "test" {
+data "okta_groups" "okta_groups" {
   q = "testAcc_"
 }
 
 data "okta_groups" "app_groups" {
   type = "APP_GROUP"
+}
+
+data "okta_groups" "built_in_groups" {
+  type = "BUILT_IN"
 }
 
 output "special_groups" {

--- a/okta/data_source_okta_groups.go
+++ b/okta/data_source_okta_groups.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/sdk/query"
 )
 
@@ -16,19 +17,22 @@ func dataSourceGroups() *schema.Resource {
 		ReadContext: dataSourceGroupsRead,
 		Schema: map[string]*schema.Schema{
 			"q": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Searches the name property of groups for matching value",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Searches the name property of groups for matching value",
+				ConflictsWith: []string{"search"},
 			},
 			"search": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Searches for groups with a supported filtering expression for all attributes except for '_embedded', '_links', and 'objectClass'",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Searches for groups with a supported filtering expression for all attributes except for '_embedded', '_links', and 'objectClass'",
+				ConflictsWith: []string{"type", "q"},
 			},
 			"type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Type of the group. When specified in the terraform resource, will act as a filter when searching for the groups",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Type of the group. When specified in the terraform resource, will act as a filter when searching for the groups",
+				ConflictsWith: []string{"search"},
 			},
 			"limit": {
 				Type:        schema.TypeInt,
@@ -36,7 +40,11 @@ func dataSourceGroups() *schema.Resource {
 				Description: "The maximum number of groups returned by the Okta API, between 1 and 10000.",
 				Default:     defaultPaginationLimit,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
+					value, ok := v.(int)
+					if !ok {
+						errors = append(errors, fmt.Errorf("expected %s to be an int", k))
+						return
+					}
 					if value < 1 || value > 10000 {
 						errors = append(errors, fmt.Errorf("limit must be between 1 and 10000"))
 					}
@@ -61,12 +69,17 @@ func dataSourceGroups() *schema.Resource {
 						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "Group type.",
+							Description: "Group type, either 'APP_GROUP' or 'OKTA_GROUP'.",
 						},
 						"description": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Group description.",
+						},
+						"source": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the application the Group is sourced/imported from (only present for groups of type APP_GROUP).",
 						},
 						"custom_profile_attributes": {
 							Type:        schema.TypeString,
@@ -82,45 +95,85 @@ func dataSourceGroups() *schema.Resource {
 }
 
 func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	limit, ok := d.GetOk("limit")
-	if !ok {
-		limit = defaultPaginationLimit
-	}
-	qp := &query.Params{Limit: limit.(int64)}
+	client := getOktaV5ClientFromMetadata(meta)
 
-	groupType, ok := d.GetOk("type")
-	if ok {
-		qp.Filter = fmt.Sprintf("type eq \"%s\"", groupType.(string))
-	}
+	apiRequest := client.GroupAPI.ListGroups(ctx)
+	apiRequest = apiRequest.Limit(int32(defaultPaginationLimit))
+	qp := &query.Params{Limit: defaultPaginationLimit}
 
-	q, ok := d.GetOk("q")
-	if ok {
-		qp.Q = q.(string)
+	if groupType, ok := d.GetOk("type"); ok {
+		filter := fmt.Sprintf("type eq \"%s\"", groupType.(string))
+		apiRequest = apiRequest.Filter(filter)
+		qp.Filter = filter
 	}
 
-	search, ok := d.GetOk("search")
-	if ok {
+	if limit, ok := d.GetOk("limit"); ok {
+		// override default page_size if user specified a custom limit value
+		apiRequest = apiRequest.Limit(int32(limit.(int)))
+	}
+
+	if query, ok := d.GetOk("q"); ok {
+		qp.Limit = 10000 // keeping this here to avoid potentially changing datasource ID generation behavior
+		apiRequest = apiRequest.Q(query.(string))
+		qp.Q = query.(string)
+	}
+
+	if search, ok := d.GetOk("search"); ok {
+		apiRequest = apiRequest.Search(search.(string))
 		qp.Search = search.(string)
 	}
 
-	groups, err := listGroups(ctx, getOktaClientFromMetadata(meta), qp)
+	groups, resp, err := apiRequest.Execute()
 	if err != nil {
+		d.SetId("")
 		return diag.Errorf("failed to list groups: %v", err)
 	}
-	d.SetId(fmt.Sprintf("%d", crc32.ChecksumIEEE([]byte(qp.String()))))
+
+	// handle pagination
+	for {
+		if !resp.HasNextPage() {
+			break
+		}
+		var moreGroups []v5okta.Group
+		var err error
+		resp, err = resp.Next(&moreGroups)
+		if err != nil {
+			return diag.Errorf("failed to get next page of groups: %v", err)
+		}
+		groups = append(groups, moreGroups...)
+
+	}
+
+	// generate a unique ID for the data source based on the query parameters
+	dataSourceId := fmt.Sprintf("%d", crc32.ChecksumIEEE([]byte(qp.String())))
+	d.SetId(dataSourceId)
+
+	// convert the groups to a list of maps
 	arr := make([]map[string]interface{}, len(groups))
 	for i := range groups {
-		customProfile, err := json.Marshal(groups[i].Profile.GroupProfileMap)
+		arr[i] = map[string]interface{}{}
+
+		arr[i]["id"] = groups[i].Id
+		arr[i]["name"] = groups[i].Profile.Name
+		arr[i]["type"] = groups[i].Type
+		arr[i]["description"] = groups[i].Profile.Description
+
+		additionalProperties := groups[i].AdditionalProperties
+		src, ok := additionalProperties["source"].(map[string]interface{})
+		if ok && src["id"] != nil {
+			arr[i]["source"] = src["id"].(string)
+		}
+
+		// OktaV5 doesn't remove "source" from additionalProperties,
+		// so we do it manually to ensure backwards compatibility with prior OktaV2 implementation
+		delete(additionalProperties, "source")
+
+		customProfile, err := json.Marshal(additionalProperties)
 		if err != nil {
-			return diag.Errorf("failed to read custom profile attributes from group: %s", groups[i].Profile.Name)
+			return diag.Errorf("failed to read custom profile attributes from group: %s", additionalProperties)
 		}
-		arr[i] = map[string]interface{}{
-			"id":                        groups[i].Id,
-			"name":                      groups[i].Profile.Name,
-			"type":                      groups[i].Type,
-			"description":               groups[i].Profile.Description,
-			"custom_profile_attributes": string(customProfile),
-		}
+		arr[i]["custom_profile_attributes"] = string(customProfile)
+
 	}
 	_ = d.Set("groups", arr)
 	return nil

--- a/okta/data_source_okta_groups_test.go
+++ b/okta/data_source_okta_groups_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestAccDataSourceOktaGroups_read(t *testing.T) {
 	mgr := newFixtureManager("data-sources", groups, t.Name())
-	groups := mgr.GetFixtures("okta_groups.tf", t)
+	// groups := mgr.GetFixtures("okta_groups.tf", t)
 	config := mgr.GetFixtures("datasource.tf", t)
 	oktaResourceTest(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
@@ -16,7 +16,8 @@ func TestAccDataSourceOktaGroups_read(t *testing.T) {
 		ProviderFactories: testAccProvidersFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: groups,
+				// Config: groups,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("okta_group.test_1", "id"),
 					resource.TestCheckResourceAttrSet("okta_group.test_2", "id"),
@@ -25,10 +26,12 @@ func TestAccDataSourceOktaGroups_read(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.okta_groups.test", "id"),
-					resource.TestCheckResourceAttr("data.okta_groups.test", "groups.#", "2"),
+					resource.TestCheckResourceAttrSet("data.okta_groups.okta_groups", "id"),
+					resource.TestCheckResourceAttr("data.okta_groups.okta_groups", "groups.#", "2"),
 					// the example enumeration doesn't match anything so as a string the output will be a blank string
-					resource.TestCheckOutput("special_groups", ""),
+					// resource.TestCheckOutput("special_groups", ""),
+					resource.TestCheckResourceAttrSet("data.okta_groups.built_in_groups", "id"),
+					resource.TestCheckResourceAttr("data.okta_groups.built_in_groups", "groups.#", "2"),
 				),
 			},
 		},

--- a/okta/group.go
+++ b/okta/group.go
@@ -42,26 +42,6 @@ func listGroupUserIDs(ctx context.Context, m interface{}, id string) ([]string, 
 	return resUsers, nil
 }
 
-func listGroups(ctx context.Context, client *sdk.Client, qp *query.Params) ([]*sdk.Group, error) {
-	groups, resp, err := client.Group.ListGroups(ctx, qp)
-	if err != nil {
-		return nil, err
-	}
-	for {
-		if resp.HasNextPage() {
-			var nextGroups []*sdk.Group
-			resp, err = resp.Next(ctx, &nextGroups)
-			if err != nil {
-				return nil, err
-			}
-			groups = append(groups, nextGroups...)
-		} else {
-			break
-		}
-	}
-	return groups, nil
-}
-
 // Group Primary Key Operations (Use when # groups < # users in operations)
 func addGroupMembers(ctx context.Context, client *sdk.Client, groupId string, users []string) error {
 	for _, user := range users {


### PR DESCRIPTION
- Fixes broken tests (there are now two BUILT_IN groups)
- Moves from SDK V2 > SDK V5
  - Tries to maintain backwards compatibility WRT datasource ID generation
- contains the changes from #2217
  - when I wrote this PR I assumed that #2217 would be merged before this PR, If that doesn't end up happening I can rebase this PR