### PR TITLE
feat: add authentication_policy field to app data sources

### DIFF
--- a/okta/services/idaas/data_source_okta_app.go
+++ b/okta/services/idaas/data_source_okta_app.go
@@ -74,6 +74,11 @@ func dataSourceApp() *schema.Resource {
 				Description: "Users associated with the application",
 				Deprecated:  "The `users` field is now deprecated for the data source `okta_app`, please replace all uses of this with: `okta_app_user_assignments`",
 			},
+			"authentication_policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the app's authentication policy",
+			},
 		}),
 		Description: "Get an application of any kind from Okta.",
 	}
@@ -125,5 +130,6 @@ func dataSourceAppRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	_ = d.Set("status", app.Status)
 	p, _ := json.Marshal(app.Links)
 	_ = d.Set("links", string(p))
+	setAuthenticationPolicy(ctx, meta, d, app.Links)
 	return nil
 }

--- a/okta/services/idaas/data_source_okta_app_oauth.go
+++ b/okta/services/idaas/data_source_okta_app_oauth.go
@@ -154,6 +154,11 @@ func dataSourceAppOauth() *schema.Resource {
 				Computed:    true,
 				Description: "Indicates if the client is allowed to use wildcard matching of redirect_uris. Some valid values include: \"SUBDOMAIN\", \"DISABLED\".",
 			},
+			"authentication_policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the app's authentication policy",
+			},
 		}),
 		Description: "Get a OIDC application from Okta.",
 	}
@@ -249,6 +254,7 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	p, _ := json.Marshal(app.Links)
 	_ = d.Set("links", string(p))
+	setAuthenticationPolicy(ctx, meta, d, app.Links)
 	return nil
 }
 

--- a/okta/services/idaas/data_source_okta_app_oauth_test.go
+++ b/okta/services/idaas/data_source_okta_app_oauth_test.go
@@ -35,10 +35,52 @@ func TestAccDataSourceOktaAppOauth_read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.okta_app_oauth.test_label", "label", acctest.BuildResourceName(mgr.Seed)),
 					resource.TestCheckResourceAttr("data.okta_app_oauth.test", "status", idaas.StatusActive),
 					resource.TestCheckResourceAttr("data.okta_app_oauth.test_label", "status", idaas.StatusActive),
+					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "authentication_policy"),
+					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test_label", "authentication_policy"),
 				),
 			},
 		},
 	})
+}
+
+func TestAccDataSourceOktaAppOauth_authentication_policy(t *testing.T) {
+	mgr := newFixtureManager("data-sources", resources.OktaIDaaSAppOAuth, t.Name())
+	config := testOauthAuthenticationPolicyConfig(mgr.Seed)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.okta_app_oauth.test", "label", acctest.BuildResourceName(mgr.Seed)),
+					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "authentication_policy"),
+					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "client_id"),
+					resource.TestCheckResourceAttrSet("data.okta_app_oauth.test", "type"),
+				),
+			},
+		},
+	})
+}
+
+func testOauthAuthenticationPolicyConfig(i int) string {
+	return fmt.Sprintf(`
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_%d"
+  type           = "web"
+  grant_types    = ["authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code"]
+  consent_method = "TRUSTED"
+}
+
+data "okta_app_oauth" "test" {
+  label = "testAcc_%d"
+  depends_on = [okta_app_oauth.test]
+}
+`, i, i)
 }
 
 func buildTestAppOauth(d int) string {

--- a/okta/services/idaas/data_source_okta_app_test.go
+++ b/okta/services/idaas/data_source_okta_app_test.go
@@ -33,6 +33,9 @@ func TestAccDataSourceOktaApp_read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.okta_app.test", "status", idaas.StatusActive),
 					resource.TestCheckResourceAttr("data.okta_app.test2", "status", idaas.StatusActive),
 					resource.TestCheckResourceAttr("data.okta_app.test3", "status", idaas.StatusActive),
+					resource.TestCheckResourceAttrSet("data.okta_app.test", "authentication_policy"),
+					resource.TestCheckResourceAttrSet("data.okta_app.test2", "authentication_policy"),
+					resource.TestCheckResourceAttrSet("data.okta_app.test3", "authentication_policy"),
 				),
 			},
 		},
@@ -69,6 +72,45 @@ func TestAccDataSourceOktaApp_label_read(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccDataSourceOktaApp_authentication_policy(t *testing.T) {
+	mgr := newFixtureManager("data-sources", resources.OktaIDaaSApp, t.Name())
+	config := testAuthenticationPolicyConfig(mgr.Seed)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.okta_app.test", "label", acctest.BuildResourceName(mgr.Seed)),
+					resource.TestCheckResourceAttrSet("data.okta_app.test", "authentication_policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAuthenticationPolicyConfig(i int) string {
+	return fmt.Sprintf(`
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_%d"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["http://d.com/"]
+  response_types = ["code", "token", "id_token"]
+  issuer_mode    = "ORG_URL"
+  consent_method = "TRUSTED"
+}
+
+data "okta_app" "test" {
+  label = "testAcc_%d"
+  depends_on = [okta_app_oauth.test]
+}
+`, i, i)
 }
 
 func testLabelConfig(i int) string {


### PR DESCRIPTION
## Summary
Adds `authentication_policy` field to `okta_app` and `okta_app_oauth` data sources to enable discovery of current app authentication policy associations.

## Problem
Currently, the app data sources only expose basic metadata (id, label, name, status) but cannot retrieve the `authentication_policy` field that exists in app resources. This limitation prevents users from building automated migration tooling for authentication policy changes.

## Solution
This change leverages the existing `setAuthenticationPolicy()` infrastructure used by app resources to extract the policy ID from the app's Links field returned by the Okta API.

## Changes
- Added `authentication_policy` schema field to both data sources
- Updated read functions to call `setAuthenticationPolicy()`
- No breaking changes - field is computed/optional

## Testing
- [x] Code compiles successfully with `go build`

The changes are minimal but enable automated authentication policy migration workflows. The implementation reuses existing infrastructure and should be ready for community review.

🤖 Generated with [Claude Code](https://claude.ai/code)