### PR TITLE
GH 2389 | OKTA-1053164 | okta_app_signon_policy Reports Bogus Change During Import

### DIFF
--- a/okta/services/idaas/resource_okta_app_signon_policy.go
+++ b/okta/services/idaas/resource_okta_app_signon_policy.go
@@ -181,7 +181,9 @@ func (r *appSignOnPolicyResource) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// When ID is set but required fields name, description aren't, it implies that the resource has been imported
+
+	// When ID is set but required fields name, description aren't, it implies that the resource has been imported.
+	// The resource needn't be created from here on out, so the value for catch_all doesn't matter since it only has effect during Create
 	if !state.ID.IsNull() && state.Name.IsNull() && state.Description.IsNull() {
 		state.CatchAll = types.BoolValue(true)
 	}

--- a/okta/services/idaas/resource_okta_app_signon_policy.go
+++ b/okta/services/idaas/resource_okta_app_signon_policy.go
@@ -181,7 +181,10 @@ func (r *appSignOnPolicyResource) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
+	// When ID is set but required fields name, description aren't, it implies that the resource has been imported
+	if !state.ID.IsNull() && state.Name.IsNull() && state.Description.IsNull() {
+		state.CatchAll = types.BoolValue(true)
+	}
 	accessPolicy, _, err := r.OktaIDaaSClient.OktaSDKClientV5().PolicyAPI.GetPolicy(ctx, state.ID.ValueString()).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
Fixes [#2389](https://github.com/okta/terraform-provider-okta/issues/2389),  [#2404](https://github.com/okta/terraform-provider-okta/issues/2404)
We check if a resource is being imported and set CatchAll to true if it is.
If ID is set BUT Name & Description, the required fields are unset, then we know that the resource is being read in the context of an import.