### PR TITLE
Okta 899300

### DIFF
--- a/docs/resources/app_signon_policy.md
+++ b/docs/resources/app_signon_policy.md
@@ -95,6 +95,7 @@ resource "okta_app_signon_policy_rule" "some_rule" {
 ### Optional
 
 - `catch_all` (Boolean, default true, creation-only argument) If false, the default rule of the policy is set access to `DENY`. Otherwise default behavior of the default rule is to leave access at `ALLOW`.  **WARNING** setting this attribute to false changes policy rule's default behavior. Use at your own risk. This is only applied during creation and does not affect import or update.
+- `priority` (Default 1) Specifies the order in which this policy is evaluated in relation to the other policies
 
 ### Read-Only
 

--- a/okta/resource_okta_app_signon_policy_test.go
+++ b/okta/resource_okta_app_signon_policy_test.go
@@ -43,6 +43,8 @@ resource "okta_app_signon_policy_rule" "test" {
 					resource.TestCheckResourceAttr(resourceName, "name", buildResourceNameWithPrefix("testAcc_Test_App", mgr.Seed)),
 					resource.TestCheckResourceAttr(resourceName, "description", "The updated app signon policy used by our test app."),
 					resource.TestCheckResourceAttrSet(resourceName, "default_rule_id"),
+					resource.TestCheckResourceAttr(resourceName, "catch_all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
 				),
 			},
 			{


### PR DESCRIPTION
The Default Authentication Policy can be modified through the API but only a few attributes. i.e, `description`. Our provider is not adding the `policy` which is not in the state. As a result, it tries to update the policy to a null value. 
This PR adds `priority` and sets it to the default value of 1. Please see [this](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Policy/#tag/Policy/operation/replacePolicy) API doc.

Closes #2246 and #2160 