### PR TITLE
chore: remove min_items from app_group_assignments (rebased for V5)

### DIFF
--- a/okta/services/idaas/resource_okta_app_group_assignments.go
+++ b/okta/services/idaas/resource_okta_app_group_assignments.go
@@ -113,7 +113,8 @@ func resourceAppGroupAssignmentsRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("failed to fetch group assignments: %v", err)
 	}
 	if currentGroupAssignments == nil {
-		d.SetId("")
+		// if there are no groups assigned to the Okta app, create the resource in TF state and return
+		// Required to explicitly manage that no groups should be assigned to an Okta application
 		return nil
 	}
 	g, ok := d.GetOk("group")


### PR DESCRIPTION
the stated use case for app_group_assignments is to explicitly manage all groups assigned to an application
This PR allows TF to explicitly manage that no groups should be assigned to an Okta application