### PR TITLE
release: prepare release v6.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.5.2 (December 09, 2025)
+
+### BUG FIXES
+* Fix creating new DPoP tokens in every retries [#2585](https://github.com/okta/terraform-provider-okta/pull/2585) by [pranav-okta](https://github.com/pranav-okta)
+
 ## 6.5.1 (November 25, 2025)
 
 **BUG FIXES** 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.5.1"
+      version = "~> 6.5.2"
     }
   }
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "6.5.1"
+	OktaTerraformProviderVersion   = "6.5.2"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.5.1"
+      version = "~> 6.5.2"
     }
   }
 }


### PR DESCRIPTION
## 6.5.2 (December 09, 2025)

### BUG FIXES
* Fix creating new DPoP tokens in every retries [#2585](https://github.com/okta/terraform-provider-okta/pull/2585) by [pranav-okta](https://github.com/pranav-okta)
