### PR TITLE
feat(network_zone): set max items for `dynamic_locations`

### DIFF
--- a/okta/services/idaas/resource_okta_network_zone.go
+++ b/okta/services/idaas/resource_okta_network_zone.go
@@ -31,6 +31,7 @@ func resourceNetworkZone() *schema.Resource {
 				Optional:    true,
 				Description: "Array of locations ISO-3166-1(2) included. Format code: countryCode OR countryCode-regionCode. Use with type `DYNAMIC` or `DYNAMIC_V2`",
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				MaxItems:    75,
 			},
 			"dynamic_locations_exclude": {
 				Type:        schema.TypeSet,


### PR DESCRIPTION
# Why

- When running a `terraform apply` with more than 75 `dynamic_locations`, the response is a vague:

```console
│ Error: failed to update network zone: 400 Bad Request
│
│   with okta_network_zone.this["0"],
│   on main.tf line 6, in resource "okta_network_zone" "this":
│    6: resource "okta_network_zone" "this" {
│
```

- To identify the underlying issue, `TF_LOG=DEBUG` must be set which reveals:

```console
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0: {
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:  "errorCode": "E0000001",
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:  "errorSummary": "Api validation failed: locations",
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:  "errorLink": "E0000001",
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:  "errorCauses": [
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:   {
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:    "errorSummary": "locations: No more than 75 locations may be included in a Location Zone."
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:   }
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0:  ]
2025-09-29T17:42:23.921Z [DEBUG] provider.terraform-provider-okta_v6.2.0: }
```

## What

- This introduces a minor update to the `resource_okta_network_zone.go` file. The change sets a maximum limit for the number of items allowed in the `dynamic_locations` field, improving data validation for network zone resources. 

* Added `MaxItems: 75` to the `dynamic_locations` schema field to restrict the number of allowed entries.