### PR TITLE
fix: make HTTP 423 retryable for `okta_group_rule`

### DIFF
--- a/examples/resources/okta_group_rule/test_423_response_capture.tf
+++ b/examples/resources/okta_group_rule/test_423_response_capture.tf
@@ -1,0 +1,53 @@
+resource "okta_group" "test" {
+  name = "test_423_response_capture"
+}
+
+# Main group rule that should succeed
+resource "okta_group_rule" "test" {
+  name              = "test_423_response_capture"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.firstName,\"andy\")"
+}
+
+# Additional rules that might trigger 423s but won't fail the test
+resource "okta_group_rule" "concurrent1" {
+  name              = "test_423_response_capture_concurrent1"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.lastName,\"smith\")"
+}
+
+resource "okta_group_rule" "concurrent2" {
+  name              = "test_423_response_capture_concurrent2"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.email,\"test\")"
+}
+
+resource "okta_group_rule" "concurrent3" {
+  name              = "test_423_response_capture_concurrent3"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.department,\"engineering\")"
+}
+
+resource "okta_group_rule" "concurrent4" {
+  name              = "test_423_response_capture_concurrent4"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.title,\"developer\")"
+}
+
+resource "okta_group_rule" "concurrent5" {
+  name              = "test_423_response_capture_concurrent5"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.employeeNumber,\"123\")"
+}

--- a/okta/acctest/acctest.go
+++ b/okta/acctest/acctest.go
@@ -221,8 +221,8 @@ func closeRecorder(t *testing.T, vcr *vcrManager) {
 	config, ok := providerConfigs[vcr.TestAndCassetteNameKey()]
 	providerConfigsLock.RUnlock()
 	if ok {
-		// don't record failing test runs
-		if !t.Failed() {
+		// don't record failing test runs (unless explicitly allowed for error response testing)
+		if !t.Failed() || os.Getenv("OKTA_VCR_RECORD_FAILURES") == "true" {
 			// If a test succeeds, write new seed/yaml to files
 			rtHelper := config.OktaIDaaSClient.(HttpClientHelper)
 			rt := rtHelper.Transport()

--- a/okta/services/idaas/resource_okta_group_rule.go
+++ b/okta/services/idaas/resource_okta_group_rule.go
@@ -2,11 +2,14 @@ package idaas
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/okta/terraform-provider-okta/okta/api"
 	"github.com/okta/terraform-provider-okta/okta/utils"
@@ -15,6 +18,8 @@ import (
 )
 
 const statusInvalid = "INVALID"
+const maxRetries = 3
+const retryDelay = 60 * time.Second
 
 func resourceGroupRule() *schema.Resource {
 	return &schema.Resource{
@@ -80,13 +85,30 @@ func StatusIsInvalidDiffFn(status string) bool {
 }
 
 func resourceGroupRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Using the existing retryOnStatusCodes context value for INTERNAL SERVER ERROR
 	ctx = context.WithValue(ctx, api.RetryOnStatusCodes, []int{http.StatusInternalServerError})
 	groupRule := buildGroupRule(d)
-	responseGroupRule, _, err := getOktaClientFromMetadata(meta).Group.CreateGroupRule(ctx, *groupRule)
+	client := getOktaClientFromMetadata(meta)
+
+	var responseGroupRule *sdk.GroupRule
+
+	err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+		var err error
+		var sdkResp *sdk.Response
+		responseGroupRule, sdkResp, err = client.Group.CreateGroupRule(ctx, *groupRule)
+		if err != nil && sdkResp != nil && sdkResp.StatusCode == http.StatusLocked {
+			return retry.RetryableError(err)
+		}
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return diag.Errorf("failed to create group rule: %v", err)
 	}
 	d.SetId(responseGroupRule.Id)
+	// Retry lifecycle operations as needed (e.g. activation or deactivation)
 	if err := handleGroupRuleLifecycle(ctx, d, meta); err != nil {
 		return diag.Errorf("failed to change group rule status: %v", err)
 	}
@@ -126,34 +148,64 @@ func resourceGroupRuleRead(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceGroupRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	desiredStatus := d.Get("status").(string)
+	client := getOktaClientFromMetadata(meta)
 	// Only inactive rules can be changed, thus we should handle this first
 	if d.HasChange("status") {
-		err := handleGroupRuleLifecycle(ctx, d, meta)
-		if err != nil {
+		if err := handleGroupRuleLifecycle(ctx, d, meta); err != nil {
 			return diag.Errorf("failed to change group rule status: %v", err)
 		}
 		_ = d.Set("status", desiredStatus)
 	}
-	// invalid group rules can not be updated
+	// If any properties (other than status) have changed and the desired status is not INVALID,
+	// we need to update the rule. We must deactivate first if the rule is active.
 	if hasGroupRuleChange(d) && desiredStatus != statusInvalid {
-		client := getOktaClientFromMetadata(meta)
 		rule := buildGroupRule(d)
+		// If rule is active, deactivate before updating
 		if desiredStatus == StatusActive {
-			// Only inactive rules can be changed, thus we should deactivate the rule in case it was "ACTIVE"
-			_, err := client.Group.DeactivateGroupRule(ctx, d.Id())
+			err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+				_, err := client.Group.DeactivateGroupRule(ctx, d.Id())
+				if err != nil && strings.Contains(err.Error(), "423") {
+					return retry.RetryableError(err)
+				}
+				if err != nil {
+					return retry.NonRetryableError(fmt.Errorf("failed to deactivate group rule: %v", err))
+				}
+				return nil
+			})
 			if err != nil {
-				return diag.Errorf("failed to deactivate group rule: %v", err)
+				return diag.FromErr(err)
 			}
 		}
-		_, _, err := client.Group.UpdateGroupRule(ctx, d.Id(), *rule)
+
+		// Retry loop for UpdateGroupRule
+		err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+			_, sdkResp, err := client.Group.UpdateGroupRule(ctx, d.Id(), *rule)
+			if err != nil && sdkResp != nil && sdkResp.StatusCode == http.StatusLocked {
+				return retry.RetryableError(err)
+			}
+			if err != nil {
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
 		if err != nil {
 			return diag.Errorf("failed to update group rule: %v", err)
 		}
+
 		if desiredStatus == StatusActive {
 			// We should reactivate the rule in case it was deactivated.
-			_, err := client.Group.ActivateGroupRule(ctx, d.Id())
+			err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+				_, err := client.Group.ActivateGroupRule(ctx, d.Id())
+				if err != nil && strings.Contains(err.Error(), "423") {
+					return retry.RetryableError(err)
+				}
+				if err != nil {
+					return retry.NonRetryableError(fmt.Errorf("failed to activate group rule: %v", err))
+				}
+				return nil
+			})
 			if err != nil {
-				return diag.Errorf("failed to activate group rule: %v", err)
+				return diag.FromErr(err)
 			}
 		}
 	}
@@ -171,15 +223,39 @@ func hasGroupRuleChange(d *schema.ResourceData) bool {
 
 func resourceGroupRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := getOktaClientFromMetadata(meta)
+	// If the rule is active, attempt to deactivate it first.
 	if d.Get("status").(string) == StatusActive {
-		_, err := client.Group.DeactivateGroupRule(ctx, d.Id())
-		// suppress error for INACTIVE group rules
-		if err != nil && !strings.Contains(err.Error(), "Cannot activate or deactivate a Group Rule with the status INVALID") {
-			return diag.Errorf("failed to deactivate group rule before removing: %v", err)
+		err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+			_, err := client.Group.DeactivateGroupRule(ctx, d.Id())
+			// If error is due to a 423 response, retry.
+			if err != nil && strings.Contains(err.Error(), "423") {
+				return retry.RetryableError(err)
+			}
+			// suppress error for INACTIVE group rules
+			if err != nil && strings.Contains(err.Error(), "Cannot activate or deactivate a Group Rule with the status INVALID") {
+				return nil
+			}
+			if err != nil {
+				return retry.NonRetryableError(fmt.Errorf("failed to deactivate group rule before removing: %v", err))
+			}
+			return nil
+		})
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 	remove := d.Get("remove_assigned_users").(bool)
-	_, err := client.Group.DeleteGroupRule(ctx, d.Id(), &query.Params{RemoveUsers: &remove})
+	// Retry loop for DeleteGroupRule
+	err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+		_, err := client.Group.DeleteGroupRule(ctx, d.Id(), &query.Params{RemoveUsers: &remove})
+		if err != nil && strings.Contains(err.Error(), "423") {
+			return retry.RetryableError(err)
+		}
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return diag.Errorf("failed to delete group rule: %v", err)
 	}
@@ -212,11 +288,29 @@ func buildGroupRule(d *schema.ResourceData) *sdk.GroupRule {
 func handleGroupRuleLifecycle(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	client := getOktaClientFromMetadata(meta)
 	if d.Get("status").(string) == StatusActive {
-		_, err := client.Group.ActivateGroupRule(ctx, d.Id())
+		err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+			_, err := client.Group.ActivateGroupRule(ctx, d.Id())
+			if err != nil && strings.Contains(err.Error(), "423") {
+				return retry.RetryableError(err)
+			}
+			if err != nil {
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
 		return err
 	} else if d.Get("status").(string) == statusInvalid {
 		return nil
 	}
-	_, err := client.Group.DeactivateGroupRule(ctx, d.Id())
+	err := retry.RetryContext(ctx, retryDelay*maxRetries, func() *retry.RetryError {
+		_, err := client.Group.DeactivateGroupRule(ctx, d.Id())
+		if err != nil && strings.Contains(err.Error(), "423") {
+			return retry.RetryableError(err)
+		}
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 	return err
 }

--- a/okta/services/idaas/resource_okta_group_rule_test.go
+++ b/okta/services/idaas/resource_okta_group_rule_test.go
@@ -222,3 +222,27 @@ func TestAccResourceOktaGroupRule_nameLengthVerification_Issue2396(t *testing.T)
 		},
 	})
 }
+
+func TestAccResourceOktaGroupRule_423ResponseCapture(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSGroupRule)
+	mgr := newFixtureManager("resources", "okta_group_rule", t.Name())
+
+	// Test that captures 423 responses but handles them gracefully
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSGroupRule, doesGroupRuleExist),
+		Steps: []resource.TestStep{
+			{
+				// Create a minimal set of resources that should succeed
+				Config: mgr.GetFixtures("test_423_response_capture.tf", t),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "test_423_response_capture"),
+					resource.TestCheckResourceAttr(resourceName, "status", idaas.StatusActive),
+					resource.TestCheckResourceAttr(resourceName, "expression_value", "String.startsWith(user.firstName,\"andy\")"),
+				),
+			},
+		},
+	})
+}

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaGroupRule_423ResponseCapture/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaGroupRule_423ResponseCapture/oie-00.yaml
@@ -1,0 +1,1429 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 66
+        host: oie-00.dne-okta.com
+        body: |
+            {"profile":{"name":"test_423_response_capture","description":""}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gtiup8m1hVjQ8qE697","created":"2025-07-24T02:10:41.000Z","lastUpdated":"2025-07-24T02:10:41.000Z","lastMembershipUpdated":"2025-07-24T02:10:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"test_423_response_capture","description":""},"_links":{"logo":[{"name":"medium","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:41 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 915.98825ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gtiup8m1hVjQ8qE697","created":"2025-07-24T02:10:41.000Z","lastUpdated":"2025-07-24T02:10:41.000Z","lastMembershipUpdated":"2025-07-24T02:10:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"test_423_response_capture","description":""},"_links":{"logo":[{"name":"medium","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:42 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 670.017333ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gtiup8m1hVjQ8qE697","created":"2025-07-24T02:10:41.000Z","lastUpdated":"2025-07-24T02:10:41.000Z","lastMembershipUpdated":"2025-07-24T02:10:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"test_423_response_capture","description":""},"_links":{"logo":[{"name":"medium","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:42 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 673.955166ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 278
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.lastName,\"smith\")"},"people":{"users":{}}},"name":"test_423_response_capture_concurrent1","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"errorCode":"E0000239","errorSummary":"Policy priorities are being reconciled. Please try again later.","errorLink":"E0000239","errorId":"oaewlhgTnyCQUWzREP2mCU7uw","errorCauses":[]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 423 Locked
+        code: 423
+        duration: 690.635292ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 274
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.email,\"test\")"},"people":{"users":{}}},"name":"test_423_response_capture_concurrent2","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"errorCode":"E0000239","errorSummary":"Policy priorities are being reconciled. Please try again later.","errorLink":"E0000239","errorId":"oae7rcI8tUvTWW2g3RV8wl5LQ","errorCauses":[]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 423 Locked
+        code: 423
+        duration: 712.864458ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 286
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.department,\"engineering\")"},"people":{"users":{}}},"name":"test_423_response_capture_concurrent3","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiurl5fTYrsz6X697","status":"INACTIVE","name":"test_423_response_capture_concurrent3","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:43.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.department,\"engineering\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 719.084ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 279
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.title,\"developer\")"},"people":{"users":{}}},"name":"test_423_response_capture_concurrent4","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiutijp1eh8XZS697","status":"INACTIVE","name":"test_423_response_capture_concurrent4","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:43.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.title,\"developer\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 726.850666ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 266
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.firstName,\"andy\")"},"people":{"users":{}}},"name":"test_423_response_capture","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiuwr6rE6E0EqO697","status":"INACTIVE","name":"test_423_response_capture","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:43.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.firstName,\"andy\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 728.169709ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 282
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.employeeNumber,\"123\")"},"people":{"users":{}}},"name":"test_423_response_capture_concurrent5","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiuont9u8W3Q1v697","status":"INACTIVE","name":"test_423_response_capture_concurrent5","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:43.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.employeeNumber,\"123\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 742.881458ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurl5fTYrsz6X697/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 734.665709ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuont9u8W3Q1v697/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 712.047ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiutijp1eh8XZS697/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 731.329417ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuwr6rE6E0EqO697/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 734.060834ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 278
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.lastName,\"smith\")"},"people":{"users":{}}},"name":"test_423_response_capture_concurrent1","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiup8m6x83EGmY697","status":"INACTIVE","name":"test_423_response_capture_concurrent1","created":"2025-07-24T02:10:44.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.lastName,\"smith\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 736.084875ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 274
+        host: oie-00.dne-okta.com
+        body: |
+            {"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"String.startsWith(user.email,\"test\")"},"people":{"users":{}}},"name":"test_423_response_capture_concurrent2","type":"group_rule"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiurkdo0MP1eRr697","status":"INACTIVE","name":"test_423_response_capture_concurrent2","created":"2025-07-24T02:10:44.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.email,\"test\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 742.128708ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuont9u8W3Q1v697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiuont9u8W3Q1v697","status":"ACTIVE","name":"test_423_response_capture_concurrent5","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.employeeNumber,\"123\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 691.278042ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuwr6rE6E0EqO697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiuwr6rE6E0EqO697","status":"ACTIVE","name":"test_423_response_capture","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.firstName,\"andy\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 697.382125ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurl5fTYrsz6X697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiurl5fTYrsz6X697","status":"ACTIVE","name":"test_423_response_capture_concurrent3","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.department,\"engineering\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 706.101667ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiutijp1eh8XZS697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiutijp1eh8XZS697","status":"ACTIVE","name":"test_423_response_capture_concurrent4","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.title,\"developer\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 715.151833ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiup8m6x83EGmY697/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:45 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 722.188125ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurkdo0MP1eRr697/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:45 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 707.690375ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiup8m6x83EGmY697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiup8m6x83EGmY697","status":"ACTIVE","name":"test_423_response_capture_concurrent1","created":"2025-07-24T02:10:44.000Z","lastUpdated":"2025-07-24T02:10:45.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.lastName,\"smith\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:46 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 692.786416ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurkdo0MP1eRr697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiurkdo0MP1eRr697","status":"ACTIVE","name":"test_423_response_capture_concurrent2","created":"2025-07-24T02:10:44.000Z","lastUpdated":"2025-07-24T02:10:45.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.email,\"test\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:46 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.14162825s
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gtiup8m1hVjQ8qE697","created":"2025-07-24T02:10:41.000Z","lastUpdated":"2025-07-24T02:10:41.000Z","lastMembershipUpdated":"2025-07-24T02:10:41.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"test_423_response_capture","description":""},"_links":{"logo":[{"name":"medium","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://ok14static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:47 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 681.838333ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurl5fTYrsz6X697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiurl5fTYrsz6X697","status":"ACTIVE","name":"test_423_response_capture_concurrent3","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.department,\"engineering\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 679.705208ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurkdo0MP1eRr697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiurkdo0MP1eRr697","status":"ACTIVE","name":"test_423_response_capture_concurrent2","created":"2025-07-24T02:10:44.000Z","lastUpdated":"2025-07-24T02:10:45.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.email,\"test\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 680.894ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuwr6rE6E0EqO697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiuwr6rE6E0EqO697","status":"ACTIVE","name":"test_423_response_capture","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.firstName,\"andy\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 682.17075ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuont9u8W3Q1v697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiuont9u8W3Q1v697","status":"ACTIVE","name":"test_423_response_capture_concurrent5","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.employeeNumber,\"123\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 684.912875ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiup8m6x83EGmY697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiup8m6x83EGmY697","status":"ACTIVE","name":"test_423_response_capture_concurrent1","created":"2025-07-24T02:10:44.000Z","lastUpdated":"2025-07-24T02:10:45.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.lastName,\"smith\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 688.084ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiutijp1eh8XZS697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"group_rule","id":"0prtiutijp1eh8XZS697","status":"ACTIVE","name":"test_423_response_capture_concurrent4","created":"2025-07-24T02:10:43.000Z","lastUpdated":"2025-07-24T02:10:44.000Z","conditions":{"people":{"users":{"exclude":[]},"groups":{"exclude":[]}},"expression":{"value":"String.startsWith(user.title,\"developer\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gtiup8m1hVjQ8qE697"]}},"allGroupsValid":true}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 695.855041ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiutijp1eh8XZS697/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 707.374708ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuwr6rE6E0EqO697/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 725.599666ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurl5fTYrsz6X697/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 729.659208ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurkdo0MP1eRr697/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 734.874667ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiup8m6x83EGmY697/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.1979725s
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuont9u8W3Q1v697/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.223053083s
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            removeUsers:
+                - "false"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiutijp1eh8XZS697?removeUsers=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 202 Accepted
+        code: 202
+        duration: 712.177709ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            removeUsers:
+                - "false"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuwr6rE6E0EqO697?removeUsers=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 202 Accepted
+        code: 202
+        duration: 707.981625ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            removeUsers:
+                - "false"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurl5fTYrsz6X697?removeUsers=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 202 Accepted
+        code: 202
+        duration: 716.029ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            removeUsers:
+                - "false"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiurkdo0MP1eRr697?removeUsers=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 202 Accepted
+        code: 202
+        duration: 735.194833ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            removeUsers:
+                - "false"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiup8m6x83EGmY697?removeUsers=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 202 Accepted
+        code: 202
+        duration: 721.366291ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            removeUsers:
+                - "false"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/rules/0prtiuont9u8W3Q1v697?removeUsers=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 24 Jul 2025 02:10:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 202 Accepted
+        code: 202
+        duration: 719.805583ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gtiup8m1hVjQ8qE697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 24 Jul 2025 02:10:51 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 718.058333ms


### PR DESCRIPTION
fixes #2151

<hr>
I've reached out to Okta support about this behavior in Support Cases `02157630` and `02192142`

I was told that there are no plans to change the HTTP `423` response code
The HTTP `423` response code is sometimes returned by the Okta API when modifying multiple group rules in rapid succession.  
The current behavior when the provider gets a HTTP `423` is to bail out from the entire `terraform apply`  
This is an over reaction (imo) as the request will often succeed if immediately retried

<hr>

I'm open to suggestions and/or guidance about how to implement this change, especially if there is a better approach I should take instead

I added the logic to the `okta_group_rule` resource as I wanted to limit the change in behavior/functionality to only this resource, which rules out making the change to the SDK request executor(s)
