### PR TITLE
Fix flaky diff for userVerificationMethods in authenticator

### DIFF
--- a/okta/services/idaas/resource_okta_authenticator.go
+++ b/okta/services/idaas/resource_okta_authenticator.go
@@ -435,6 +435,10 @@ func establishAuthenticator(authenticator *sdk.Authenticator, d *schema.Resource
 }
 
 func noChangeInObjectFromUnmarshaledJSON(k, oldJSON, newJSON string, d *schema.ResourceData) bool {
+	if newJSON == "" {
+		return true
+	}
+
 	var oldObj sdk.AuthenticatorSettings
 	var newObj sdk.AuthenticatorSettings
 	if err := json.Unmarshal([]byte(oldJSON), &oldObj); err != nil {

--- a/okta/services/idaas/resource_okta_authenticator.go
+++ b/okta/services/idaas/resource_okta_authenticator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -62,7 +64,7 @@ deactivated if it's not in use by any other policy.`,
 				Description:      "Settings for the authenticator. The settings JSON contains values based on Authenticator key. It is not used for authenticators with type `security_key`",
 				ValidateDiagFunc: stringIsJSON,
 				StateFunc:        utils.NormalizeDataJSON,
-				DiffSuppressFunc: utils.NoChangeInObjectFromUnmarshaledJSON,
+				DiffSuppressFunc: noChangeInObjectFromUnmarshaledJSON,
 			},
 			"provider_json": {
 				Type:             schema.TypeString,
@@ -430,4 +432,20 @@ func establishAuthenticator(authenticator *sdk.Authenticator, d *schema.Resource
 			_ = d.Set("provider_integration_key", authenticator.Provider.Configuration.IntegrationKey)
 		}
 	}
+}
+
+func noChangeInObjectFromUnmarshaledJSON(k, oldJSON, newJSON string, d *schema.ResourceData) bool {
+	var oldObj sdk.AuthenticatorSettings
+	var newObj sdk.AuthenticatorSettings
+	if err := json.Unmarshal([]byte(oldJSON), &oldObj); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(newJSON), &newObj); err != nil {
+		return false
+	}
+
+	slices.Sort(oldObj.UserVerificationMethods)
+	slices.Sort(newObj.UserVerificationMethods)
+
+	return reflect.DeepEqual(oldObj, newObj)
 }

--- a/okta/utils/utils.go
+++ b/okta/utils/utils.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -647,6 +648,79 @@ func NoChangeInObjectFromUnmarshaledJSON(k, oldJSON, newJSON string, d *schema.R
 	}
 
 	return reflect.DeepEqual(oldObj, newObj)
+}
+
+// NoChangeInObjectWithSortedSlicesFromUnmarshaledJSON Intended for use by a DiffSuppressFunc,
+// returns true if old and new JSONs are equivalent object representations no matter the order of any slices...
+// It is true, there is no change!  Edge chase if newJSON is blank, will also
+// return true which cover the new resource case.
+func NoChangeInObjectWithSortedSlicesFromUnmarshaledJSON(k, oldJSON, newJSON string, d *schema.ResourceData) bool {
+	if newJSON == "" {
+		return true
+	}
+
+	var oldObj any
+	var newObj any
+
+	if err := json.Unmarshal([]byte(oldJSON), &oldObj); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(newJSON), &newObj); err != nil {
+		return false
+	}
+
+	oldObj = sortSlices(oldObj)
+	newObj = sortSlices(newObj)
+
+	return reflect.DeepEqual(oldObj, newObj)
+}
+
+func sortSlices(obj any) any {
+	switch v := obj.(type) {
+	case []any:
+		for i := range v {
+			v[i] = sortSlices(v[i])
+		}
+		sort.SliceStable(v, func(i, j int) bool {
+			return less(v[i], v[j])
+		})
+		return v
+	case map[string]any:
+		for key, val := range v {
+			v[key] = sortSlices(val)
+		}
+		return v
+	default:
+		return v
+	}
+}
+
+func less(a, b any) bool {
+	// Unmarshaled JSON into any can only have string, float64, bool, nil, []any, map[string]any
+	switch aTyped := a.(type) {
+	case string:
+		if bTyped, ok := b.(string); ok {
+			return aTyped < bTyped
+		}
+	case float64:
+		if bTyped, ok := b.(float64); ok {
+			return aTyped < bTyped
+		}
+	case bool:
+		if bTyped, ok := b.(bool); ok {
+			return !aTyped && bTyped
+		}
+	}
+
+	if a == nil {
+		return true
+	}
+	if b == nil {
+		return false
+	}
+
+	// Fallback: use type name as last resort to ensure consistency
+	return reflect.TypeOf(a).String() < reflect.TypeOf(b).String()
 }
 
 func Intersection(old, new []string) (intersection, exclusiveOld, exclusiveNew []string) {


### PR DESCRIPTION
Updates DiffSuppressFunc to use local noChangeInObjectFromUnmarshaledJSON function which ignores slice order through sorting

This fixes #2463 