### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
-
-## 5.0.0 (June 18, 2025)
+## 5.0.0 (June 24, 2025)
 
 ### IMPROVEMENTS
 
+* Update okta_app_signon_policy_rule resource docs to include `chains` attribute by [#2362](https://github.com/okta/terraform-provider-okta/pull/2362) by [aditya-okta](https://github.com/aditya-okta)
 * Code refactor of the Okta Terraform Provider [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [Mike](https://github.com/monde), [aditya-okta](https://github.com/aditya-okta)
 * Fix minor errors found while tuning up the test suite [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [Mike](https://github.com/monde), [aditya-okta](https://github.com/aditya-okta)
 * Full acceptance test harness run to gate releases [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [Mike](https://github.com/monde), [aditya-okta](https://github.com/aditya-okta) 
 * New Issue Templates [#2354](https://github.com/okta/terraform-provider-okta/pull/2354) by [aditya-okta](https://github.com/aditya-okta) 
+* Bump goreleaser/goreleaser-action from 6.2.1 to 6.3.0 [#2354](https://github.com/okta/terraform-provider-okta/pull/2364)
+* Bump github.com/hashicorp/go-retryablehttp from 0.7.7 to 0.7.8 [#2365](https://github.com/okta/terraform-provider-okta/pull/2365)
 * Bump gopkg.in/dnaeon/go-vcr from v3.2.0 to v4.0.3 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
 * Bump github.com/cloudflare/circl from v1.6.0 to v1.6.1 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
 * Bump gopkg.in/dnaeon/go-vcr from v3.2.0 to v4.0.3 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)


### PR DESCRIPTION
## 5.0.0 (June 24, 2025)

### IMPROVEMENTS

* Update okta_app_signon_policy_rule resource docs to include `chains` attribute by [#2362](https://github.com/okta/terraform-provider-okta/pull/2362) by [aditya-okta](https://github.com/aditya-okta)
* Code refactor of the Okta Terraform Provider [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [Mike](https://github.com/monde), [aditya-okta](https://github.com/aditya-okta)
* Fix minor errors found while tuning up the test suite [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [Mike](https://github.com/monde), [aditya-okta](https://github.com/aditya-okta)
* Full acceptance test harness run to gate releases [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [Mike](https://github.com/monde), [aditya-okta](https://github.com/aditya-okta) 
* New Issue Templates [#2354](https://github.com/okta/terraform-provider-okta/pull/2354) by [aditya-okta](https://github.com/aditya-okta) 
* Bump goreleaser/goreleaser-action from 6.2.1 to 6.3.0 [#2354](https://github.com/okta/terraform-provider-okta/pull/2364)
* Bump github.com/hashicorp/go-retryablehttp from 0.7.7 to 0.7.8 [#2365](https://github.com/okta/terraform-provider-okta/pull/2365)
* Bump gopkg.in/dnaeon/go-vcr from v3.2.0 to v4.0.3 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump github.com/cloudflare/circl from v1.6.0 to v1.6.1 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump gopkg.in/dnaeon/go-vcr from v3.2.0 to v4.0.3 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump github.com/zclconf/go-cty from v1.16.2 to v1.16.3 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump golang.org/x/crypto from v0.38.0 to v0.39.0 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump golang.org/x/mod from v0.24.0 to v0.25.0 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump golang.org/x/mod from v0.39.0 to v0.40.0 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump golang.org/x/text from v0.25.0 to v0.26.0 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)
* Bump golang.org/x/tools from v0.22.0 to v0.33.0 [#2238](https://github.com/okta/terraform-provider-okta/pull/2238) by [aditya-okta](https://github.com/aditya-okta)