### PR TITLE
prepare release v6.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.5.4 (January 13, 2025)
+### FEATURE
+* Add AgentPools resource [#2603](https://github.com/okta/terraform-provider-okta/pull/2603) by [aditya-okta](https://github.com/aditya-okta)
+* Add nil checks when accessing fields for resources and data sources `okta_idp_saml`, `okta_idp_oidc` and resource `okta_idp_social` [#2601](https://github.com/okta/terraform-provider-okta/pull/2601) by [aditya-okta](https://github.com/aditya-okta)
+* Changes To Update Okta Default Brand's `help_url` [#2607](https://github.com/okta/terraform-provider-okta/pull/2607) by [dhiwakar-okta](https://github.com/dhiwakar-okta)
+* Adds support for `ID` field in `AuthenticationMethodObject` [#2609](https://github.com/okta/terraform-provider-okta/pull/2609) by [aditya-okta](https://github.com/aditya-okta)
+
 
 ## 6.5.3 (December 24, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.5.4 (January 13, 2025)
+## 6.5.4 (January 15, 2025)
 ### FEATURE
 * Add AgentPools resource [#2603](https://github.com/okta/terraform-provider-okta/pull/2603) by [aditya-okta](https://github.com/aditya-okta)
 * Add nil checks when accessing fields for resources and data sources `okta_idp_saml`, `okta_idp_oidc` and resource `okta_idp_social` [#2601](https://github.com/okta/terraform-provider-okta/pull/2601) by [aditya-okta](https://github.com/aditya-okta)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.5.3"
+      version = "~> 6.5.4"
     }
   }
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "6.5.3"
+	OktaTerraformProviderVersion   = "6.5.4"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.5.3"
+      version = "~> 6.5.4"
     }
   }
 }


### PR DESCRIPTION
## 6.5.4 (January 15, 2025)
### FEATURE
* Add AgentPools resource [#2603](https://github.com/okta/terraform-provider-okta/pull/2603) by [aditya-okta](https://github.com/aditya-okta)
* Add nil checks when accessing fields for resources and data sources `okta_idp_saml`, `okta_idp_oidc` and resource `okta_idp_social` [#2601](https://github.com/okta/terraform-provider-okta/pull/2601) by [aditya-okta](https://github.com/aditya-okta)
* Changes To Update Okta Default Brand's `help_url` [#2607](https://github.com/okta/terraform-provider-okta/pull/2607) by [dhiwakar-okta](https://github.com/dhiwakar-okta)
* Adds support for `ID` field in `AuthenticationMethodObject` [#2609](https://github.com/okta/terraform-provider-okta/pull/2609) by [aditya-okta](https://github.com/aditya-okta)
