### PR TITLE
release: prep 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 5.3.0 (August 12, 2025)
+
+### BUG FIXES
+
+* 400 Bad Request - The DPoP proof JWT has already been used [#2421](https://github.com/okta/terraform-provider-okta/pull/2421) by [pranav-okta](https://github.com/pranav-okta)
+* Add missing fields to state to avoid false diffs for `okta_inline_hook` [#2420](https://github.com/okta/terraform-provider-okta/pull/2420) by [dhiwakar-okta](https://github.com/dhiwakar-okta)
+
+### IMPROVEMENTS
+
+* Realm assignment support [#2293](https://github.com/okta/terraform-provider-okta/pull/2293) by [tim-koehler](https://github.com/tim-koehler)
+* Add support for `enrollmentSecurityLevel` and `userVerificationMethods` to `okta_authenticator` [#2409](https://github.com/okta/terraform-provider-okta/pull/2409) by [dhiwakar-okta](https://github.com/dhiwakar-okta)
+
 ## 5.2.0 (July 16, 2025)
 
 ### BUG FIXES

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
   }
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "5.2.0"
+	OktaTerraformProviderVersion   = "5.3.0"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
   }
 }


### PR DESCRIPTION
## 5.3.0 (August 12, 2025)

### BUG FIXES

* 400 Bad Request - The DPoP proof JWT has already been used [#2421](https://github.com/okta/terraform-provider-okta/pull/2421) by [pranav-okta](https://github.com/pranav-okta)
* Add missing fields to state to avoid false diffs for `okta_inline_hook` [#2420](https://github.com/okta/terraform-provider-okta/pull/2420) by [dhiwakar-okta](https://github.com/dhiwakar-okta)

### IMPROVEMENTS

* Realm assignment support [#2293](https://github.com/okta/terraform-provider-okta/pull/2293) by [tim-koehler](https://github.com/tim-koehler)
* Add support for `enrollmentSecurityLevel` and `userVerificationMethods` to `okta_authenticator` [#2409](https://github.com/okta/terraform-provider-okta/pull/2409) by [dhiwakar-okta](https://github.com/dhiwakar-okta)
