### PR TITLE
Add okta sdk golang v6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/okta/okta-governance-sdk-golang v1.0.1
 	github.com/okta/okta-sdk-golang/v4 v4.1.2
 	github.com/okta/okta-sdk-golang/v5 v5.0.6
+	github.com/okta/okta-sdk-golang/v6 v6.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/dnaeon/go-vcr.v4 v4.0.5
@@ -89,7 +90,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/okta/okta-sdk-golang/v6 v6.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/crewjam/saml v0.5.1
-	github.com/go-jose/go-jose/v4 v4.1.1
+	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.5.0
@@ -89,6 +89,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/okta/okta-sdk-golang/v6 v6.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFS
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.1 h1:JYhSgy4mXXzAdF3nUx3ygx347LRXJRrpgyU3adRmkAI=
 github.com/go-jose/go-jose/v4 v4.1.1/go.mod h1:BdsZGqgdO3b6tTc6LSE56wcDbMMLuPsw5d4ZD5f94kA=
+github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -218,6 +219,8 @@ github.com/okta/okta-sdk-golang/v4 v4.1.2 h1:gSycAYWGrvYeXBW8HakMZnNu/ptMuTvTQ/z
 github.com/okta/okta-sdk-golang/v4 v4.1.2/go.mod h1:01oiHDXvZQHlZo1Uw084VDYwXIqJe19z34b53PBZpUY=
 github.com/okta/okta-sdk-golang/v5 v5.0.6 h1:p7ptDMB1KxQ/7xSh+6FhMSybwl+ubTV4f1oL4N0Bu6U=
 github.com/okta/okta-sdk-golang/v5 v5.0.6/go.mod h1:T/vmECtJX33YPZSVD+sorebd8LLhe38Bi/VrFTjgVX0=
+github.com/okta/okta-sdk-golang/v6 v6.0.0 h1:6gS4r+Y1lYa4rcFYGLY+JaS7MMAUDaLTSzE34CY4PS4=
+github.com/okta/okta-sdk-golang/v6 v6.0.0/go.mod h1:4SyyJmsMn2Sd6W+F87VqXvB/wO90W7fpEDUCNR+tvFs=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,7 @@ github.com/go-git/go-git/v5 v5.14.0 h1:/MD3lCrGjCen5WfEAzKg00MJJffKhC8gzS80ycmCi
 github.com/go-git/go-git/v5 v5.14.0/go.mod h1:Z5Xhoia5PcWA3NF8vRLURn9E5FRhSl7dGj9ItW3Wk5k=
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
-github.com/go-jose/go-jose/v4 v4.1.1 h1:JYhSgy4mXXzAdF3nUx3ygx347LRXJRrpgyU3adRmkAI=
-github.com/go-jose/go-jose/v4 v4.1.1/go.mod h1:BdsZGqgdO3b6tTc6LSE56wcDbMMLuPsw5d4ZD5f94kA=
+github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/okta/acctest/acctest.go
+++ b/okta/acctest/acctest.go
@@ -29,6 +29,7 @@ import (
 	"github.com/okta/okta-governance-sdk-golang/governance"
 	v4SdkOkta "github.com/okta/okta-sdk-golang/v4/okta"
 	v5SdkOkta "github.com/okta/okta-sdk-golang/v5/okta"
+	v6SdkOkta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/api"
 	"github.com/okta/terraform-provider-okta/okta/config"
 	"github.com/okta/terraform-provider-okta/okta/fwprovider"
@@ -667,6 +668,7 @@ type HttpClientHelper interface {
 }
 
 type vcrIDaaSTestClient struct {
+	sdkV6Client         *v6SdkOkta.APIClient
 	sdkV5Client         *v5SdkOkta.APIClient
 	sdkV3Client         *v4SdkOkta.APIClient
 	sdkV2Client         *oktaSdk.Client
@@ -687,6 +689,7 @@ func NewVcrIDaaSClient(d *schema_sdk.ResourceData) *vcrIDaaSTestClient {
 	// force all the API clients on a new config to use the same round tripper
 	// for VCR recording/playback
 	tripper := c.OktaIDaaSClient.OktaSDKClientV5().GetConfig().HTTPClient.Transport
+	c.OktaIDaaSClient.OktaSDKClientV6().GetConfig().HTTPClient.Transport = tripper
 	c.OktaIDaaSClient.OktaSDKClientV3().GetConfig().HTTPClient.Transport = tripper
 	c.OktaIDaaSClient.OktaSDKClientV2().GetConfig().HttpClient.Transport = tripper
 	re := c.OktaIDaaSClient.OktaSDKClientV2().CloneRequestExecutor()
@@ -696,6 +699,7 @@ func NewVcrIDaaSClient(d *schema_sdk.ResourceData) *vcrIDaaSTestClient {
 	}
 
 	client := &vcrIDaaSTestClient{
+		sdkV6Client:         c.OktaIDaaSClient.OktaSDKClientV6(),
 		sdkV5Client:         c.OktaIDaaSClient.OktaSDKClientV5(),
 		sdkV3Client:         c.OktaIDaaSClient.OktaSDKClientV3(),
 		sdkV2Client:         c.OktaIDaaSClient.OktaSDKClientV2(),
@@ -738,6 +742,7 @@ func (c *vcrGovernanceTestClient) Transport() http.RoundTripper {
 func (c *vcrIDaaSTestClient) SetTransport(rt http.RoundTripper) {
 	c.transport = rt
 
+	c.sdkV6Client.GetConfig().HTTPClient.Transport = rt
 	c.sdkV5Client.GetConfig().HTTPClient.Transport = rt
 	c.sdkV3Client.GetConfig().HTTPClient.Transport = rt
 	c.sdkV2Client.GetConfig().HttpClient.Transport = rt
@@ -751,6 +756,10 @@ func (c *vcrIDaaSTestClient) SetTransport(rt http.RoundTripper) {
 func (c *vcrGovernanceTestClient) SetTransport(rt http.RoundTripper) {
 	c.transport = rt
 	c.oktaGovernanceSDKClient.GetConfig().HTTPClient.Transport = rt
+}
+
+func (c *vcrIDaaSTestClient) OktaSDKClientV6() *v6SdkOkta.APIClient {
+	return c.sdkV6Client
 }
 
 func (c *vcrIDaaSTestClient) OktaSDKClientV5() *v5SdkOkta.APIClient {

--- a/okta/api/api.go
+++ b/okta/api/api.go
@@ -15,12 +15,115 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
+	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/internal/apimutex"
 	"github.com/okta/terraform-provider-okta/okta/internal/transport"
 	"github.com/okta/terraform-provider-okta/okta/utils"
 	"github.com/okta/terraform-provider-okta/okta/version"
 	"github.com/okta/terraform-provider-okta/sdk"
 )
+
+func getV6ClientConfig(c *OktaAPIConfig) (*v6okta.Configuration, *v6okta.APIClient, error) {
+	var httpClient *http.Client
+	if c.Backoff {
+		retryableClient := retryablehttp.NewClient()
+		retryableClient.RetryWaitMin = time.Second * time.Duration(c.MinWait)
+		retryableClient.RetryWaitMax = time.Second * time.Duration(c.MaxWait)
+		retryableClient.RetryMax = c.RetryCount
+		retryableClient.Logger = c.Logger
+		retryableClient.HTTPClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Okta", retryableClient.HTTPClient.Transport)
+		retryableClient.ErrorHandler = errHandler
+		retryableClient.CheckRetry = checkRetry
+		httpClient = retryableClient.StandardClient()
+		c.Logger.Info(fmt.Sprintf("v6 running with backoff http client, wait min %d, wait max %d, retry max %d", retryableClient.RetryWaitMin, retryableClient.RetryWaitMax, retryableClient.RetryMax))
+	} else {
+		httpClient = cleanhttp.DefaultClient()
+		httpClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Okta", httpClient.Transport)
+		c.Logger.Info("v6 running with default http client")
+	}
+
+	// adds transport governor to retryable or default client
+	if c.MaxAPICapacity > 0 && c.MaxAPICapacity < 100 {
+		c.Logger.Info(fmt.Sprintf("v6 running with experimental max_api_capacity configuration at %d%%", c.MaxAPICapacity))
+		apiMutex, err := apimutex.NewAPIMutex(c.MaxAPICapacity)
+		if err != nil {
+			return nil, nil, err
+		}
+		httpClient.Transport = transport.NewGovernedTransport(httpClient.Transport, apiMutex, c.Logger)
+	}
+	var orgURL string
+	var disableHTTPS bool
+	if c.HttpProxy != "" {
+		orgURL = strings.TrimSuffix(c.HttpProxy, "/")
+		disableHTTPS = strings.HasPrefix(orgURL, "http://")
+	} else {
+		orgURL = fmt.Sprintf("https://%v.%v", c.OrgName, c.Domain)
+	}
+	_, err := url.Parse(orgURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("malformed Okta API URL (org_name+base_url value, or http_proxy value): %+v", err)
+	}
+
+	setters := []v6okta.ConfigSetter{
+		v6okta.WithOrgUrl(orgURL),
+		v6okta.WithCache(false),
+		v6okta.WithHttpClientPtr(httpClient),
+		v6okta.WithRateLimitMaxBackOff(int64(c.MaxWait)),
+		v6okta.WithRequestTimeout(int64(c.RequestTimeout)),
+		v6okta.WithRateLimitMaxRetries(int32(c.RetryCount)),
+		v6okta.WithUserAgentExtra(version.OktaTerraformProviderUserAgent),
+	}
+	// v6 client also needs http proxy explicitly set
+	if c.HttpProxy != "" {
+		_url, err := url.Parse(c.HttpProxy)
+		if err != nil {
+			return nil, nil, err
+		}
+		host := v6okta.WithProxyHost(_url.Hostname())
+		setters = append(setters, host)
+
+		sPort := _url.Port()
+		if sPort == "" {
+			sPort = "80"
+		}
+		iPort, err := strconv.Atoi(sPort)
+		if err != nil {
+			return nil, nil, err
+		}
+		port := v6okta.WithProxyPort(int32(iPort))
+		setters = append(setters, port)
+	}
+
+	switch {
+	case c.AccessToken != "":
+		setters = append(
+			setters,
+			v6okta.WithToken(c.AccessToken), v6okta.WithAuthorizationMode("Bearer"),
+		)
+
+	case c.ApiToken != "":
+		setters = append(
+			setters,
+			v6okta.WithToken(c.ApiToken), v6okta.WithAuthorizationMode("SSWS"),
+		)
+
+	case c.PrivateKey != "":
+		setters = append(
+			setters,
+			v6okta.WithPrivateKey(c.PrivateKey), v6okta.WithPrivateKeyId(c.PrivateKeyId), v6okta.WithScopes(c.Scopes), v6okta.WithClientId(c.ClientID), v6okta.WithAuthorizationMode("PrivateKey"),
+		)
+	}
+
+	if disableHTTPS {
+		setters = append(setters, v6okta.WithTestingDisableHttpsCheck(true))
+	}
+
+	config, err := v6okta.NewConfiguration(setters...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return config, nil, nil
+}
 
 func getV5ClientConfig(c *OktaAPIConfig) (*v5okta.Configuration, *v5okta.APIClient, error) {
 	var httpClient *http.Client

--- a/okta/services/idaas/idaas.go
+++ b/okta/services/idaas/idaas.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	oktav5sdk "github.com/okta/okta-sdk-golang/v5/okta"
+	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
 	"github.com/okta/terraform-provider-okta/okta/internal/mutexkv"
 	"github.com/okta/terraform-provider-okta/okta/resources"
@@ -54,6 +55,10 @@ func getOktaV3ClientFromMetadata(meta interface{}) *okta.APIClient {
 
 func getOktaV5ClientFromMetadata(meta interface{}) *oktav5sdk.APIClient {
 	return meta.(*config.Config).OktaIDaaSClient.OktaSDKClientV5()
+}
+
+func getOktaV6ClientFromMetadata(meta interface{}) *v6okta.APIClient {
+	return meta.(*config.Config).OktaIDaaSClient.OktaSDKClientV6()
 }
 
 func getAPISupplementFromMetadata(meta interface{}) *sdk.APISupplement {


### PR DESCRIPTION
This PR adds the `okta-sdk-golang` `v6` setup to the Terraform provider.