### PR TITLE
updated documentation to add warning for resource okta_app_oauth to disable attaching  auth policy in future release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 The Terraform Okta provider is a plugin for Terraform that allows for the full lifecycle management of Okta resources.
 This provider is maintained internally by the Okta development team.
 
+### WARNING
+We're working on releasing of the okta-terraform-provider v6.0.0, which will introduce support for managing a broader range of Okta resources beyond just management-related ones. Following that, we'd be deprecating the v5 versions of the okta-terraform-provider.
+
 ## Examples
 
 All the resources and data sources has [one or more examples](./examples) to give you an idea of how to use this

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ Use the navigation to the left to read about the available resources and data so
 In case the provider configuration is still using old `"oktadeveloper/okta"` source, please change it to `"okta/okta"` and run
 `terraform state replace-provider oktadeveloper/okta okta/okta`. Okta no longer supports `"oktadeveloper/okta"`.
 
+### WARNING
+We're working on releasing of the okta-terraform-provider v6.0.0, which will introduce support for managing a broader range of Okta resources beyond just management-related ones. Following that, we'd be deprecating the v5 versions of the okta-terraform-provider.
+
 ## Example Usage
 
 Terraform 0.14 and later:

--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -71,7 +71,7 @@ resource "okta_app_oauth" "example" {
 - `admin_note` (String) Application notes for admins.
 - `app_links_json` (String) Displays specific appLinks for the app. The value for each application link should be boolean.
 - `app_settings_json` (String) Application settings in JSON format
-- `authentication_policy` (String) The ID of the associated app_signon_policy. If this property is removed from the application the default sign-on-policy will be associated with this application.
+- `authentication_policy` (String) The ID of the associated app_signon_policy. If this property is removed from the application the default sign-on-policy will be associated with this application. We will be stop attaching authentication_policy for applications of type `SERVICE` in the upcoming release.
 - `auto_key_rotation` (Boolean) Requested key rotation mode. If
 				auto_key_rotation isn't specified, the client automatically opts in for Okta's
 				key rotation. You can update this property via the API or via the administrator

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -401,7 +401,7 @@ other arguments that changed will be applied.`,
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: `The ID of the associated app_signon_policy. If this property is removed from the application the default sign-on-policy will be associated with this application.`,
+				Description: `The ID of the associated app_signon_policy. If this property is removed from the application the default sign-on-policy will be associated with this application. We will be stop attaching authentication_policy for applications of type SERVICE in the upcoming release`,
 			},
 			"jwks_uri": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
- Adds warning to stop attaching/updating authentication policy for service apps in okta_app_oauth
- Adds a deprecation warning for v5 versions of the provider. 