### PR TITLE
fix: okta_app_oauth add jwt-bearer to the valid grant types of native…

### DIFF
--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -31,6 +31,7 @@ const (
 	clientCredentials = "client_credentials"
 	tokenExchange     = "urn:ietf:params:oauth:grant-type:token-exchange"
 	saml2Bearer       = "urn:ietf:params:oauth:grant-type:saml2-bearer"
+	jwtBearer         = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 	deviceCode        = "urn:ietf:params:oauth:grant-type:device_code"
 	oob               = "urn:okta:params:oauth:grant-type:oob"
 	otp               = "urn:okta:params:oauth:grant-type:otp"
@@ -74,6 +75,7 @@ var appRequirementsByType = map[string]*applicationMap{
 			refreshToken,
 			password,
 			saml2Bearer,
+			jwtBearer,
 			tokenExchange,
 			deviceCode,
 			interactionCode,


### PR DESCRIPTION
… app

During the import of remote native apps, we encountered the validation issue which reject the creation of `urn:ietf:params:oauth:grant-type:jwt-bearer` grant. 
```
Error: failed to update OAuth application: failed conditional validation for field "grant_types" of type "native", it can contain authorization_code, implicit, refresh_token, password, urn:ietf:params:oauth:grant-type:saml2-bearer, urn:ietf:params:oauth:grant-type:token-exchange, urn:ietf:params:oauth:grant-type:device_code, interaction_code, urn:okta:params:oauth:grant-type:oob, urn:okta:params:oauth:grant-type:otp, http://auth0.com/oauth/grant-type/mfa-oob, http://auth0.com/oauth/grant-type/mfa-otp and must contain authorization_code, received urn:ietf:params:oauth:grant-type:jwt-bearer, authorization_code, refresh_token
```
Though it's not available on the tenant UI, it is a valid grant type according to https://developer.okta.com/docs/guides/authenticators-custom-authenticator/android/main/#maintenance-token-configuration-and-usage

