### PR TITLE
missing import policy_rule_idp_discovery

### DIFF
--- a/okta/resource_okta_policy_rule_idp_discovery.go
+++ b/okta/resource_okta_policy_rule_idp_discovery.go
@@ -139,6 +139,10 @@ func resourcePolicyRuleIdpDiscoveryRead(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.Errorf("failed to set IDP discovery policy rule properties: %v", err)
 	}
+	if len(rule.Actions.IDP.Providers) > 0 {
+		_ = d.Set("idp_id", rule.Actions.IDP.Providers[0].ID)
+		_ = d.Set("idp_type", rule.Actions.IDP.Providers[0].Type)
+	}
 	return nil
 }
 


### PR DESCRIPTION
fix missing idp_id and idp_type when importing policy_rule_idp_discovery