### PR TITLE
fix: HTTP 404 handling okta_app_group_assignments

### DIFF
--- a/okta/services/idaas/resource_okta_app_group_assignments.go
+++ b/okta/services/idaas/resource_okta_app_group_assignments.go
@@ -408,8 +408,8 @@ func deleteGroupAssignments(
 	assignments []*sdk.ApplicationGroupAssignment,
 ) error {
 	for i := range assignments {
-		_, err := delete(ctx, appID, assignments[i].Id)
-		if err != nil {
+		resp, err := delete(ctx, appID, assignments[i].Id)
+		if err := suppressErrorOn404(resp, err); err != nil {
 			return fmt.Errorf("could not delete assignment for group %s, to application %s: %w", assignments[i].Id, appID, err)
 		}
 	}


### PR DESCRIPTION
The function `deleteGroupAssignments ` trigger an error if we get a 404 response when we try to remove an `app_group_assignment`

If we get a 404 in this circumstance, it can only mean one of the following:
- The App ID is wrong
- The Group ID is wrong
- The Group no longer exists
- The App no longer exists
- The Group is no longer assigned to the app

In all of these cases we don't need to throw an error as the group is no longer assigned to the application in all cases
Therefore, this function should suppress the a 404 response if it gets one, this aligns with functions elsewhere in the file that also call `suppressErrorOn404`