### PR TITLE
release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 5.1.0 (July 3, 2025)
+
+### BUG FIXES
+
+* Fix regression in `data_source_okta_groups` for not handling custom_profile_attributes[#2328](https://github.com/okta/terraform-provider-okta/pull/2328) by [exitcode0](https://github.com/exitcode0).
+
+### IMPROVEMENTS
+
+* Add warning to stop adding authentication policy for `SERVICE` apps for resource `okta_app_oauth`[#2376](https://github.com/okta/terraform-provider-okta/pull/2376) by [aditya-okta](https://github.com/aditya-okta). 
+* Bump gopkg.in/dnaeon/go-vcr.v4 from 4.0.3 to 4.0.4 [#2372](https://github.com/okta/terraform-provider-okta/pull/2372)
+
 ## 5.0.0 (June 24, 2025)
 
 ### IMPROVEMENTS

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.0.0"
+      version = "~> 5.1.0"
     }
   }
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "5.0.0"
+	OktaTerraformProviderVersion   = "5.1.0"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.0.0"
+      version = "~> 5.1.0"
     }
   }
 }


### PR DESCRIPTION
## 5.1.0 (July 3, 2025)

### BUG FIXES

* Fix regression in `data_source_okta_groups` for not handling custom_profile_attributes by [exitcode0](https://github.com/exitcode0).

### IMPROVEMENTS

* Add warning to stop adding authentication policy for `SERVICE` apps for resource `okta_app_oauth`[#2376](https://github.com/okta/terraform-provider-okta/pull/2376) by [aditya-okta](https://github.com/aditya-okta). 
* Bumps gopkg.in/dnaeon/go-vcr.v4 from 4.0.3 to 4.0.4 [#2372](https://github.com/okta/terraform-provider-okta/pull/2372)