### PR TITLE
fix: add source to `data_source_okta_groups`

### DIFF
--- a/okta/services/idaas/data_source_okta_groups.go
+++ b/okta/services/idaas/data_source_okta_groups.go
@@ -150,6 +150,14 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta inte
 		arr[i]["type"] = okta_groups[i].Type
 		arr[i]["description"] = okta_groups[i].Profile.Description
 
+		additionalProperties := okta_groups[i].AdditionalProperties
+		src, ok := additionalProperties["source"].(map[string]any)
+		if ok && src["id"] != nil {
+			arr[i]["source"] = src["id"].(string)
+		}
+
+		delete(additionalProperties, "source")
+
 		// Use Profile.AdditionalProperties for custom profile attributes
 		customProfileMap := okta_groups[i].Profile.AdditionalProperties
 		customProfile, err := json.Marshal(customProfileMap)


### PR DESCRIPTION
Fixes: #2393 

This is due to the removal of `additionalProperties` in [this](https://github.com/okta/terraform-provider-okta/pull/2328/files#diff-2c0890d421f05dd3df2f2fb55b6440954e41f9bbccec8fabd5900a63cc85086dL153) PR. Since the `source` is present in `additionalProperties`, the source is set to an empty string.