### PR TITLE
chore: add warning msg to `okta_rate_limiting`

### DIFF
--- a/docs/resources/rate_limiting.md
+++ b/docs/resources/rate_limiting.md
@@ -3,16 +3,14 @@ page_title: "Resource: okta_rate_limiting"
 description: |-
   Manages rate limiting.
   This resource allows you to configure the client-based rate limit and rate limiting communications settings.
-  ~> WARNING: This resource is available only when using a SSWS API token in the provider config, it is incompatible with OAuth 2.0 authentication.
-  ~> WARNING: This resource makes use of an internal/private Okta API endpoint that could change without notice rendering this resource inoperable.
+  ~> WARNING: This resource is deprecated and will be removed in a future release. A new resource to manage rate limiting settings will be implemented in the future.
 ---
 
 # Resource: okta_rate_limiting
 
 Manages rate limiting.
 This resource allows you to configure the client-based rate limit and rate limiting communications settings.
-~> **WARNING:** This resource is available only when using a SSWS API token in the provider config, it is incompatible with OAuth 2.0 authentication.
-~> **WARNING:** This resource makes use of an internal/private Okta API endpoint that could change without notice rendering this resource inoperable.
+~> **WARNING:** This resource is deprecated and will be removed in a future release. A new resource to manage rate limiting settings will be implemented in the future.
 
 ## Example Usage
 

--- a/okta/services/idaas/resource_okta_rate_limiting.go
+++ b/okta/services/idaas/resource_okta_rate_limiting.go
@@ -40,6 +40,7 @@ This resource allows you to configure the client-based rate limit and rate limit
 				Default:     true,
 			},
 		},
+		DeprecationMessage: "This resource is deprecated and will be removed in a future release. A new resource to manage rate limiting settings will be implemented in the future.",
 	}
 }
 


### PR DESCRIPTION
This PR adds a warning message to the resource `okta_rate_limiting` since the internal API returns an error.

Please see: [OKTA-1001100](https://oktainc.atlassian.net/browse/OKTA-1001100)