### PR TITLE
Fixing Pipeline VCR Test Failures

### DIFF
--- a/okta/services/idaas/resource_okta_customized_signin_page.go
+++ b/okta/services/idaas/resource_okta_customized_signin_page.go
@@ -31,6 +31,10 @@ func (r *customizedSigninPageResource) Metadata(_ context.Context, req resource.
 }
 
 func (r *customizedSigninPageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+
+	oktaMutexKV.Lock(resources.OktaIDaaSCustomizedSignInPage)
+	defer oktaMutexKV.Unlock(resources.OktaIDaaSCustomizedSignInPage)
+
 	newSchema := resourceSignInSchema
 	pageContentAttribute := newSchema.Attributes["page_content"].(resourceSchema.StringAttribute)
 	pageContentAttribute.Required = false
@@ -51,9 +55,9 @@ func (r *customizedSigninPageResource) Configure(_ context.Context, req resource
 
 func (r *customizedSigninPageResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 
-	oktaMutexKV.Lock(resources.OktaIDaaSCustomizedSignInPage)
-	defer oktaMutexKV.Unlock(resources.OktaIDaaSCustomizedSignInPage)
-
+	// oktaMutexKV.Lock(resources.OktaIDaaSCustomizedSignInPage)
+	// defer oktaMutexKV.Unlock(resources.OktaIDaaSCustomizedSignInPage)
+	// DUMMY CHANGE
 	var state signinPageModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
Fixing the following panic which occurs when executing VCR tests as part of the CI/CD checks.

```
=== VCR PLAY CASSETTE "classic-00" for TestAccResourceOktaCustomizedSignInPage_crud
fatal error: concurrent map writes
goroutine 422441 [running]:
internal/runtime/maps.fatal({0x391cb54?, 0x33f8020?})
	/opt/hostedtoolcache/go/1.24.7/x64/src/runtime/panic.go:1058 +0x18
[github.com/okta/terraform-provider-okta/okta/services/idaas.(*customizedSigninPageResource).Schema(0x3db5268](http://github.com/okta/terraform-provider-okta/okta/services/idaas.(*customizedSigninPageResource).Schema(0x3db5268)?, {0xc00662da10?, 0x390798b?}, {}, 0xc0028b3a40)
```