### PR TITLE
updates resource and data source name in description of okta_email_smtp_server

### DIFF
--- a/docs/data-sources/email_smtp_server.md
+++ b/docs/data-sources/email_smtp_server.md
@@ -4,14 +4,14 @@ description: |-
   Get SMTP email server configuration.
 ---
 
-# Data Source: okta_email_smtp
+# Data Source: okta_email_smtp_server
 
 Get existing SMTP email server configuration.
 
 ## Example Usage
 
 ```terraform
-resource "okta_email_smtp" "smtp_server" {
+resource "okta_email_smtp_server" "smtp_server" {
   alias    = "CustomServer"
   host     = "192.168.160.1"
   port     = 8086
@@ -19,7 +19,7 @@ resource "okta_email_smtp" "smtp_server" {
   password = "abcd"
 }
 
-data "okta_email_smtp" "server_config" {
+data "okta_email_smtp_server" "server_config" {
   id = "id-of-your-smtp-server"
 }
 ```

--- a/docs/resources/email_smtp_server.md
+++ b/docs/resources/email_smtp_server.md
@@ -1,17 +1,17 @@
 ---
-page_title: "Resource: okta_email_domain_verification"
+page_title: "Resource: okta_email_smtp_server"
 description: |-
   Verifies the email domain. The resource won't be created if the email domain could not be verified.
 ---
 
-# Resource: okta_email_smtp
+# Resource: okta_email_smtp_server
 
 Create and configure SMTP email server configuration for your org.
 
 ## Example Usage
 
 ```terraform
-resource "okta_email_smtp" "example" {
+resource "okta_email_smtp_server" "example" {
   alias    = "CustomServer"
   host     = "192.168.160.1"
   port     = 8086


### PR DESCRIPTION
Fixes #2446 .
The data source and the resource name for **okta_email_smtp_server** is documented incorrectly as of now. This PR fixes it.