### PR TITLE
fix: avoid unnecessary API calls okta_request_condition

### DIFF
--- a/docs/resources/request_condition.md
+++ b/docs/resources/request_condition.md
@@ -75,15 +75,15 @@ resource "okta_request_condition" "example_active" {
 ### Nested Schema for `access_scope_settings`
 Required:
 - `type` (String) Enum: `RESOURCE_DEFAULT`, `GROUPS`, `ENTITLEMENT_BUNDLES`.
-- `id` (Block List) Defines access scope configuration.
-  Each block specifies a type (e.g., GROUPS) and one or more ids blocks containing an id (the group or entitlement bundle ID).
+- `id` (Block Set) Defines access scope configuration.
+  Each block specifies a type (e.g., GROUPS) and one or more ids blocks containing an id (the group or entitlement bundle ID). Using a set prevents spurious diffs when group order changes.
 
 <a id="nestedblock--requester_settings"></a>
 ### Nested Schema for `requester_settings`
 Required:
 - `type` (String) Enum: `EVERYONE`, `TEAMS`, `GROUPS`.
-- `id` (Block List) Defines requester settings.
-  Each block specifies a type (e.g., GROUPS) and one or more ids blocks containing an id (the group or entitlement bundle ID).
+- `id` (Block Set) Defines requester settings.
+  Each block specifies a type (e.g., GROUPS) and one or more ids blocks containing an id (the group or entitlement bundle ID). Using a set prevents spurious diffs when group order changes.
 
 <a id="nestedblock--access_duration_settings"></a>
 ### Nested Schema for `access_duration_settings`

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -126,8 +126,8 @@ func (r *requestConditionResource) Schema(ctx context.Context, req resource.Sche
 		Blocks: map[string]schema.Block{
 			"access_scope_settings": schema.SingleNestedBlock{
 				Blocks: map[string]schema.Block{
-					"ids": schema.ListNestedBlock{
-						Description: "Block list of groups/entitlement bundles ids.",
+					"ids": schema.SetNestedBlock{
+						Description: "Block set of groups/entitlement bundles ids.",
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
 								"id": schema.StringAttribute{
@@ -146,8 +146,8 @@ func (r *requestConditionResource) Schema(ctx context.Context, req resource.Sche
 			},
 			"requester_settings": schema.SingleNestedBlock{
 				Blocks: map[string]schema.Block{
-					"ids": schema.ListNestedBlock{
-						Description: "Block list of teams/groups ids.",
+					"ids": schema.SetNestedBlock{
+						Description: "Block set of teams/groups ids.",
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
 								"id": schema.StringAttribute{


### PR DESCRIPTION
Changes from ListNestedBlock to SetNestedBlock for:
- `okta_request_condition.access_scope_settings.ids`
- `okta_request_condition.requester_settings.ids`

This avoids necessary API calls when the contents have only been re-ordered