### PR TITLE
Correct `.gitignore` for .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ terraform-provider-okta*
 **/.DS_Store
 .vscode
 
-.env
+**.env
 dist
 
 bin/


### PR DESCRIPTION
`.env` seemed to only ignore files called exactly `.env` in my IDE 
`*.env` ignored all env files at the top level of the repo
`**.env` ignored env files located at any level throughout the repo and thus seemed the most appropriate to me