### PR TITLE
feat: skip provider credential validation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,19 @@ provider "okta" {
 }
 ```
 
+### Skip Validation Example
+
+For environments where Okta resources are conditionally used:
+
+```hcl
+provider "okta" {
+  org_name = null
+  base_url = null
+  api_token = null
+  skip_validation = true
+}
+```
+
 For the resources and data sources examples, please check the [examples](https://github.com/okta/terraform-provider-okta/tree/master/examples) directory.
 
 ## Authentication
@@ -136,3 +149,6 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
 - `max_api_capacity` - (Optional) sets what percentage of capacity the provider can use of the total
   rate limit capacity while making calls to the Okta management API endpoints. Okta API operates in one minute buckets.
   See Okta Management API Rate Limits: https://developer.okta.com/docs/reference/rl-global-mgmt. Can be set to a value between 1 and 100.
+
+- `skip_validation` - (Optional) Skip all input validation for Okta Provider credentials. Can also be set via the `OKTA_SKIP_VALIDATION` environment variable. Defaults to `false`.  
+  **Note**: Using `skip_validation = true` may make troubleshooting more difficult and may result in less helpful error messages if missing/invalid credentials are used with the provider.

--- a/okta/config/config.go
+++ b/okta/config/config.go
@@ -41,6 +41,8 @@ type (
 		RequestTimeout       int
 		RetryCount           int
 		Scopes               []string
+		// SkipValidation determines whether to skip credential validation during provider initialization
+		SkipValidation       bool
 		TimeOperations       TimeOperations
 	}
 )
@@ -166,6 +168,26 @@ func NewConfig(d *schema.ResourceData) *Config {
 
 	if v := os.Getenv("OKTA_API_SCOPES"); v != "" && len(config.Scopes) == 0 {
 		config.Scopes = strings.Split(v, ",")
+	}
+
+	if val, ok := d.GetOk("skip_validation"); ok {
+		config.SkipValidation = val.(bool)
+	} else if envVal := os.Getenv("OKTA_SKIP_VALIDATION"); envVal != "" {
+		// Only use environment variable if not explicitly set in provider config
+		if skipValidation, err := strconv.ParseBool(envVal); err == nil {
+			config.SkipValidation = skipValidation
+		} else {
+			// Log warning with more context about valid values
+			if config.Logger != nil {
+				config.Logger.Warn("Invalid value for OKTA_SKIP_VALIDATION environment variable; defaulting to false",
+					"value", envVal,
+					"valid_values", "true, false, 1, 0",
+					"error", err.Error(),
+					"default_value", false)
+			}
+			// Explicitly set to false for invalid values
+			config.SkipValidation = false
+		}
 	}
 
 	config.SetupLogger()

--- a/okta/config/config_test.go
+++ b/okta/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestConfigLoadAndValidate(t *testing.T) {
@@ -49,5 +50,107 @@ func TestConfigLoadAndValidate(t *testing.T) {
 			t.Errorf("test %q: did not expect error but received error: %+v", test.name, err)
 			fmt.Println()
 		}
+	}
+}
+
+func TestConfigSkipValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		skipValidation bool
+		apiToken       string
+		expectError    bool
+	}{
+		{"skip_validation = true with invalid token", true, "invalid_token", false},
+		{"skip_validation = false with invalid token", false, "invalid_token", true},
+		{"skip_validation = true with empty token", true, "", false},
+		{"skip_validation = true with valid token", true, "valid_token", false},
+		{"skip_validation = false with empty token", false, "", false}, // Should not error when no token
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := Config{
+				OrgName:        "test",
+				Domain:         "invalid.okta.com",
+				ApiToken:       test.apiToken,
+				SkipValidation: test.skipValidation,
+				LogLevel:       int(hclog.Warn),
+			}
+			config.Logger = hclog.New(hclog.DefaultOptions)
+
+			// Only test validation when skip_validation is false and we have a token
+			// We need to initialize the API client first, but we expect it to fail for invalid credentials
+			if !test.skipValidation && test.apiToken != "" {
+				// For this test, we just verify that the SkipValidation field is set correctly
+				// since we can't easily test the actual API call without valid credentials
+				if config.SkipValidation != test.skipValidation {
+					t.Errorf("expected SkipValidation to be %v but got %v", test.skipValidation, config.SkipValidation)
+				}
+			} else {
+				// When skip_validation is true or no token, we shouldn't call VerifyCredentials
+				// This test just verifies the config can be created without error
+				if config.SkipValidation != test.skipValidation {
+					t.Errorf("expected SkipValidation to be %v but got %v", test.skipValidation, config.SkipValidation)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigSkipValidationEnvironmentVariable(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		expectedSkip bool
+	}{
+		{"OKTA_SKIP_VALIDATION=true", "true", true},
+		{"OKTA_SKIP_VALIDATION=false", "false", false},
+		{"OKTA_SKIP_VALIDATION=1", "1", true},
+		{"OKTA_SKIP_VALIDATION=0", "0", false},
+		{"OKTA_SKIP_VALIDATION=invalid", "invalid", false}, // Invalid values should default to false
+		{"OKTA_SKIP_VALIDATION empty", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a mock ResourceData
+			d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+				"skip_validation": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+			}, map[string]interface{}{})
+
+			// Set environment variable
+			if test.envValue != "" {
+				t.Setenv("OKTA_SKIP_VALIDATION", test.envValue)
+			}
+
+			config := NewConfig(d)
+
+			if config.SkipValidation != test.expectedSkip {
+				t.Errorf("expected SkipValidation to be %v but got %v", test.expectedSkip, config.SkipValidation)
+			}
+		})
+	}
+}
+
+func TestConfigSkipValidationProviderOverridesEnv(t *testing.T) {
+	// Test that provider configuration takes precedence over environment variable
+	t.Setenv("OKTA_SKIP_VALIDATION", "false")
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"skip_validation": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+	}, map[string]interface{}{
+		"skip_validation": true,
+	})
+
+	config := NewConfig(d)
+
+	if !config.SkipValidation {
+		t.Error("expected provider configuration to override environment variable")
 	}
 }

--- a/okta/fwprovider/framework_provider.go
+++ b/okta/fwprovider/framework_provider.go
@@ -59,6 +59,7 @@ type FrameworkProviderData struct {
 	LogLevel       types.Int64  `tfsdk:"log_level"`
 	MaxAPICapacity types.Int64  `tfsdk:"max_api_capacity"`
 	RequestTimeout types.Int64  `tfsdk:"request_timeout"`
+	SkipValidation types.Bool   `tfsdk:"skip_validation"`
 }
 
 // Metadata returns the provider type name.
@@ -195,6 +196,10 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 					int64validator.AtLeast(0),
 					int64validator.AtMost(300),
 				},
+			},
+			"skip_validation": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Skip validation of the provided Okta credentials during provider initialization. This allows the provider to be configured without valid credentials, which can be useful in environments where Okta resources are conditionally used.",
 			},
 		},
 	}

--- a/okta/provider/provider.go
+++ b/okta/provider/provider.go
@@ -116,6 +116,12 @@ func Provider() *schema.Provider {
 				ValidateDiagFunc: intBetween(0, 300),
 				Description:      "Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `300`.",
 			},
+			"skip_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Skip validation of the provided Okta credentials during provider initialization. This allows the provider to be configured without valid credentials, which can be useful in environments where Okta resources are conditionally used.",
+			},
 		},
 		ResourcesMap:         idaas.ProviderResources(),
 		DataSourcesMap:       idaas.ProviderDataSources(),
@@ -144,9 +150,19 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	// NOTE: production runtime needs to know about VCR test environment for
 	// this one case where the validate function calls GET /api/v1/users/me to
 	// quickly verify if the operator's auth settings are correct.
-	if os.Getenv("OKTA_VCR_TF_ACC") == "" {
+	shouldSkipValidation := os.Getenv("OKTA_VCR_TF_ACC") != "" || cfg.SkipValidation
+
+	if shouldSkipValidation {
+		if cfg.Logger != nil {
+			if os.Getenv("OKTA_VCR_TF_ACC") != "" {
+				cfg.Logger.Info("Skipping Okta credential validation due to VCR test mode")
+			} else {
+				cfg.Logger.Info("Skipping Okta credential validation as requested")
+			}
+		}
+	} else {
 		if err := cfg.VerifyCredentials(ctx); err != nil {
-			return nil, diag.Errorf("[ERROR] failed validate configuration: %v", err)
+			return nil, diag.Errorf("[ERROR] failed to validate configuration: %v", err)
 		}
 	}
 

--- a/okta/services/idaas/idaas_test.go
+++ b/okta/services/idaas/idaas_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	schema_sdk "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -15,6 +18,7 @@ import (
 	"github.com/okta/terraform-provider-okta/okta/acctest"
 	"github.com/okta/terraform-provider-okta/okta/api"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/fwprovider"
 	"github.com/okta/terraform-provider-okta/okta/provider"
 	"github.com/okta/terraform-provider-okta/okta/resources"
 	"github.com/okta/terraform-provider-okta/okta/services/idaas"
@@ -141,37 +145,43 @@ func TestProviderValidate(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		accessToken  string
-		apiToken     string
-		clientID     string
-		privateKey   string
-		privateKeyID string
-		scopes       []interface{}
-		expectError  bool
+		name           string
+		accessToken    string
+		apiToken       string
+		clientID       string
+		privateKey     string
+		privateKeyID   string
+		scopes         []interface{}
+		skipValidation bool
+		expectError    bool
 	}{
-		{"simple pass", "", "", "", "", "", []interface{}{}, false},
-		{"access_token pass", "accessToken", "", "", "", "", []interface{}{}, false},
-		{"access_token fail 1", "accessToken", "apiToken", "", "", "", []interface{}{}, true},
-		{"access_token fail 2", "accessToken", "", "cliendID", "", "", []interface{}{}, true},
-		{"access_token fail 3", "accessToken", "", "", "privateKey", "", []interface{}{}, true},
-		{"access_token fail 4", "accessToken", "", "", "", "", []interface{}{"scope1", "scope2"}, true},
-		{"api_token pass", "", "apiToken", "", "", "", []interface{}{}, false},
-		{"api_token fail 1", "accessToken", "apiToken", "", "", "", []interface{}{}, true},
-		{"api_token fail 2", "", "apiToken", "clientID", "", "", []interface{}{}, true},
-		{"api_token fail 3", "", "apiToken", "", "", "privateKey", []interface{}{}, true},
-		{"api_token fail 4", "", "apiToken", "", "", "", []interface{}{"scope1", "scope2"}, true},
-		{"client_id pass", "", "", "clientID", "", "", []interface{}{}, false},
-		{"client_id fail 1", "accessToken", "", "clientID", "", "", []interface{}{}, true},
-		{"client_id fail 2", "accessToken", "apiToken", "clientID", "", "", []interface{}{}, true},
-		{"private_key pass", "", "", "", "privateKey", "", []interface{}{}, false},
-		{"private_key fail 1", "accessToken", "", "", "privateKey", "", []interface{}{}, true},
-		{"private_key fail 2", "", "apiToken", "", "privateKey", "", []interface{}{}, true},
-		{"private_key_id pass", "", "", "", "", "privateKeyID", []interface{}{}, false},
-		{"private_key_id fail 1", "", "apiToken", "", "", "privateKeyID", []interface{}{}, true},
-		{"scopes pass", "", "", "", "", "", []interface{}{"scope1", "scope2"}, false},
-		{"scopes fail 1", "accessToken", "", "", "", "", []interface{}{"scope1", "scope2"}, true},
-		{"scopes fail 2", "", "apiToken", "", "", "", []interface{}{"scope1", "scope2"}, true},
+		{"simple pass", "", "", "", "", "", []interface{}{}, false, false},
+		{"access_token pass", "accessToken", "", "", "", "", []interface{}{}, false, false},
+		{"access_token fail 1", "accessToken", "apiToken", "", "", "", []interface{}{}, false, true},
+		{"access_token fail 2", "accessToken", "", "cliendID", "", "", []interface{}{}, false, true},
+		{"access_token fail 3", "accessToken", "", "", "privateKey", "", []interface{}{}, false, true},
+		{"access_token fail 4", "accessToken", "", "", "", "", []interface{}{"scope1", "scope2"}, false, true},
+		{"api_token pass", "", "apiToken", "", "", "", []interface{}{}, false, false},
+		{"api_token fail 1", "accessToken", "apiToken", "", "", "", []interface{}{}, false, true},
+		{"api_token fail 2", "", "apiToken", "clientID", "", "", []interface{}{}, false, true},
+		{"api_token fail 3", "", "apiToken", "", "", "privateKey", []interface{}{}, false, true},
+		{"api_token fail 4", "", "apiToken", "", "", "", []interface{}{"scope1", "scope2"}, false, true},
+		{"client_id pass", "", "", "clientID", "", "", []interface{}{}, false, false},
+		{"client_id fail 1", "accessToken", "", "clientID", "", "", []interface{}{}, false, true},
+		{"client_id fail 2", "accessToken", "apiToken", "clientID", "", "", []interface{}{}, false, true},
+		{"private_key pass", "", "", "", "privateKey", "", []interface{}{}, false, false},
+		{"private_key fail 1", "accessToken", "", "", "privateKey", "", []interface{}{}, false, true},
+		{"private_key fail 2", "", "apiToken", "", "privateKey", "", []interface{}{}, false, true},
+		{"private_key_id pass", "", "", "", "", "privateKeyID", []interface{}{}, false, false},
+		{"private_key_id fail 1", "", "apiToken", "", "", "privateKeyID", []interface{}{}, false, true},
+		{"scopes pass", "", "", "", "", "", []interface{}{"scope1", "scope2"}, false, false},
+		{"scopes fail 1", "accessToken", "", "", "", "", []interface{}{"scope1", "scope2"}, false, true},
+		{"scopes fail 2", "", "apiToken", "", "", "", []interface{}{"scope1", "scope2"}, false, true},
+		// skip_validation parameter tests
+		{"skip_validation true pass", "", "", "", "", "", []interface{}{}, true, false},
+		{"skip_validation false pass", "", "", "", "", "", []interface{}{}, false, false},
+		{"skip_validation with api_token", "", "apiToken", "", "", "", []interface{}{}, true, false},
+		{"skip_validation with access_token", "accessToken", "", "", "", "", []interface{}{}, true, false},
 	}
 
 	for _, test := range tests {
@@ -193,6 +203,9 @@ func TestProviderValidate(t *testing.T) {
 		}
 		if len(test.scopes) > 0 {
 			resourceConfig["scopes"] = test.scopes
+		}
+		if test.skipValidation {
+			resourceConfig["skip_validation"] = test.skipValidation
 		}
 
 		config := terraform.NewResourceConfigRaw(resourceConfig)
@@ -799,6 +812,388 @@ func sweepPolicyRulesByType(ruleType string, client api.OktaIDaaSClient) error {
 		}
 	}
 	return nil
+}
+
+// Provider skip_validation tests
+
+func TestProviderSkipValidationWithInvalidCredentials(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use the standard AccPreCheck since we're testing invalid credentials
+		},
+		ProviderFactories: map[string]func() (*schema_sdk.Provider, error){
+			"okta": func() (*schema_sdk.Provider, error) {
+				return provider.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testProviderSkipValidationConfig(),
+				Check: func(s *terraform.State) error {
+					// Verify that the provider was configured successfully
+					// even with invalid credentials
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestProviderSkipValidationWithEnvironmentVariable(t *testing.T) {
+	// Set environment variable
+	t.Setenv("OKTA_SKIP_VALIDATION", "true")
+	t.Setenv("OKTA_ORG_NAME", "invalid")
+	t.Setenv("OKTA_BASE_URL", "invalid.com")
+	t.Setenv("OKTA_API_TOKEN", "invalid")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use standard AccPreCheck
+		},
+		ProviderFactories: map[string]func() (*schema_sdk.Provider, error){
+			"okta": func() (*schema_sdk.Provider, error) {
+				return provider.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testProviderSkipValidationEnvConfig(),
+				Check: func(s *terraform.State) error {
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestProviderValidationFailsWithoutSkip(t *testing.T) {
+	// This test verifies that validation fails when skip_validation is false
+	// and invalid credentials are provided with an API token
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use standard AccPreCheck
+		},
+		ProviderFactories: map[string]func() (*schema_sdk.Provider, error){
+			"okta": func() (*schema_sdk.Provider, error) {
+				return provider.Provider(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testProviderInvalidCredentialsWithTokenConfig(),
+				ExpectError: regexp.MustCompile("failed validate configuration"),
+			},
+		},
+	})
+}
+
+func TestAccProviderSkipValidationConditionalResources(t *testing.T) {
+	// This test demonstrates the real-world use case from issue #1452:
+	// - Monolithic Terraform codebase with conditional Okta resource usage
+	// - skip_validation=true allows provider to initialize without valid credentials
+	// - Resources are conditionally created based on feature flags/variables
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use standard AccPreCheck since we're testing with invalid credentials
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderSkipValidationConditionalResourcesConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					// When count=0, the resource shouldn't exist in state
+					// We verify this by checking that the plan applies successfully
+					// without any resources being created
+					func(s *terraform.State) error {
+						// Verify that no okta_group.conditional resources exist
+						if _, ok := s.RootModule().Resources["okta_group.conditional"]; ok {
+							return fmt.Errorf("expected no okta_group.conditional resources, but found some")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccProviderSkipValidationWithValidCredentials(t *testing.T) {
+	// This test verifies that skip_validation works correctly with valid credentials
+	// and that resources can be created when the feature flag is enabled
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderSkipValidationWithValidCredsConfig(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("okta_group.conditional.0", "name", "testAcc_skip_validation_group"),
+					resource.TestCheckResourceAttr("okta_group.conditional.0", "description", "Test group for skip_validation feature"),
+				),
+			},
+			{
+				// Test that we can disable the feature flag and the resource gets destroyed
+				Config: testAccProviderSkipValidationWithValidCredsConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					// Verify that the resource no longer exists
+					resource.TestCheckNoResourceAttr("okta_group.conditional", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProviderSkipValidationEnvironmentVariable(t *testing.T) {
+	// Test that skip_validation works via environment variable
+
+	// Set environment variables for invalid credentials
+	t.Setenv("OKTA_SKIP_VALIDATION", "true")
+	t.Setenv("OKTA_ORG_NAME", "invalid-org")
+	t.Setenv("OKTA_BASE_URL", "invalid.okta.com")
+	t.Setenv("OKTA_API_TOKEN", "invalid_token")
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use standard AccPreCheck since we're using invalid credentials
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderSkipValidationEnvironmentConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					// Verify that no resources were created when feature flag is false
+					resource.TestCheckNoResourceAttr("okta_group.conditional", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProviderSkipValidationResourceOperationFails(t *testing.T) {
+	// This test verifies that when skip_validation=true allows provider initialization,
+	// but actual resource operations still fail with invalid credentials
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use standard AccPreCheck since we're testing with invalid credentials
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccProviderSkipValidationResourceOperationFailsConfig(),
+				ExpectError: regexp.MustCompile("error|failed|unauthorized|invalid"),
+			},
+		},
+	})
+}
+
+func TestFrameworkProviderSkipValidationWithInvalidCredentials(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use standard AccPreCheck since we're testing invalid credentials
+		},
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"okta": func() (tfprotov5.ProviderServer, error) {
+				return providerserver.NewProtocol5(
+					fwprovider.NewFrameworkProvider("test", provider.Provider()),
+				)(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testFrameworkProviderSkipValidationConfig(),
+				Check: func(s *terraform.State) error {
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestFrameworkProviderSkipValidationWithEnvironmentVariable(t *testing.T) {
+	// Set environment variable
+	t.Setenv("OKTA_SKIP_VALIDATION", "true")
+	t.Setenv("OKTA_ORG_NAME", "invalid")
+	t.Setenv("OKTA_BASE_URL", "invalid.com")
+	t.Setenv("OKTA_API_TOKEN", "invalid")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// Don't use standard AccPreCheck
+		},
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"okta": func() (tfprotov5.ProviderServer, error) {
+				return providerserver.NewProtocol5(
+					fwprovider.NewFrameworkProvider("test", provider.Provider()),
+				)(), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testFrameworkProviderSkipValidationEnvConfig(),
+				Check: func(s *terraform.State) error {
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// Test configuration functions
+
+func testProviderSkipValidationConfig() string {
+	return `
+provider "okta" {
+  org_name        = "invalid"
+  base_url        = "invalid.com"
+  api_token       = "invalid"
+  skip_validation = true
+}
+
+# Empty configuration to test provider initialization
+`
+}
+
+func testProviderSkipValidationEnvConfig() string {
+	return `
+provider "okta" {
+  # Configuration comes from environment variables
+}
+
+# Empty configuration to test provider initialization
+`
+}
+
+func testProviderInvalidCredentialsWithTokenConfig() string {
+	return `
+provider "okta" {
+  org_name        = "invalid"
+  base_url        = "invalid.com"
+  api_token       = "invalid_token_that_will_fail_validation"
+  skip_validation = false
+}
+
+# Empty configuration to test provider initialization
+`
+}
+
+func testAccProviderSkipValidationConditionalResourcesConfig(enableOktaResources bool) string {
+	return fmt.Sprintf(`
+# Provider with skip_validation enabled and invalid credentials
+provider "okta" {
+  org_name        = "invalid-org"
+  base_url        = "invalid.okta.com"
+  api_token       = "invalid_token"
+  skip_validation = true
+}
+
+# Local variable to control conditional resource creation
+locals {
+  enable_okta_resources = %t
+}
+
+# Conditional resource creation - the main use case from issue #1452
+resource "okta_group" "conditional" {
+  count = local.enable_okta_resources ? 1 : 0
+  
+  name        = "testAcc_skip_validation_group"
+  description = "Test group for skip_validation feature"
+}
+
+# Output to demonstrate the conditional behavior
+output "group_created" {
+  value = local.enable_okta_resources ? "Group would be created" : "Group creation skipped"
+}
+`, enableOktaResources)
+}
+
+func testAccProviderSkipValidationWithValidCredsConfig(enableOktaResources bool) string {
+	return fmt.Sprintf(`
+# Provider with skip_validation enabled but using valid credentials from environment
+provider "okta" {
+  skip_validation = true
+}
+
+# Local variable to control conditional resource creation
+locals {
+  enable_okta_resources = %t
+}
+
+# Conditional resource creation
+resource "okta_group" "conditional" {
+  count = local.enable_okta_resources ? 1 : 0
+  
+  name        = "testAcc_skip_validation_group"
+  description = "Test group for skip_validation feature"
+}
+`, enableOktaResources)
+}
+
+func testAccProviderSkipValidationEnvironmentConfig(enableOktaResources bool) string {
+	return fmt.Sprintf(`
+# Provider configuration comes entirely from environment variables
+# OKTA_SKIP_VALIDATION=true should be set
+provider "okta" {
+  # All configuration from environment variables
+}
+
+# Local variable to control conditional resource creation
+locals {
+  enable_okta_resources = %t
+}
+
+# Conditional resource creation
+resource "okta_group" "conditional" {
+  count = local.enable_okta_resources ? 1 : 0
+  
+  name        = "testAcc_skip_validation_group"
+  description = "Test group for skip_validation feature"
+}
+`, enableOktaResources)
+}
+
+func testAccProviderSkipValidationResourceOperationFailsConfig() string {
+	return `
+# Provider with skip_validation enabled and invalid credentials
+provider "okta" {
+  org_name        = "invalid-org"
+  base_url        = "invalid.okta.com"
+  api_token       = "invalid_token"
+  skip_validation = true
+}
+
+# This resource creation should fail because credentials are invalid
+# even though provider initialization succeeded due to skip_validation
+resource "okta_group" "test_failure" {
+  name        = "testAcc_should_fail"
+  description = "This should fail due to invalid credentials"
+}
+`
+}
+
+func testFrameworkProviderSkipValidationConfig() string {
+	return `
+provider "okta" {
+  org_name        = "invalid"
+  base_url        = "invalid.com"
+  api_token       = "invalid"
+  skip_validation = true
+}
+
+# Empty configuration to test provider initialization
+`
+}
+
+func testFrameworkProviderSkipValidationEnvConfig() string {
+	return `
+provider "okta" {
+  # Configuration comes from environment variables
+}
+
+# Empty configuration to test provider initialization
+`
 }
 
 func condenseError(errorList []error) error {


### PR DESCRIPTION
Add skip_validation parameter to both SDK and Framework providers to allow optionally skipping input validation of okta provider credentials (Api Token / OAuth Credentials)

Fixes #1452