### PR TITLE
Fix bugs in v4.13.0 and v4.13.1 related to resource `okta_app_signon_policy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.14.1 (Mar 03, 2025)
+
+### BUG FIXES
+
+* Fix `default_rule_id` argument error in `okta_app_signon_policy` introduced in v4.13.0 / v4.13.1 [#2240](https://github.com/okta/terraform-provider-okta/pull/2240). Thanks, [@monde](https://github.com/monde)!
+
 ## 4.14.0 (Feb 11, 2025)
 
 ### IMPROVEMENTS

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 4.14.0"
+      version = "~> 4.14.1"
     }
   }
 }

--- a/docs/resources/app_signon_policy.md
+++ b/docs/resources/app_signon_policy.md
@@ -98,7 +98,7 @@ resource "okta_app_signon_policy_rule" "some_rule" {
 
 ### Read-Only
 
-- `default_rule_id` (String) Default rules id of the policy
+- `default_rule_id` (String) Default rule (system=true) id of the policy
 - `id` (String) Policy id
 
 ## Import

--- a/docs/resources/app_signon_policy.md
+++ b/docs/resources/app_signon_policy.md
@@ -94,7 +94,7 @@ resource "okta_app_signon_policy_rule" "some_rule" {
 
 ### Optional
 
-- `catch_all` (Boolean) Default rules of the policy set to `DENY` or not. If `false`, it is set to `DENY`. **WARNING** setting this attribute to false change the OKTA default behavior. Use at your own risk. This is only apply during creation, so import or update will not work
+- `catch_all` (Boolean, default true, creation-only argument) If false, the default rule of the policy is set access to `DENY`. Otherwise default behavior of the default rule is to leave access at `ALLOW`.  **WARNING** setting this attribute to false changes policy rule's default behavior. Use at your own risk. This is only applied during creation and does not affect import or update.
 
 ### Read-Only
 

--- a/okta/config.go
+++ b/okta/config.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	OktaTerraformProviderVersion   = "4.14.0"
+	OktaTerraformProviderVersion   = "4.14.1"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )
 

--- a/okta/resource_okta_app_signon_policy.go
+++ b/okta/resource_okta_app_signon_policy.go
@@ -231,6 +231,10 @@ func (r *appSignOnPolicyResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	for _, a := range apps {
+		if a.GetActualInstance() == nil {
+			// nil bumper
+			continue
+		}
 		app := a.GetActualInstance().(OktaApp)
 		accessPolicy := app.GetLinks().AccessPolicy.GetHref()
 		// ignore apps that don't have an access policy, typically Classic org apps.

--- a/okta/resource_okta_app_signon_policy.go
+++ b/okta/resource_okta_app_signon_policy.go
@@ -74,7 +74,7 @@ default/system access policy.`,
 				Required:    true,
 			},
 			"catch_all": schema.BoolAttribute{
-				Description: "Default rules of the policy set to `DENY` or not. If `false`, it is set to `DENY`. **WARNING** setting this attribute to false change the OKTA default behavior. Use at your own risk. This is only apply during creation, so import or update will not work",
+				Description: "If false, the default rule of the policy is set access to `DENY`. Otherwise default behavior of the default rule is to leave access at `ALLOW`.  **WARNING** setting this attribute to false changes policy rule's default behavior. Use at your own risk. This is only applied during creation and does not affect import or update.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),

--- a/okta/resource_okta_app_signon_policy_test.go
+++ b/okta/resource_okta_app_signon_policy_test.go
@@ -1,10 +1,12 @@
 package okta
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceOktaAppSignOnPolicy_crud(t *testing.T) {
@@ -13,6 +15,11 @@ func TestAccResourceOktaAppSignOnPolicy_crud(t *testing.T) {
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", t)
 	renamedConfig := mgr.GetFixtures("basic_renamed.tf", t)
 	resourceName := fmt.Sprintf("%v.test", appSignOnPolicy)
+
+	importConfig := mgr.ConfigReplace(`
+resource "okta_app_signon_policy_rule" "test" {
+  depends_on = [okta_app_signon_policy.test]
+}`)
 
 	oktaResourceTest(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),
@@ -26,6 +33,7 @@ func TestAccResourceOktaAppSignOnPolicy_crud(t *testing.T) {
 					ensurePolicyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("testAcc_Test_App", mgr.Seed)),
 					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
+					resource.TestCheckResourceAttrSet(resourceName, "default_rule_id"),
 				),
 			},
 			{
@@ -34,6 +42,7 @@ func TestAccResourceOktaAppSignOnPolicy_crud(t *testing.T) {
 					ensurePolicyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("testAcc_Test_App", mgr.Seed)),
 					resource.TestCheckResourceAttr(resourceName, "description", "The updated app signon policy used by our test app."),
+					resource.TestCheckResourceAttrSet(resourceName, "default_rule_id"),
 				),
 			},
 			{
@@ -42,7 +51,109 @@ func TestAccResourceOktaAppSignOnPolicy_crud(t *testing.T) {
 					ensurePolicyExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("testAcc_Test_App_Renamed", mgr.Seed)),
 					resource.TestCheckResourceAttr(resourceName, "description", "The app signon policy used by our test app."),
+					resource.TestCheckResourceAttrSet(resourceName, "default_rule_id"),
 				),
+			},
+			// check the default_rule_id was set by looking up the real policy rule by id and check its access is set to ALLOW
+			{
+				Config:       fmt.Sprintf("%s\n%s", renamedConfig, importConfig),
+				ResourceName: "okta_app_signon_policy_rule.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["okta_app_signon_policy.test"]
+					if !ok {
+						return "", fmt.Errorf("failed to find policy")
+					}
+
+					policyId := rs.Primary.Attributes["id"]
+					defaultRuleId := rs.Primary.Attributes["default_rule_id"]
+
+					return fmt.Sprintf("%s/%s", policyId, defaultRuleId), nil
+				},
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return errors.New("failed to import schema into state")
+					}
+					instance := states[0]
+					access := instance.Attributes["access"]
+					if access != "ALLOW" {
+						return fmt.Errorf("expected okta_app_signon_policy.test access to be set to ALLOW, got %s", access)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// TestAccResourceOktaAppSignOnPolicy_default_policy_rule_can_be_set_to_deny
+// tests to see if catch_all = false results in a default policy rule of DENY
+func TestAccResourceOktaAppSignOnPolicy_default_policy_rule_can_be_set_to_deny(t *testing.T) {
+	resourceName := fmt.Sprintf("%v.test", appSignOnPolicy)
+	mgr := newFixtureManager("resources", appSignOnPolicy, t.Name())
+	config := `
+resource "okta_app_signon_policy" "test" {
+  name        = "testAcc_Test_App_replace_with_uuid"
+  description = "App Sign-On Policy with Default Rule DENY"
+  catch_all   = false
+}`
+	importConfig := `
+resource "okta_app_signon_policy" "test" {
+  name        = "testAcc_Test_App_replace_with_uuid"
+  description = "App Sign-On Policy with Default Rule DENY"
+  catch_all   = false
+}
+resource "okta_app_signon_policy_rule" "test" {
+  depends_on = [okta_app_signon_policy.test]
+}`
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: testAccMergeProvidersFactories,
+		CheckDestroy:             checkPolicyDestroy(appSignOnPolicy),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(config),
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr("okta_app_signon_policy.test", "name", buildResourceNameWithPrefix("testAcc_Test_App", mgr.Seed)),
+					resource.TestCheckResourceAttr("okta_app_signon_policy.test", "description", "App Sign-On Policy with Default Rule DENY"),
+					resource.TestCheckResourceAttr("okta_app_signon_policy.test", "catch_all", "false"),
+					resource.TestCheckResourceAttrSet("okta_app_signon_policy.test", "default_rule_id"),
+				),
+			},
+			{
+				Config:       mgr.ConfigReplace(importConfig),
+				ResourceName: "okta_app_signon_policy_rule.test",
+				ImportState:  true,
+
+				// fyi, import state id func equivelent to
+				// terraform import okta_app_signon_policy_rule.test [policy id]/[policy rule id]
+				// and is dirived directly off the attributes on okta_app_signon_policy.test
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["okta_app_signon_policy.test"]
+					if !ok {
+						return "", fmt.Errorf("failed to find policy")
+					}
+
+					policyId := rs.Primary.Attributes["id"]
+					defaultRuleId := rs.Primary.Attributes["default_rule_id"]
+
+					return fmt.Sprintf("%s/%s", policyId, defaultRuleId), nil
+				},
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return errors.New("failed to import schema into state")
+					}
+					instance := states[0]
+					access := instance.Attributes["access"]
+					if access != "DENY" {
+						return fmt.Errorf("expected okta_app_signon_policy.test access to be set to DENY, got %s", access)
+					}
+
+					return nil
+				},
 			},
 		},
 	})

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 4.14.0"
+      version = "~> 4.14.1"
     }
   }
 }


### PR DESCRIPTION
Fixes the update to `okta_app_signon_policy` resource that failed to set `default_rule_id` on update and read which would break imports and applies to `okta_app_signon_policy` instances created before v4.13.0.

Puts bumpers on a nil path that can happen during destroy.

Added acceptance tests to validate [`catch_all`](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_signon_policy#catch_all-2) is working as advertised.

> [catch_all](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_signon_policy#catch_all-2) (Boolean, default true, creation-only argument) If false, the default rule of the policy is set access to `DENY`. Otherwise default behavior of the default rule is to leave access at `ALLOW`. **WARNING** setting this attribute to false changes policy rule's default behavior. Use at your own risk. This is only applied during creation and does not affect import or update.

Closes #2197
Closes #2199
Closes #2198
