### PR TITLE
fix: `v4.18.0`/`v4.19.0` Regression `data_source_okta_groups` not handling `custom_profile_attributes`

### DIFF
--- a/okta/services/idaas/data_source_okta_groups.go
+++ b/okta/services/idaas/data_source_okta_groups.go
@@ -150,22 +150,13 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta inte
 		arr[i]["type"] = okta_groups[i].Type
 		arr[i]["description"] = okta_groups[i].Profile.Description
 
-		additionalProperties := okta_groups[i].AdditionalProperties
-		src, ok := additionalProperties["source"].(map[string]interface{})
-		if ok && src["id"] != nil {
-			arr[i]["source"] = src["id"].(string)
-		}
-
-		// OktaV5 doesn't remove "source" from additionalProperties,
-		// so we do it manually to ensure backwards compatibility with prior OktaV2 implementation
-		delete(additionalProperties, "source")
-
-		customProfile, err := json.Marshal(additionalProperties)
+		// Use Profile.AdditionalProperties for custom profile attributes
+		customProfileMap := okta_groups[i].Profile.AdditionalProperties
+		customProfile, err := json.Marshal(customProfileMap)
 		if err != nil {
-			return diag.Errorf("failed to read custom profile attributes from group: %s", additionalProperties)
+			return diag.Errorf("failed to read custom profile attributes from group ID: %s", *okta_groups[i].Id)
 		}
 		arr[i]["custom_profile_attributes"] = string(customProfile)
-
 	}
 	_ = d.Set("groups", arr)
 	return nil


### PR DESCRIPTION
fixed a regression introduced in v4.19.0 (a regression introduced by me 🫠)
`custom_profile_attributes` were note handled or saved to state correctly

fixes: #2327