### PR TITLE
fix(governance): surface API error details for okta_campaign

### DIFF
--- a/okta/services/governance/helpers.go
+++ b/okta/services/governance/helpers.go
@@ -1,0 +1,35 @@
+package governance
+
+import (
+	"errors"
+	"strings"
+
+	sdkgov "github.com/okta/okta-governance-sdk-golang/governance"
+)
+
+// APIErrorMessage returns a detailed error message from the governance SDK,
+// including the API response body and decoded ModelError summary when available.
+// Use this when reporting SDK errors in diagnostics so users see the API's message.
+func APIErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	var apiErr *sdkgov.GenericOpenAPIError
+	if errors.As(err, &apiErr) {
+		if body := apiErr.Body(); len(body) > 0 {
+			bodyStr := strings.TrimSpace(string(body))
+			if bodyStr != "" && !strings.Contains(msg, bodyStr) {
+				msg += ". Response: " + bodyStr
+			}
+		}
+		if model := apiErr.Model(); model != nil {
+			if modelErr, ok := model.(sdkgov.ModelError); ok {
+				if s := modelErr.GetErrorSummary(); s != "" && !strings.Contains(msg, s) {
+					msg += ". " + s
+				}
+			}
+		}
+	}
+	return msg
+}

--- a/okta/services/governance/resource_campaign.go
+++ b/okta/services/governance/resource_campaign.go
@@ -648,7 +648,7 @@ func (r *campaignResource) Create(ctx context.Context, req resource.CreateReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Campaign",
-			"Could not create Campaign, unexpected error: "+err.Error(),
+			"Could not create Campaign, unexpected error: "+APIErrorMessage(err),
 		)
 		return
 	}
@@ -674,8 +674,8 @@ func (r *campaignResource) Read(ctx context.Context, req resource.ReadRequest, r
 	getCampaignResponse, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().CampaignsAPI.GetCampaign(ctx, data.Id.ValueString()).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading campaign",
-			"Could not read Campaign, unexpected error: "+err.Error(),
+			"Error reading Campaign",
+			"Could not read Campaign, unexpected error: "+APIErrorMessage(err),
 		)
 		return
 	}
@@ -723,7 +723,7 @@ func (r *campaignResource) Delete(ctx context.Context, req resource.DeleteReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting Campaign",
-			"Could not delete Campaign with ID"+data.Id.ValueString()+" unexpected error: "+err.Error(),
+			"Could not delete Campaign with ID "+data.Id.ValueString()+", unexpected error: "+APIErrorMessage(err),
 		)
 		return
 	}


### PR DESCRIPTION
When `okta_campaign` create, read, or delete failed, the provider only showed a generic message like `"Error creating Campaign"`.
The real error message from the Okta Governance API was not surfaced
