### PR TITLE
Fixes #2396: Updates implementation for func StrMaxLength

### DIFF
--- a/examples/resources/okta_group_rule/basic_group_rule_name_length_fail.tf
+++ b/examples/resources/okta_group_rule/basic_group_rule_name_length_fail.tf
@@ -1,0 +1,11 @@
+resource "okta_group" "test" {
+  name = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもらりるれろ"
+}
+
+resource "okta_group_rule" "test" {
+  name              = "ABCDEFGHIJKLMNOPQRSTUVWXYZあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもらりるれろ"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.firstName,\"andy\")"
+}

--- a/examples/resources/okta_group_rule/basic_group_rule_name_length_verify.tf
+++ b/examples/resources/okta_group_rule/basic_group_rule_name_length_verify.tf
@@ -1,0 +1,11 @@
+resource "okta_group" "test" {
+  name = "[xx]ZZZ_ああああ_yyyyyyあいうえおかきくけ1ww1"
+}
+
+resource "okta_group_rule" "test" {
+  name              = "[xx]ZZZ_ああああ_yyyyyyあいうw1w1えおかきくけ1"
+  status            = "ACTIVE"
+  group_assignments = [okta_group.test.id]
+  expression_type   = "urn:okta:expression:1.0"
+  expression_value  = "String.startsWith(user.firstName,\"andy\")"
+}

--- a/okta/services/idaas/resource_okta_group_rule_test.go
+++ b/okta/services/idaas/resource_okta_group_rule_test.go
@@ -197,3 +197,28 @@ func TestAccResourceOktaGroupRule_statusIsInvalidDiffFn(t *testing.T) {
 		})
 	}
 }
+
+func TestAccResourceOktaGroupRule_nameLengthVerification_Issue2396(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSGroupRule)
+	mgr := newFixtureManager("resources", "okta_group_rule", t.Name())
+	config := mgr.GetFixtures("basic_group_rule_name_length_verify.tf", t)
+	failConfig := mgr.GetFixtures("basic_group_rule_name_length_fail.tf", t)
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSGroupRule, doesGroupRuleExist),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "[xx]ZZZ_ああああ_yyyyyyあいうw1w1えおかきくけ1"),
+				),
+			},
+			{
+				Config:      failConfig,
+				ExpectError: regexp.MustCompile(`\[\{\{\} name\}\] cannot be longer than 50 runes`),
+			},
+		},
+	})
+}

--- a/okta/utils/utils.go
+++ b/okta/utils/utils.go
@@ -715,14 +715,16 @@ func LinksValue(links interface{}, keys ...string) string {
 	return LinksValue(l[keys[0]], keys[1:]...)
 }
 
+// StrMaxLength updated implementation to count runes instead of bytes (https://github.com/okta/terraform-provider-okta/issues/2396)
 func StrMaxLength(max int) schema.SchemaValidateDiagFunc {
 	return func(i interface{}, k cty.Path) diag.Diagnostics {
 		v, ok := i.(string)
 		if !ok {
 			return diag.Errorf("expected type of %s to be string", k)
 		}
-		if len(v) > max {
-			return diag.Errorf("%s cannot be longer than %d characters", k, max)
+		runes := []rune(v)
+		if len(runes) > max {
+			return diag.Errorf("%s cannot be longer than %d runes", k, max)
 		}
 		return nil
 	}

--- a/okta/utils/utils.go
+++ b/okta/utils/utils.go
@@ -715,13 +715,15 @@ func LinksValue(links interface{}, keys ...string) string {
 	return LinksValue(l[keys[0]], keys[1:]...)
 }
 
-// StrMaxLength updated implementation to count runes instead of bytes (https://github.com/okta/terraform-provider-okta/issues/2396)
+// StrMaxLength validates that the string is not longer than the specified maximum length.
 func StrMaxLength(max int) schema.SchemaValidateDiagFunc {
 	return func(i interface{}, k cty.Path) diag.Diagnostics {
 		v, ok := i.(string)
 		if !ok {
 			return diag.Errorf("expected type of %s to be string", k)
 		}
+
+		// https://github.com/okta/terraform-provider-okta/issues/2396
 		runes := []rune(v)
 		if len(runes) > max {
 			return diag.Errorf("%s cannot be longer than %d runes", k, max)


### PR DESCRIPTION
Fixes #2396 
Earlier the function StrMaxLength was counting the number of bytes for getting the length of the string which led to issues for languages like Japanese where each character is of 3 bytes hence the max length validation was failing. With this implementation, we are calculating the length of the string by counting the number of characters in the string. 