### PR TITLE
fix: linter warning "tautological nil check"

### DIFF
--- a/okta/services/idaas/resource_okta_policy_mfa.go
+++ b/okta/services/idaas/resource_okta_policy_mfa.go
@@ -100,9 +100,7 @@ func buildSettings(d *schema.ResourceData) *sdk.SdkPolicySettings {
 
 			authenticator := &sdk.PolicyAuthenticator{}
 			authenticator.Key = key
-			if enroll != nil {
-				authenticator.Enroll = &sdk.Enroll{Self: enroll.(string)}
-			}
+			authenticator.Enroll = &sdk.Enroll{Self: enroll.(string)}
 			constraints := rawFactor["constraints"]
 			if constraints != nil {
 				c, ok := constraints.(string)


### PR DESCRIPTION
We already check for the possibility of a `nil` value earlier in the function at line 98-100
```go
for _, key := range sdk.AuthenticatorProviders {
	rawFactor := d.Get(key).(map[string]interface{})
	enroll := rawFactor["enroll"]
	if enroll == nil {
		continue
	}
```

This means by the time we reach line 102-103, enroll is guaranteed to be non-nil
This makes checking for a `nil` value again redundant, which is causing the tautological condition warning

Remove the redundant `nil` value check will resolve the compiler warning