### PR TITLE
disable call to auth policy api for service apps

### DIFF
--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -114,6 +114,7 @@ resource "okta_app_oauth" "example" {
 - `user_name_template_suffix` (String) Username template suffix
 - `user_name_template_type` (String) Username template type. Default: `BUILT_IN`
 - `wildcard_redirect` (String) *Early Access Property*. Indicates if the client is allowed to use wildcard matching of redirect_uris
+- `disable_auth_policy` (Boolean) Disable attaching any authentication policy to the application. To be used only with applications of type SERVICE.
 
 ### Read-Only
 

--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -114,7 +114,7 @@ resource "okta_app_oauth" "example" {
 - `user_name_template_suffix` (String) Username template suffix
 - `user_name_template_type` (String) Username template type. Default: `BUILT_IN`
 - `wildcard_redirect` (String) *Early Access Property*. Indicates if the client is allowed to use wildcard matching of redirect_uris
-- `disable_auth_policy` (Boolean) Disable attaching any authentication policy to the application. To be used only with applications of type SERVICE.
+- `disable_auth_policy` (Boolean) Disable adding authorization policy for SERVICE applications. WARNING: This is a temporary field and will be deprecated in future releases i.e. the ability to toggle the authorization policy will be removed in a future release. This field applies only to SERVICE applications, authorization policies will always be attached to other application types.
 
 ### Read-Only
 

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -412,7 +412,7 @@ other arguments that changed will be applied.`,
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Disable adding authorization policy for SERVICE applications. WARNING: This is a temporary field since we will be removing the ability to toggle auth policy in the future. This is only for SERVICE applications, other application types will always have an auth policy attached to them.",
+				Description: "Disable adding authorization policy for SERVICE applications. WARNING: This is a temporary field. The ability to toggle the authorization policy will be removed in a future release. This field applies only to SERVICE applications, authorization policies will always be attached to other application types.",
 			},
 		}),
 		Timeouts: &schema.ResourceTimeout{

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -408,6 +408,12 @@ other arguments that changed will be applied.`,
 				Optional:    true,
 				Description: "URL reference to JWKS",
 			},
+			"disable_auth_policy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Disable adding authorization policy for SERVICE applications. WARNING: This is a temporary field since we will be removing the ability to toggle auth policy in the future. This is only for SERVICE applications, other application types will always have an auth policy attached to them.",
+			},
 		}),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Hour),
@@ -478,9 +484,11 @@ func resourceAppOAuthCreate(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.Errorf("failed to update groups claim for an OAuth application: %v", err)
 	}
-	err = createOrUpdateAuthenticationPolicy(ctx, d, meta, app.Id)
-	if err != nil {
-		return diag.Errorf("failed to set authentication policy for an OAuth application: %v", err)
+	if !(d.Get("disable_auth_policy").(bool) && d.Get("type").(string) == "service") {
+		err = createOrUpdateAuthenticationPolicy(ctx, d, meta, app.Id)
+		if err != nil {
+			return diag.Errorf("failed to set authentication policy for an OAuth application: %v", err)
+		}
 	}
 	return resourceAppOAuthRead(ctx, d, meta)
 }
@@ -747,9 +755,11 @@ func resourceAppOAuthUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.Errorf("failed to update groups claim for an OAuth application: %v", err)
 	}
-	err = createOrUpdateAuthenticationPolicy(ctx, d, meta, app.Id)
-	if err != nil {
-		return diag.Errorf("failed to set authentication policy an OAuth application: %v", err)
+	if !(d.Get("disable_auth_policy").(bool) && d.Get("type").(string) == "service") {
+		err = createOrUpdateAuthenticationPolicy(ctx, d, meta, app.Id)
+		if err != nil {
+			return diag.Errorf("failed to set authentication policy an OAuth application: %v", err)
+		}
 	}
 	return resourceAppOAuthRead(ctx, d, meta)
 }


### PR DESCRIPTION
Adds a new temporary field "disable_auth_policy" to prevent making calls to auth policy api for service apps. In future releases, we will be marking this field as deprecated.