### PR TITLE
Documentation Fix: resource_set example missing attribute

### DIFF
--- a/docs/resources/resource_set.md
+++ b/docs/resources/resource_set.md
@@ -44,8 +44,8 @@ resource "okta_resource_set" "test" {
 data "okta_org_metadata" "_" {}
 locals {
   org_url = try(
-    data.okta_org_metadata._.alternate,
-    data.okta_org_metadata._.organization
+    data.okta_org_metadata._.domains.alternate,
+    data.okta_org_metadata._.domains.organization
   )
 }
 resource "okta_resource_set" "example" {

--- a/examples/resources/okta_resource_set/resource.tf
+++ b/examples/resources/okta_resource_set/resource.tf
@@ -15,8 +15,8 @@ resource "okta_resource_set" "test" {
 data "okta_org_metadata" "_" {}
 locals {
   org_url = try(
-    data.okta_org_metadata._.alternate,
-    data.okta_org_metadata._.organization
+    data.okta_org_metadata._.domains.alternate,
+    data.okta_org_metadata._.domains.organization
   )
 }
 resource "okta_resource_set" "example" {


### PR DESCRIPTION
**Missing attribute in documentation**
In the example for the `okta_resource_set`, the Okta organization URL is fetched by calling the `okta_org_metadata` data resource. The local variables however were missing the `domains` attribute of the data resource and are not working the way they're written. This PR should fix that.