### PR TITLE
fix: 'make qc' failures in f0c77cd / #2323

### DIFF
--- a/okta/services/idaas/resource_okta_app_group_assignments.go
+++ b/okta/services/idaas/resource_okta_app_group_assignments.go
@@ -409,7 +409,7 @@ func deleteGroupAssignments(
 ) error {
 	for i := range assignments {
 		resp, err := delete(ctx, appID, assignments[i].Id)
-		if err := suppressErrorOn404(resp, err); err != nil {
+		if err := utils.SuppressErrorOn404(resp, err); err != nil {
 			return fmt.Errorf("could not delete assignment for group %s, to application %s: %w", assignments[i].Id, appID, err)
 		}
 	}


### PR DESCRIPTION
It ran the tests on (f0c77cd / [#2323](https://github.com/okta/terraform-provider-okta/issues/2323)) locally when I created the branch/pr

I don't think I did this again when I rebased the branch after the release of `V5`
this meant that the diff was referencing the old location for 'SuppressErrorOn404' which has since been moved to `utils`