### PR TITLE
Release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.2.0 (July 16, 2025)
+
+### BUG FIXES
+
+* Fix regression in `data_source_okta_groups` for not handling custom_profile_attributes[#2328](https://github.com/okta/terraform-provider-okta/pull/2328) by [exitcode0](https://github.com/exitcode0).
+* Remove verifying domain from `resource_okta_domain`[#2397](https://github.com/okta/terraform-provider-okta/pull/2397) by [pranav-okta](https://github.com/pranav-okta).
+* Fix implementation of function StrMaxLength to counts bytes instead of characters[#2398](https://github.com/okta/terraform-provider-okta/pull/2398) by [aditya-okta](https://github.com/aditya-okta).
+* Support for okta features[#2232](https://github.com/okta/terraform-provider-okta/pull/2322)
+
+### IMPROVEMENTS
+
+* Stop adding authentication policy for `SERVICE` apps for resource `okta_app_oauth`[#2403](https://github.com/okta/terraform-provider-okta/pull/2403) by [aditya-okta](https://github.com/aditya-okta).
+* Bump github.com/hashicorp/terraform-plugin-docs from 0.21.0 to 0.22.0 [#2388](https://github.com/okta/terraform-provider-okta/pull/2388)
+
 ## 5.1.0 (July 3, 2025)
 
 ### BUG FIXES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### IMPROVEMENTS
 
 * Stop adding authentication policy for `SERVICE` apps for resource `okta_app_oauth`[#2403](https://github.com/okta/terraform-provider-okta/pull/2403) by [aditya-okta](https://github.com/aditya-okta).
-* Bump github.com/hashicorp/terraform-plugin-docs from 0.21.0 to 0.22.0 [#2388](https://github.com/okta/terraform-provider-okta/pull/2388)
+* Bump github.com/hashicorp/terraform-plugin-docs from 0.21.0 to 0.22.0 [#2388](https://github.com/okta/terraform-provider-okta/pull/2388).
 
 ## 5.1.0 (July 3, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,10 @@
 * Fix regression in `data_source_okta_groups` for not handling custom_profile_attributes[#2328](https://github.com/okta/terraform-provider-okta/pull/2328) by [exitcode0](https://github.com/exitcode0).
 * Remove verifying domain from `resource_okta_domain`[#2397](https://github.com/okta/terraform-provider-okta/pull/2397) by [pranav-okta](https://github.com/pranav-okta).
 * Fix implementation of function StrMaxLength to counts bytes instead of characters[#2398](https://github.com/okta/terraform-provider-okta/pull/2398) by [aditya-okta](https://github.com/aditya-okta).
-* Support for okta features[#2232](https://github.com/okta/terraform-provider-okta/pull/2322)
 
 ### IMPROVEMENTS
 
 * Stop adding authentication policy for `SERVICE` apps for resource `okta_app_oauth`[#2403](https://github.com/okta/terraform-provider-okta/pull/2403) by [aditya-okta](https://github.com/aditya-okta).
-* Bump github.com/hashicorp/terraform-plugin-docs from 0.21.0 to 0.22.0 [#2388](https://github.com/okta/terraform-provider-okta/pull/2388).
 
 ## 5.1.0 (July 3, 2025)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
   }
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "5.1.0"
+	OktaTerraformProviderVersion   = "5.2.0"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
   }
 }


### PR DESCRIPTION
## 5.2.0 (July 16, 2025)

### BUG FIXES

* Fix regression in `data_source_okta_groups` for not handling custom_profile_attributes[#2328](https://github.com/okta/terraform-provider-okta/pull/2328) by [exitcode0](https://github.com/exitcode0).
* Remove verifying domain from `resource_okta_domain`[#2397](https://github.com/okta/terraform-provider-okta/pull/2397) by [pranav-okta](https://github.com/pranav-okta).
* Fix implementation of function StrMaxLength to counts bytes instead of characters[#2398](https://github.com/okta/terraform-provider-okta/pull/2398) by [aditya-okta](https://github.com/aditya-okta).

### IMPROVEMENTS

* Stop adding authentication policy for `SERVICE` apps for resource `okta_app_oauth`[#2403](https://github.com/okta/terraform-provider-okta/pull/2403) by [aditya-okta](https://github.com/aditya-okta).
* Bump github.com/hashicorp/terraform-plugin-docs from 0.21.0 to 0.22.0 [#2388](https://github.com/okta/terraform-provider-okta/pull/2388).