### PR TITLE
fix(#2535): add missing documentation for realm_id attributes

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -79,6 +79,7 @@ data "okta_user" "example" {
 - `preferred_language` (String)
 - `primary_phone` (String)
 - `profile_url` (String)
+- `realm_id` (String) The Realm ID associated with the user.
 - `roles` (Set of String)
 - `second_email` (String)
 - `state` (String)

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -106,6 +106,7 @@ Read-Only:
 - `preferred_language` (String)
 - `primary_phone` (String)
 - `profile_url` (String)
+- `realm_id` (String)
 - `roles` (Set of String)
 - `second_email` (String)
 - `state` (String)

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -95,6 +95,7 @@ resource "okta_user" "test2" {
 - `preferred_language` (String) User preferred language
 - `primary_phone` (String) User primary phone number
 - `profile_url` (String) User online profile (web page)
+- `realm_id` (String) The Realm ID to associate the user with
 - `recovery_answer` (String, Sensitive) User Password Recovery Answer
 - `recovery_question` (String) User Password Recovery Question
 - `second_email` (String) User secondary email address, used for account recovery


### PR DESCRIPTION
@aditya-okta 
Sorry. I realized that I missed to extend the documentation. Here it is.