### PR TITLE
fix: remove verifying domain from `resource_okta_domain`

### DIFF
--- a/okta/services/idaas/resource_okta_domain.go
+++ b/okta/services/idaas/resource_okta_domain.go
@@ -115,20 +115,12 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 		d.SetId("")
 		return nil
 	}
-	vd, err := validateDomain(ctx, d, meta, string(domain.GetValidationStatus()))
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	d.Set("name", domain.GetDomain())
 	d.Set("certificate_source_type", domain.GetCertificateSourceType())
 	d.Set("brand_id", domain.GetBrandId())
+	d.Set("validation_status", domain.GetValidationStatus())
 
-	if vd != nil {
-		_ = d.Set("validation_status", vd.GetValidationStatus())
-	} else {
-		_ = d.Set("validation_status", domain.GetValidationStatus())
-	}
 	arr := make([]map[string]interface{}, len(domain.DnsRecords))
 	for i := range domain.DnsRecords {
 		arr[i] = map[string]interface{}{

--- a/okta/services/idaas/resource_okta_domain_test.go
+++ b/okta/services/idaas/resource_okta_domain_test.go
@@ -30,7 +30,7 @@ func TestAccResourceOktaDomain_crud(t *testing.T) {
 					ensureResourceExists(resourceName, domainExists),
 					resource.TestCheckResourceAttr(resourceName, "name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "certificate_source_type", "MANUAL"),
-					resource.TestCheckResourceAttr(resourceName, "validation_status", "FAILED_TO_VERIFY"),
+					resource.TestCheckResourceAttr(resourceName, "validation_status", "NOT_STARTED"),
 					resource.TestCheckResourceAttr(resourceName, "dns_records.#", "2"),
 				),
 			},


### PR DESCRIPTION
The resource `okta_domain` creates a domain and verifies the domain. We already have another resource `okta_domain_verification` to verify the domain.

This PR removes the `api/v1/domains/:id/verify` API from the `resource_okta_domain` and follows the same approach as `okta_email_domain`.