### PR TITLE
Okta-920847

### DIFF
--- a/docs/data-sources/apps.md
+++ b/docs/data-sources/apps.md
@@ -17,8 +17,9 @@ description: |-
 
 - `active_only` (Boolean) Search only active applications.
 - `include_non_deleted` (Boolean) Specifies whether to include non-active, but not deleted apps in the results.
+- `q` (String) Searches for apps with name or label properties that starts with the `q` value.
 - `label` (String) Searches for applications whose label or name property matches this value exactly.
-- `label_prefix` (String) Searches for applications whose label or name property begins with this value.
+- `label_prefix` (String) Searches for applications whose label or name property begins with this value. **Warning:** This might not work as intended and will be removed in the future release. Use `q` instead.
 - `use_optimization` (Boolean) Specifies whether to use query optimization. If you specify `useOptimization=true` in the request query, the response contains a subset of app instance properties.
 
 ### Read-Only

--- a/examples/data-sources/okta_apps/data-source.tf
+++ b/examples/data-sources/okta_apps/data-source.tf
@@ -1,0 +1,5 @@
+data "okta_apps" "example" {
+  q                   = "Example"
+  active_only         = true
+  include_non_deleted = true
+}

--- a/examples/data-sources/okta_apps/datasource.tf
+++ b/examples/data-sources/okta_apps/datasource.tf
@@ -1,0 +1,8 @@
+resource "okta_app_oauth" "example" {
+  label          = "example"
+  type           = "web"
+}
+
+data "okta_apps" "apps" {
+  q = "example"
+}

--- a/okta/data_source_okta_apps.go
+++ b/okta/data_source_okta_apps.go
@@ -92,9 +92,10 @@ func (d *AppsDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				Description: "Searches for applications whose label or name property matches this value exactly.",
 			},
 			"label_prefix": schema.StringAttribute{
-				Optional:    true,
-				Validators:  []validator.String{stringvalidator.ConflictsWith(path.MatchRoot("label"))},
-				Description: "Searches for applications whose label or name property begins with this value.",
+				Optional:           true,
+				Validators:         []validator.String{stringvalidator.ConflictsWith(path.MatchRoot("label"))},
+				Description:        "Searches for applications whose label or name property begins with this value.",
+				DeprecationMessage: "Use `q` instead. This attribute will be removed in a future version.",
 			},
 			"include_non_deleted": schema.BoolAttribute{
 				Optional:    true,

--- a/okta/data_source_okta_apps_test.go
+++ b/okta/data_source_okta_apps_test.go
@@ -1,0 +1,27 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceOktaApps_read(t *testing.T) {
+	mgr := newFixtureManager("data-sources", apps, t.Name())
+	config := mgr.GetFixtures("datasource.tf", t)
+
+	oktaResourceTest(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ErrorCheck:        testAccErrorChecks(t),
+		ProviderFactories: testAccProvidersFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("okta_app_oauth.test", "id"),
+					resource.TestCheckResourceAttr("data.okta_groups.apps", "apps.#", "0"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Closes: #2251 

This adds a `q` attribute to the `data_source_okta_apps`, which will search the applications that start with a label or name.