### PR TITLE
Fix: normalize nil description to empty string to prevent diff

### DIFF
--- a/okta/services/idaas/resource_okta_app_signon_policy.go
+++ b/okta/services/idaas/resource_okta_app_signon_policy.go
@@ -319,6 +319,7 @@ func (r *appSignOnPolicyResource) mapAccessPolicyToState(ctx context.Context, da
 	}
 	state.ID = types.StringPointerValue(data.AccessPolicy.Id)
 	state.Name = types.StringPointerValue(data.AccessPolicy.Name)
+	// See https://github.com/okta/terraform-provider-okta/issues/2349
 	desc := ""
 	if data.AccessPolicy.Description != nil {
 		desc = *data.AccessPolicy.Description

--- a/okta/services/idaas/resource_okta_app_signon_policy.go
+++ b/okta/services/idaas/resource_okta_app_signon_policy.go
@@ -319,7 +319,11 @@ func (r *appSignOnPolicyResource) mapAccessPolicyToState(ctx context.Context, da
 	}
 	state.ID = types.StringPointerValue(data.AccessPolicy.Id)
 	state.Name = types.StringPointerValue(data.AccessPolicy.Name)
-	state.Description = types.StringPointerValue(data.AccessPolicy.Description)
+	desc := ""
+	if data.AccessPolicy.Description != nil {
+		desc = *data.AccessPolicy.Description
+	}
+	state.Description = types.StringValue(desc)
 	state.Priority = types.Int32PointerValue(data.AccessPolicy.Priority)
 
 	defaultRule, err := r.findDefaultPolicyRuleResponse(ctx, state.ID.ValueString())

--- a/okta/services/idaas/resource_okta_app_signon_policy.go
+++ b/okta/services/idaas/resource_okta_app_signon_policy.go
@@ -319,7 +319,7 @@ func (r *appSignOnPolicyResource) mapAccessPolicyToState(ctx context.Context, da
 	}
 	state.ID = types.StringPointerValue(data.AccessPolicy.Id)
 	state.Name = types.StringPointerValue(data.AccessPolicy.Name)
-	// See https://github.com/okta/terraform-provider-okta/issues/2349
+	// See issue https://github.com/okta/terraform-provider-okta/issues/2349
 	desc := ""
 	if data.AccessPolicy.Description != nil {
 		desc = *data.AccessPolicy.Description


### PR DESCRIPTION
The description section of appSignOnPolicyResourceModel can receive null value from okta API, but we set description as required field which means customer has to pass either empty string or string with values.

When customer passes empty string like this
```
resource "okta_app_signon_policy" "app_signon_policyjamf-connect-login-oidc" {
  description = ""
  name        = "Jamf Connect Login OIDC - Managed"
}
```
It will trigger comparison diff as terraform expect "" but detects null, that's why we saw 
```
│ When applying changes to
│ okta_app_signon_policy.app_signon_policy-jamf-connect-login-oidc, provider
│ "provider[\"registry.terraform.io/okta/okta\"]" produced an unexpected new
│ value: .description: was cty.StringVal(""), but now null.
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```

ref https://github.com/okta/terraform-provider-okta/issues/2349