### PR TITLE
docs: add mfa_lifetime usecase

### DIFF
--- a/docs/resources/policy_rule_signon.md
+++ b/docs/resources/policy_rule_signon.md
@@ -105,8 +105,8 @@ resource "okta_policy_rule_signon" "example" {
 	- 'factor_type' - (Required) Factor type of the additional authentication step. (see [below for nested schema](#nestedblock--factor_sequence))
 - `identity_provider` (String) Apply rule based on the IdP used: `ANY`, `OKTA` or `SPECIFIC_IDP`. Default: `ANY`. ~> **WARNING**: Use of `identity_provider` requires a feature flag to be enabled.
 - `identity_provider_ids` (List of String) When identity_provider is `SPECIFIC_IDP` then this is the list of IdP IDs to apply the rule on
-- `mfa_lifetime` (Number) Elapsed time before the next MFA challenge
 - `mfa_prompt` (String) Prompt for MFA based on the device used, a factor session lifetime, or every sign-on attempt: `DEVICE`, `SESSION` or`ALWAYS`.
+- `mfa_lifetime` (Number) Elapsed time before the next MFA challenge. Only applicable when the `mfa_prompt` is set to `SESSION` or `ALWAYS`.
 - `mfa_remember_device` (Boolean) Remember MFA device. Default: `false`
 - `mfa_required` (Boolean) Require MFA. Default: `false`
 - `network_connection` (String) Network selection mode: `ANYWHERE`, `ZONE`, `ON_NETWORK`, or `OFF_NETWORK`. Default: `ANYWHERE`


### PR DESCRIPTION
The Terraform [documentation](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/policy_rule_signon) for the `okta_policy_rule_signon` does not specify anything about the `mfa_lifetime`.  The `mfa_lifetime` is only valid when the `mfa_prompt` is either `ALWAYS` or `SESSION`. Since this is not specified anywhere, there are issues where the `mfa_lifetime` is used even if the `mfa_prompt` is invalid. This PR adds docs about the specification.
