### PR TITLE
Add Basic Realm Support

### DIFF
--- a/examples/data-sources/okta_realm/data-source.tf
+++ b/examples/data-sources/okta_realm/data-source.tf
@@ -1,0 +1,7 @@
+data "okta_realm" "example_name" {
+  name = "Example Realm"
+}
+
+data "okta_realm" "example_id" {
+  id = "<realm_id>"
+}

--- a/examples/data-sources/okta_realm/datasource.tf
+++ b/examples/data-sources/okta_realm/datasource.tf
@@ -1,0 +1,9 @@
+resource "okta_realm" "test" {
+  name       = "AccTest Example Realm"
+  realm_type = "DEFAULT"
+}
+
+data "okta_realm" "test" {
+  name       = "AccTest Example Realm"
+  depends_on = [okta_realm.test]
+}

--- a/examples/data-sources/okta_realm/datasource_not_found.tf
+++ b/examples/data-sources/okta_realm/datasource_not_found.tf
@@ -1,0 +1,4 @@
+# Should fail to find the realm doesn't exist
+data "okta_realm" "test_not_found" {
+  name = "Unknown Example Realm"
+}

--- a/examples/resources/okta_realm/README.md
+++ b/examples/resources/okta_realm/README.md
@@ -1,0 +1,6 @@
+# okta_realm
+
+Represents an Okta
+Realm. [See Okta documentation for more details](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Realm/).
+
+- Example of a simple realm [can be found here](./resource.tf)

--- a/examples/resources/okta_realm/import.sh
+++ b/examples/resources/okta_realm/import.sh
@@ -1,0 +1,1 @@
+terraform import okta_realm.example <realm_id>

--- a/examples/resources/okta_realm/okta_realm.tf
+++ b/examples/resources/okta_realm/okta_realm.tf
@@ -1,0 +1,4 @@
+resource "okta_realm" "example" {
+  name       = "TestAcc Example Realm"
+  realm_type = "DEFAULT"
+}

--- a/examples/resources/okta_realm/okta_realm_updated.tf
+++ b/examples/resources/okta_realm/okta_realm_updated.tf
@@ -1,0 +1,4 @@
+resource "okta_realm" "example" {
+  name       = "TestAcc Example Realm Updated"
+  realm_type = "PARTNER"
+}

--- a/examples/resources/okta_realm/resource.tf
+++ b/examples/resources/okta_realm/resource.tf
@@ -1,0 +1,4 @@
+resource "okta_realm" "example" {
+  name       = "Example Realm"
+  realm_type = "DEFAULT"
+}

--- a/okta/resources/resources.go
+++ b/okta/resources/resources.go
@@ -98,6 +98,7 @@ const (
 	OktaIDaaSPolicySignOn                  = "okta_policy_signon"
 	OktaIDaaSProfileMapping                = "okta_profile_mapping"
 	OktaIDaaSRateLimiting                  = "okta_rate_limiting"
+	OktaIDaaSRealm                         = "okta_realm"
 	OktaIDaaSResourceSet                   = "okta_resource_set"
 	OktaIDaaSRoleSubscription              = "okta_role_subscription"
 	OktaIDaaSSecurityNotificationEmails    = "okta_security_notification_emails"

--- a/okta/services/idaas/data_source_okta_realm.go
+++ b/okta/services/idaas/data_source_okta_realm.go
@@ -1,0 +1,141 @@
+package idaas
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/okta/okta-sdk-golang/v5/okta"
+	"github.com/okta/terraform-provider-okta/okta/config"
+)
+
+type realmDataSource struct {
+	config *config.Config
+}
+
+func newRealmDataSource() datasource.DataSource {
+	return &realmDataSource{}
+}
+
+func (r *realmDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_realm"
+}
+
+func (r *realmDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	r.config = dataSourceConfiguration(req, resp)
+}
+
+func (r *realmDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: "The id of the Okta Realm.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("name"),
+					}...),
+				},
+			},
+			"name": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: "The name of the Okta Realm.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("id"),
+					}...),
+				},
+			},
+			"realm_type": schema.StringAttribute{
+				Optional:    true,
+				Description: "The realm type. Valid values: `PARTNER` and `DEFAULT`",
+			},
+			"is_default": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Indicates whether the realm is the default realm.",
+			},
+		},
+		Description: "Get a realm from Okta.",
+	}
+}
+
+func (r *realmDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state realmModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var selectedRealm *okta.Realm
+	if state.ID.ValueString() != "" {
+		realm, response, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.GetRealm(ctx, state.ID.ValueString()).Execute()
+		if err != nil {
+			body, ioErr := io.ReadAll(response.Body)
+			defer response.Body.Close()
+			if ioErr != nil {
+				resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+				return
+			}
+			resp.Diagnostics.AddError("failed to read realm:"+err.Error(), string(body))
+			return
+		}
+		selectedRealm = realm
+	} else if state.Name.ValueString() != "" {
+		searchString := fmt.Sprintf(`profile.name eq "%s"`, state.Name.ValueString())
+
+		err := retry.RetryContext(ctx, 3*time.Second, func() *retry.RetryError {
+			realms, response, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.ListRealms(ctx).Search(searchString).Execute()
+			if err != nil {
+				body, ioErr := io.ReadAll(response.Body)
+				defer response.Body.Close()
+				if ioErr != nil {
+					resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+					return retry.NonRetryableError(ioErr)
+				}
+				resp.Diagnostics.AddError("failed to list realms:"+err.Error(), string(body))
+				return retry.NonRetryableError(err)
+			}
+
+			if len(realms) == 0 {
+				resp.Diagnostics.AddWarning("Realm not found", fmt.Sprintf("No realm found with name %s. Retrying...", state.Name.ValueString()))
+				return retry.RetryableError(fmt.Errorf("no realm found with name %s", state.Name.ValueString()))
+			}
+
+			if len(realms) != 1 {
+				resp.Diagnostics.AddError("Multiple realms found", fmt.Sprintf("Found %d realms with name %s. Please specify a unique name.", len(realms), state.Name.ValueString()))
+				return retry.NonRetryableError(fmt.Errorf("multiple realms found"))
+			}
+
+			selectedRealm = &realms[0]
+			return nil
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Realm with name %s not found", state.Name), "Please check the name and try again.")
+			return
+		}
+
+	} else {
+		resp.Diagnostics.AddError("Error reading realm", "Either 'id' or 'name' must be specified.")
+		return
+	}
+
+	state.ID = types.StringPointerValue(selectedRealm.Id)
+	state.Name = types.StringValue(selectedRealm.Profile.Name)
+	state.RealmType = types.StringPointerValue(selectedRealm.Profile.RealmType)
+	state.IsDefault = types.BoolPointerValue(selectedRealm.IsDefault)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/okta/services/idaas/data_source_okta_realm_test.go
+++ b/okta/services/idaas/data_source_okta_realm_test.go
@@ -1,0 +1,36 @@
+package idaas_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+)
+
+func TestAccDataSourceOktaRealm_read(t *testing.T) {
+	mgr := newFixtureManager("data-sources", resources.OktaIDaaSRealm, t.Name())
+	config := mgr.GetFixtures("datasource.tf", t)
+	configInvalid := mgr.GetFixtures("datasource_not_found.tf", t)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.okta_realm.test", "id"),
+					resource.TestCheckResourceAttr("data.okta_realm.test", "name", "AccTest Example Realm"),
+					resource.TestCheckResourceAttr("data.okta_realm.test", "realm_type", "DEFAULT"),
+				),
+			},
+			{
+				Config:      configInvalid,
+				ExpectError: regexp.MustCompile(`Realm with name "Unknown Example Realm" not found`),
+			},
+		},
+	})
+}

--- a/okta/services/idaas/idaas.go
+++ b/okta/services/idaas/idaas.go
@@ -97,6 +97,7 @@ func FWProviderResources() []func() resource.Resource {
 		newAppSignOnPolicyResource,
 		newEmailTemplateSettingsResource,
 		newFeaturesResource,
+		newRealmResource,
 	}
 }
 
@@ -109,6 +110,7 @@ func FWProviderDataSources() []func() datasource.DataSource {
 		newUserTypeDataSource,
 		newDeviceAssurancePolicyDataSource,
 		newFeaturesDataSource,
+		newRealmDataSource,
 	}
 }
 

--- a/okta/services/idaas/resource_okta_realm.go
+++ b/okta/services/idaas/resource_okta_realm.go
@@ -1,0 +1,216 @@
+package idaas
+
+import (
+	"context"
+	"io"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
+	"github.com/okta/terraform-provider-okta/okta/config"
+)
+
+type realmModel struct {
+	ID        types.String `tfsdk:"id"`
+	Name      types.String `tfsdk:"name"`
+	RealmType types.String `tfsdk:"realm_type"`
+	IsDefault types.Bool   `tfsdk:"is_default"`
+}
+
+type realmResource struct {
+	config *config.Config
+}
+
+func newRealmResource() resource.Resource {
+	return &realmResource{}
+}
+
+func (r *realmResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_realm"
+}
+
+func (r *realmResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Realm ID",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "The name of the Okta Realm.",
+			},
+			"realm_type": schema.StringAttribute{
+				Required:    true,
+				Description: "The realm type. Valid values: `PARTNER` and `DEFAULT`",
+				Validators: []validator.String{
+					stringvalidator.OneOf("PARTNER", "DEFAULT"),
+				},
+			},
+			"is_default": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Indicates whether the realm is the default realm.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Description: "Creates an Okta Realm. This resource allows you to create and configure an Okta Realm.",
+	}
+}
+
+func (r *realmResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.config = resourceConfiguration(req, resp)
+}
+
+func (r *realmResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var state realmModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createRealmRequest := v5okta.NewCreateRealmRequest()
+	profile := v5okta.NewRealmProfile(state.Name.ValueString())
+	profile.RealmType = state.RealmType.ValueStringPointer()
+	createRealmRequest.Profile = profile
+
+	responseRealm, response, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.CreateRealm(ctx).Body(*createRealmRequest).Execute()
+	if err != nil {
+		body, ioErr := io.ReadAll(response.Body)
+		defer response.Body.Close()
+		if ioErr != nil {
+			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			return
+		}
+		resp.Diagnostics.AddError("failed to create realm:"+err.Error(), string(body))
+		return
+	}
+
+	resp.Diagnostics.Append(mapRealmResourceToState(responseRealm, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *realmResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state realmModel
+	resp.Diagnostics.Append(resp.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	realm, response, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.GetRealm(ctx, state.ID.ValueString()).Execute()
+	if err != nil {
+		body, ioErr := io.ReadAll(response.Body)
+		defer response.Body.Close()
+		if ioErr != nil {
+			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			return
+		}
+		resp.Diagnostics.AddError("failed to read realm:"+err.Error(), string(body))
+		return
+	}
+
+	if realm == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(mapRealmResourceToState(realm, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *realmResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state realmModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateRealmRequest := v5okta.NewUpdateRealmRequest()
+	profile := v5okta.NewRealmProfile(state.Name.ValueString())
+	profile.RealmType = state.RealmType.ValueStringPointer()
+	updateRealmRequest.Profile = profile
+
+	realm, response, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.ReplaceRealm(ctx, state.ID.ValueString()).Body(*updateRealmRequest).Execute()
+	if err != nil {
+		body, ioErr := io.ReadAll(response.Body)
+		defer response.Body.Close()
+		if ioErr != nil {
+			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			return
+		}
+		resp.Diagnostics.AddError("failed to update realm:"+err.Error(), string(body))
+		return
+	}
+
+	resp.Diagnostics.Append(mapRealmResourceToState(realm, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *realmResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state realmModel
+	resp.Diagnostics.Append(resp.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.DeleteRealm(ctx, state.ID.ValueString()).Execute()
+	if err != nil {
+		body, ioErr := io.ReadAll(response.Body)
+		defer response.Body.Close()
+		if ioErr != nil {
+			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			return
+		}
+		resp.Diagnostics.AddError("failed to delete realm:"+err.Error(), string(body))
+		return
+	}
+}
+
+func (r *realmResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func mapRealmResourceToState(realmResource *v5okta.Realm, state *realmModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	state.ID = types.StringPointerValue(realmResource.Id)
+	state.Name = types.StringValue(realmResource.Profile.Name)
+	state.RealmType = types.StringPointerValue(realmResource.Profile.RealmType)
+	state.IsDefault = types.BoolPointerValue(realmResource.IsDefault)
+
+	return diags
+}

--- a/okta/services/idaas/resource_okta_realm_test.go
+++ b/okta/services/idaas/resource_okta_realm_test.go
@@ -1,0 +1,48 @@
+package idaas_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+	"github.com/okta/terraform-provider-okta/okta/utils"
+)
+
+func TestAccResourceOktaRealm_crud(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.example", resources.OktaIDaaSRealm)
+	mgr := newFixtureManager("resources", resources.OktaIDaaSRealm, t.Name())
+	config := mgr.GetFixtures("okta_realm.tf", t)
+	updatedConfig := mgr.GetFixtures("okta_realm_updated.tf", t)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSRealm, doesRealmExist),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "TestAcc Example Realm"),
+					resource.TestCheckResourceAttr(resourceName, "realm_type", "DEFAULT"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "TestAcc Example Realm Updated"),
+					resource.TestCheckResourceAttr(resourceName, "realm_type", "PARTNER"),
+				),
+			},
+		},
+	})
+}
+
+func doesRealmExist(id string) (bool, error) {
+	client := iDaaSAPIClientForTestUtil.OktaSDKClientV5()
+	_, response, err := client.RealmAPI.GetRealm(context.Background(), id).Execute()
+	return utils.DoesResourceExistV5(response, err)
+}

--- a/test/fixtures/vcr/idaas/TestAccDataSourceOktaRealm_read/realm-support.yaml
+++ b/test/fixtures/vcr/idaas/TestAccDataSourceOktaRealm_read/realm-support.yaml
@@ -1,0 +1,402 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 67
+        host: realm-support.dne-okta.com
+        body: |
+            {"profile":{"name":"AccTest Example Realm","realmType":"DEFAULT"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://realm-support.dne-okta.com/api/v1/realms
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyz5t9unKOhnjN697","created":"2025-08-07T11:00:11.000Z","lastUpdated":"2025-08-07T11:00:11.000Z","profile":{"name":"AccTest Example Realm","realmType":"DEFAULT","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:11 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.088548375s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        form:
+            search:
+                - profile.name eq "AccTest Example Realm"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms?search=profile.name+eq+%22AccTest+Example+Realm%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:12 GMT
+            Link:
+                - <https://realm-support.dne-okta.com/api/v1/realms?limit=10&search=profile.name+eq+%22AccTest+Example+Realm%22>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 811.260833ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        form:
+            search:
+                - profile.name eq "AccTest Example Realm"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms?search=profile.name+eq+%22AccTest+Example+Realm%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"guotyz5t9unKOhnjN697","created":"2025-08-07T11:00:11.000Z","lastUpdated":"2025-08-07T11:00:11.000Z","profile":{"name":"AccTest Example Realm","realmType":"DEFAULT"},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697","method":"GET"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:13 GMT
+            Link:
+                - <https://realm-support.dne-okta.com/api/v1/realms?limit=10&search=profile.name+eq+%22AccTest+Example+Realm%22>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 913.341083ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        form:
+            search:
+                - profile.name eq "AccTest Example Realm"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms?search=profile.name+eq+%22AccTest+Example+Realm%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"guotyz5t9unKOhnjN697","created":"2025-08-07T11:00:11.000Z","lastUpdated":"2025-08-07T11:00:11.000Z","profile":{"name":"AccTest Example Realm","realmType":"DEFAULT"},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697","method":"GET"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:14 GMT
+            Link:
+                - <https://realm-support.dne-okta.com/api/v1/realms?limit=10&search=profile.name+eq+%22AccTest+Example+Realm%22>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 739.508084ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyz5t9unKOhnjN697","created":"2025-08-07T11:00:11.000Z","lastUpdated":"2025-08-07T11:00:11.000Z","profile":{"name":"AccTest Example Realm","realmType":"DEFAULT","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 946.910708ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        form:
+            search:
+                - profile.name eq "AccTest Example Realm"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms?search=profile.name+eq+%22AccTest+Example+Realm%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"guotyz5t9unKOhnjN697","created":"2025-08-07T11:00:11.000Z","lastUpdated":"2025-08-07T11:00:11.000Z","profile":{"name":"AccTest Example Realm","realmType":"DEFAULT"},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697","method":"GET"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:16 GMT
+            Link:
+                - <https://realm-support.dne-okta.com/api/v1/realms?limit=10&search=profile.name+eq+%22AccTest+Example+Realm%22>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 767.837ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        form:
+            search:
+                - profile.name eq "AccTest Example Realm"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms?search=profile.name+eq+%22AccTest+Example+Realm%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"guotyz5t9unKOhnjN697","created":"2025-08-07T11:00:11.000Z","lastUpdated":"2025-08-07T11:00:11.000Z","profile":{"name":"AccTest Example Realm","realmType":"DEFAULT"},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697","method":"GET"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:17 GMT
+            Link:
+                - <https://realm-support.dne-okta.com/api/v1/realms?limit=10&search=profile.name+eq+%22AccTest+Example+Realm%22>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 757.050208ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        form:
+            search:
+                - profile.name eq "Unknown Example Realm"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms?search=profile.name+eq+%22Unknown+Example+Realm%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:17 GMT
+            Link:
+                - <https://realm-support.dne-okta.com/api/v1/realms?limit=10&search=profile.name+eq+%22Unknown+Example+Realm%22>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 752.184ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyz5t9unKOhnjN697","created":"2025-08-07T11:00:11.000Z","lastUpdated":"2025-08-07T11:00:11.000Z","profile":{"name":"AccTest Example Realm","realmType":"DEFAULT","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:18 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 902.446459ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        form:
+            search:
+                - profile.name eq "Unknown Example Realm"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms?search=profile.name+eq+%22Unknown+Example+Realm%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 11:00:19 GMT
+            Link:
+                - <https://realm-support.dne-okta.com/api/v1/realms?limit=10&search=profile.name+eq+%22Unknown+Example+Realm%22>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 789.963459ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyz5t9unKOhnjN697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 07 Aug 2025 11:00:21 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 988.415584ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaRealm_crud/realm-support.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaRealm_crud/realm-support.yaml
@@ -1,0 +1,206 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 67
+        host: realm-support.dne-okta.com
+        body: |
+            {"profile":{"name":"TestAcc Example Realm","realmType":"DEFAULT"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://realm-support.dne-okta.com/api/v1/realms
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyyzbl1YWn63OB697","created":"2025-08-07T10:56:05.000Z","lastUpdated":"2025-08-07T10:56:05.000Z","profile":{"name":"TestAcc Example Realm","realmType":"DEFAULT","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 10:56:05 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.061888292s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyyzbl1YWn63OB697","created":"2025-08-07T10:56:05.000Z","lastUpdated":"2025-08-07T10:56:05.000Z","profile":{"name":"TestAcc Example Realm","realmType":"DEFAULT","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 10:56:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 891.3495ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyyzbl1YWn63OB697","created":"2025-08-07T10:56:05.000Z","lastUpdated":"2025-08-07T10:56:05.000Z","profile":{"name":"TestAcc Example Realm","realmType":"DEFAULT","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 10:56:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 876.239416ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 75
+        host: realm-support.dne-okta.com
+        body: |
+            {"profile":{"name":"TestAcc Example Realm Updated","realmType":"PARTNER"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyyzbl1YWn63OB697","created":"2025-08-07T10:56:05.000Z","lastUpdated":"2025-08-07T10:56:08.000Z","profile":{"name":"TestAcc Example Realm Updated","realmType":"PARTNER","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 10:56:08 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 946.544667ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"guotyyzbl1YWn63OB697","created":"2025-08-07T10:56:05.000Z","lastUpdated":"2025-08-07T10:56:08.000Z","profile":{"name":"TestAcc Example Realm Updated","realmType":"PARTNER","domains":[]},"isDefault":false,"_links":{"self":{"rel":"self","href":"https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 07 Aug 2025 10:56:09 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 909.665958ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: realm-support.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://realm-support.dne-okta.com/api/v1/realms/guotyyzbl1YWn63OB697
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 07 Aug 2025 10:56:10 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.145766s


### PR DESCRIPTION
With this PR basic realm support is added which allows the use of the `okta_realm` resource: 

```tf
resource "okta_realm" "example" {
  name       = "Example Realm"
  realm_type = "DEFAULT"
}
```
as well as the data-source:
```tf
data "okta_realm" "example" {
  name       = "Example Realm"
  # or
  id         = "<some-realm-id>
}
```

This is the first step towards closing #2242.

Looking forward to receive some feedback 😊
