### PR TITLE
uses reflect to inspect and retrieve link values

### DIFF
--- a/okta/utils/utils.go
+++ b/okta/utils/utils.go
@@ -30,6 +30,8 @@ import (
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/sdk"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const DefaultPaginationLimit int64 = 200
@@ -841,7 +843,7 @@ func LinksValue(links interface{}, keys ...string) string {
 	case reflect.Struct:
 		field := val.FieldByName(key)
 		if !field.IsValid() {
-			field = val.FieldByName(strings.Title(key))
+			field = val.FieldByName(cases.Title(language.Und, cases.NoLower).String(key))
 		}
 
 		if !field.IsValid() {


### PR DESCRIPTION
### Summary
This change refactors the `LinksValue` helper function to use Go's reflect package. The function can now dynamically navigate through nested data structures regardless of whether they are underlying Maps, Slices, or Structs.

Key Changes

1.  **Transition to reflect.Indirect**
Previously, the function would fail if passed a pointer to a struct or map. By using `reflect.Indirect(reflect.ValueOf(links))`, the function now automatically dereferences pointers to get to the actual data.

2. **Generic Slice Unwrapping**
The previous version checked specifically for `[]interface{}`. The new version uses reflect.Slice, allowing it to handle any slice type (e.g., `[]HrefObject `or `[]string`). It recursively calls itself on the first element of the slice:

3. **Support for Go Structs (reflect.Struct)**
This is the most critical update. The function can now "read" fields inside a Go struct by name.
Case-Insensitivity: It attempts to find a field by the exact key, and if that fails, it tries a strings.Title(key) version (e.g., looking for AccessPolicy if the key provided was accesspolicy). This bridges the gap between JSON/HCL snake_case/camelCase and Go's PascalCase exported fields.

4. **Map Support (reflect.Map)**
It retains the ability to look up keys in a map, but uses `val.MapIndex()` instead of type assertion, making the code more robust against different map types (like `map[string]string`).
