### PR TITLE
 Release v5.4.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 5.4.0 (September 3, 2025)
+
+### BUG FIXES
+
+* Fix documentation error for `risk_level` for resource `okta_policy_rule_signon` [#2436](https://github.com/okta/terraform-provider-okta/pull/2436) by [dhiwakar-okta](https://github.com/dhiwakar-okta).
+* Fix documentation for `resource_okta_email_smtp_server` [#2456](https://github.com/okta/terraform-provider-okta/pull/2456) by [aditya-okta](https://github.com/aditya-okta).
+* Added handling for missing reauthenticateIn field for resource `okta_app_signon_policy_rule` [#2443](https://github.com/okta/terraform-provider-okta/pull/2443) by [dhiwakar-okta](https://github.com/dhiwakar-okta).
+
+### IMPROVEMENTS
+
+* Replace usage of the sdk API with okta-sdk-golang API for `resource_okta_behavior` and `data_source_behavior` [#2429](https://github.com/okta/terraform-provider-okta/pull/2429) by [dhiwakar-okta](https://github.com/dhiwakar-okta). 
+* Add documentation for `resource_okta_realm` , `resource_okta_realm_assignment`, `data_source_okta_realm_assignment`, and `data_source_okta_realm_assignment` [#2440](https://github.com/okta/terraform-provider-okta/pull/2440) by [tim-koehler](https://github.com/tim-koehler)
+* Add deprecation warning msg to `resource_okta_rate_limiting` [#2455](https://github.com/okta/terraform-provider-okta/pull/2455)  by [pranav-okta](https://github.com/pranav-okta).
+* Make HTTP 423 retryable for resource `okta_group_rule` [#2258](https://github.com/okta/terraform-provider-okta/pull/2258) by [exitcode0](https://github.com/exitcode0).
+* Replaced delete binding with removing binding for resource `okta_admin_role_custom_assignments` [#2458](https://github.com/okta/terraform-provider-okta/pull/2458) by [aditya-okta](https://github.com/aditya-okta).
+
 ## 5.3.0 (August 12, 2025)
 
 ### BUG FIXES

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.3.0"
+      version = "~> 5.4.0"
     }
   }
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "5.3.0"
+	OktaTerraformProviderVersion   = "5.4.0"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 5.3.0"
+      version = "~> 5.4.0"
     }
   }
 }


### PR DESCRIPTION
## 5.4.0 (September 3, 2025)

### BUG FIXES

* Fix documentation error for `risk_level` for resource `okta_policy_rule_signon` [#2436](https://github.com/okta/terraform-provider-okta/pull/2436) by [dhiwakar-okta](https://github.com/dhiwakar-okta).
* Fix documentation for `resource_okta_email_smtp_server` [#2456](https://github.com/okta/terraform-provider-okta/pull/2456) by [aditya-okta](https://github.com/aditya-okta).
* Added handling for missing reauthenticateIn field for resource `okta_app_signon_policy_rule` [#2443](https://github.com/okta/terraform-provider-okta/pull/2443) by [dhiwakar-okta](https://github.com/dhiwakar-okta).

### IMPROVEMENTS

* Replace usage of the sdk API with okta-sdk-golang API for `resource_okta_behavior` and `data_source_behavior` [#2429](https://github.com/okta/terraform-provider-okta/pull/2429) by [dhiwakar-okta](https://github.com/dhiwakar-okta). 
* Add documentation for `resource_okta_realm` , `resource_okta_realm_assignment`, `data_source_okta_realm_assignment`, and `data_source_okta_realm_assignment` [#2440](https://github.com/okta/terraform-provider-okta/pull/2440) by [tim-koehler](https://github.com/tim-koehler)
* Add deprecation warning msg to `resource_okta_rate_limiting` [#2455](https://github.com/okta/terraform-provider-okta/pull/2455)  by [pranav-okta](https://github.com/pranav-okta).
* Make HTTP 423 retryable for resource `okta_group_rule` [#2258](https://github.com/okta/terraform-provider-okta/pull/2258) by [exitcode0](https://github.com/exitcode0).
* Replaced delete binding with removing binding for resource `okta_admin_role_custom_assignments` [#2458](https://github.com/okta/terraform-provider-okta/pull/2458) by [aditya-okta](https://github.com/aditya-okta).
