### PR TITLE
feat: Add Location header sanitization to VCR hook

### DIFF
--- a/okta/acctest/acctest.go
+++ b/okta/acctest/acctest.go
@@ -547,6 +547,16 @@ func vcrHook(mgr *vcrManager) func(*cassette.Interaction) error {
 			i.Response.Headers.Add("Link", val)
 		}
 
+		// Sanitize Location header (used in 201 Created responses)
+		// %s/example-admin.okta.com/test-admin.dne-okta.com/
+		headerLocations := replaceHeaderValues(i.Response.Headers["Location"], orgAdminHostname, vcrAdminHostname)
+		// %s/example.okta.com/test.dne-okta.com/
+		headerLocations = replaceHeaderValues(headerLocations, orgHostname, vcrHostname)
+		i.Response.Headers.Del("Location")
+		for _, val := range headerLocations {
+			i.Response.Headers.Add("Location", val)
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
### Changes
- Adds `Location` header sanitization to the VCR hook, matching the existing pattern used for `Link` headers
- Prevents real org hostnames from leaking into cassette files via `Location` headers in `201 Created` responses

### Context
The `vcrHook` sanitizes hostnames in request URLs, request/response bodies, and `Link` headers, but does not sanitize `Location` headers

A `HTTP 201 Created` response includes a `Location` header which points to the newly created resource, this header contains the real org hostname (e.g. `acme-admin.oktapreview.com`)

### References
- #2740
- #2741