### PR TITLE
preparing 4.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 4.16.0 (Apr 08, 2025)
+
+### IMPROVEMENTS
+
+* Add `timeout` argument to `okta_app_group_assignments` resource allowing custom timeouts [#1832](https://github.com/okta/terraform-provider-okta/pull/2255). Thanks, [@aditya-okta](https://github.com/aditya-okta)!
+* Improve resource `okta_app_user_schema_property` docs to include `array_enum` and `array_one_of` arguments[#1747](https://github.com/okta/terraform-provider-okta/issues/1747). Thanks, [@aditya-okta](https://github.com/aditya-okta)!
+* Added functionality to `activate` or `deactivate` `DefaultEnhancedNetworkZone`[#2252](https://github.com/okta/terraform-provider-okta/issues/2252). Thanks, [@pranav-okta](https://github.com/pranav-okta)!
+* Added `priority` argument to `app_signon_policy` resource allowing custom ordering[#2246,#2160](https://github.com/okta/terraform-provider-okta/issues/2246,https://github.com/okta/terraform-provider-okta/issues/2160). Thanks, [@pranav-okta](https://github.com/pranav-okta)!
+* Improve resource `policy_rule_signon` docs for argument `mfa_lifetime`[#2052](https://github.com/okta/terraform-provider-okta/issues/2052). Thanks, [@pranav-okta](https://github.com/pranav-okta)!
+
+### BUG FIXES
+
+* Fix issue for resource `okta_user_schema_property` when `enum` argument includes `empty string`[#1840](https://github.com/okta/terraform-provider-okta/issues/1840). Thanks, [@aditya-okta](https://github.com/aditya-okta)!
+
 ## 4.15.0 (Mar 06, 2025)
 
 ### IMPROVEMENTS

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 4.15.0"
+      version = "~> 4.16.0"
     }
   }
 }

--- a/docs/resources/app_signon_policy.md
+++ b/docs/resources/app_signon_policy.md
@@ -95,7 +95,7 @@ resource "okta_app_signon_policy_rule" "some_rule" {
 ### Optional
 
 - `catch_all` (Boolean, default true, creation-only argument) If false, the default rule of the policy is set access to `DENY`. Otherwise default behavior of the default rule is to leave access at `ALLOW`.  **WARNING** setting this attribute to false changes policy rule's default behavior. Use at your own risk. This is only applied during creation and does not affect import or update.
-- `priority` (Default 1) Specifies the order in which this policy is evaluated in relation to the other policies
+- `priority` (Default 1) Specifies the order in which this policy is evaluated in relation to the other policies.
 
 ### Read-Only
 

--- a/okta/config.go
+++ b/okta/config.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	OktaTerraformProviderVersion   = "4.15.0"
+	OktaTerraformProviderVersion   = "4.16.0"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )
 

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 4.15.0"
+      version = "~> 4.16.0"
     }
   }
 }


### PR DESCRIPTION
# 4.16.0 (Apr 08, 2025)

### IMPROVEMENTS

* Add `timeout` argument to `okta_app_group_assignments` resource allowing custom timeouts [#1832](https://github.com/okta/terraform-provider-okta/pull/2255). Thanks, [@aditya-okta](https://github.com/aditya-okta)!
* Improve resource `okta_app_user_schema_property` docs to include `array_enum` and `array_one_of` arguments[#1747](https://github.com/okta/terraform-provider-okta/issues/1747). Thanks, [@aditya-okta](https://github.com/aditya-okta)!
* Added functionality to `activate` or `deactivate` `DefaultEnhancedNetworkZone`[#2252](https://github.com/okta/terraform-provider-okta/issues/2252). Thanks, [@pranav-okta](https://github.com/pranav-okta)!
* Added `priority` argument to `app_signon_policy` resource allowing custom ordering[#2246,#2160](https://github.com/okta/terraform-provider-okta/issues/2246,https://github.com/okta/terraform-provider-okta/issues/2160). Thanks, [@pranav-okta](https://github.com/pranav-okta)!
* Improve resource `policy_rule_signon` docs for argument `mfa_lifetime`[#2052](https://github.com/okta/terraform-provider-okta/issues/2052). Thanks, [@pranav-okta](https://github.com/pranav-okta)!

### BUG FIXES

* Fix issue for resource `okta_user_schema_property` when `enum` argument includes `empty string`[#1840](https://github.com/okta/terraform-provider-okta/issues/1840). Thanks, [@aditya-okta](https://github.com/aditya-okta)!
