### PR TITLE
adds warning regarding the resource being deleted and re-created on updating certain properties

### DIFF
--- a/docs/resources/user_schema_property.md
+++ b/docs/resources/user_schema_property.md
@@ -14,8 +14,8 @@ in the Terraform Plugin SDK runtime and we juggle the type correctly when making
 Okta API calls. Same holds for the `const` value of `one_of` as well as the
 `array_*` variation of `enum` and `one_of`.
 
-⚠️ **IMPORTANT - Terraform/Pulumi Users:** Modifying certain properties of an existing
-`okta_user_schema_property` resource through Terraform/Pulumi will cause the resource to be
+⚠️ **IMPORTANT - Terraform Users:** Modifying certain properties of an existing
+`okta_user_schema_property` resource through Terraform will cause the resource to be
 **deleted and recreated**, which results in **permanent data loss** for any user data stored
 in this schema property.
 
@@ -25,16 +25,14 @@ in this schema property.
 - `unique`
 
 **Note:** The Okta API supports in-place updates for these properties. This delete/recreate
-behavior is specific to the Terraform/Pulumi provider implementation.
+behavior is specific to the Terraform provider implementation.
 
 **Workaround to prevent data loss:**
 1. Update the schema property directly via the Okta Admin Console or API (e.g., using `curl`)
-2. Remove the resource from your Terraform/Pulumi state:
+2. Remove the resource from your Terraform state:
 	- Terraform: `terraform state rm <resource_address>`
-	- Pulumi: `pulumi state delete <resource_urn>`
 3. Re-import the updated resource:
 	- Terraform: `terraform import <resource_address> <resource_id>`
-	- Pulumi: `pulumi import <resource_type> <resource_name> <resource_id>`
 
 
 ## Example Usage

--- a/docs/resources/user_schema_property.md
+++ b/docs/resources/user_schema_property.md
@@ -13,6 +13,30 @@ may be something other than string. This is a limitation of the schema defintion
 in the Terraform Plugin SDK runtime and we juggle the type correctly when making
 Okta API calls. Same holds for the `const` value of `one_of` as well as the
 `array_*` variation of `enum` and `one_of`.
+
+⚠️ **IMPORTANT - Terraform/Pulumi Users:** Modifying certain properties of an existing
+`okta_user_schema_property` resource through Terraform/Pulumi will cause the resource to be
+**deleted and recreated**, which results in **permanent data loss** for any user data stored
+in this schema property.
+
+**Affected properties:**
+- `external_name`
+- `external_namespace`
+- `unique`
+
+**Note:** The Okta API supports in-place updates for these properties. This delete/recreate
+behavior is specific to the Terraform/Pulumi provider implementation.
+
+**Workaround to prevent data loss:**
+1. Update the schema property directly via the Okta Admin Console or API (e.g., using `curl`)
+2. Remove the resource from your Terraform/Pulumi state:
+	- Terraform: `terraform state rm <resource_address>`
+	- Pulumi: `pulumi state delete <resource_urn>`
+3. Re-import the updated resource:
+	- Terraform: `terraform import <resource_address> <resource_id>`
+	- Pulumi: `pulumi import <resource_type> <resource_name> <resource_id>`
+
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
Fixes #2593

**Description**

Adds documentation warning for okta_user_schema_property resource to alert users that modifying the following properties via Terraform/Pulumi triggers a delete/recreate cycle, which can cause data loss:

- external_name
- external_namespace
- unique

**Note**: The Okta API supports in-place updates for these properties. This is a Terraform/Pulumi provider behavior, not an API limitation.

Workaround: Update the property directly via the Okta Admin Console or API, then remove and re-import the resource in your IaC state.