### PR TITLE
re-records vcr and adds changes to set settings when importing log_stream resource

### DIFF
--- a/test/fixtures/vcr/idaas/TestAccDataSourceOktaLogStream_read/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccDataSourceOktaLogStream_read/classic-00.yaml
@@ -7,14 +7,9 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 303
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_530667077 Splunk","settings":{"edition":"aws","host":"acme.splunkcloud.com","token":"58A7C8D6-4E2F-4C3B-8F5B-D4E2F3A4B5C6"},"status":"ACTIVE","type":"splunk_cloud_logstreaming"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -28,37 +23,30 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwufik4xrxD6r11d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzje9hwngUytd61d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:09:30.000Z","created":"2026-02-13T09:09:30.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:03 GMT
+                - Fri, 13 Feb 2026 09:09:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 349.230792ms
+        duration: 1.302044708s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 287
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_530667077 AWS","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"status":"ACTIVE","type":"aws_eventbridge"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -72,77 +60,61 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:03 GMT
+                - Fri, 13 Feb 2026 09:09:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 943.835292ms
+        duration: 1.843247s
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:03 GMT
+                - Fri, 13 Feb 2026 09:09:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 242.057292ms
+        duration: 1.19770575s
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -154,245 +126,197 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwufik4xrxD6r11d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '[{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzje9hwngUytd61d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:09:30.000Z","created":"2026-02-13T09:09:30.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7/lifecycle/deactivate","method":"POST"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:04 GMT
+                - Fri, 13 Feb 2026 09:09:32 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 290.290667ms
+        duration: 1.264816083s
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwufik4xrxD6r11d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:04 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
+                - Fri, 13 Feb 2026 09:09:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 297.226833ms
+        duration: 1.206190875s
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '[{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzje9hwngUytd61d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:09:30.000Z","created":"2026-02-13T09:09:30.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7/lifecycle/deactivate","method":"POST"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:04 GMT
+                - Fri, 13 Feb 2026 09:09:33 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 381.602625ms
+        duration: 1.271632916s
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwufik4xrxD6r11d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:04 GMT
+                - Fri, 13 Feb 2026 09:09:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 305.658625ms
+        duration: 1.220762s
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzje9hwngUytd61d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:09:30.000Z","created":"2026-02-13T09:09:30.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:05 GMT
+                - Fri, 13 Feb 2026 09:09:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 347.963708ms
+        duration: 1.261838709s
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:05 GMT
+                - Fri, 13 Feb 2026 09:09:36 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 219.44075ms
+        duration: 1.201228334s
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -404,79 +328,30 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwufik4xrxD6r11d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '[{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzje9hwngUytd61d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:09:30.000Z","created":"2026-02-13T09:09:30.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7/lifecycle/deactivate","method":"POST"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:05 GMT
+                - Fri, 13 Feb 2026 09:09:36 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 315.638791ms
+        duration: 1.255035958s
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 14 Mar 2025 03:05:05 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 218.341875ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -488,53 +363,75 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwu016vvTFjtR31d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwufik4xrxD6r11d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-14T03:05:03.000Z","created":"2025-03-14T03:05:03.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '[{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzje9hwngUytd61d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:09:30.000Z","created":"2026-02-13T09:09:30.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7/lifecycle/deactivate","method":"POST"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:05:05 GMT
+                - Fri, 13 Feb 2026 09:09:37 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 441.458042ms
+        duration: 1.200636583s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oauzjdcphboX7cJm1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:09:31.000Z","created":"2026-02-13T09:09:31.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 13 Feb 2026 09:09:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.203608459s
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -542,40 +439,31 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 14 Mar 2025 03:05:06 GMT
+                - Fri, 13 Feb 2026 09:09:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 233.182166ms
+        duration: 1.062126875s
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -583,87 +471,69 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 14 Mar 2025 03:05:06 GMT
+                - Fri, 13 Feb 2026 09:09:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 236.661042ms
+        duration: 1.062917333s
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwufik4xrxD6r11d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje9hwngUytd61d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 14 Mar 2025 03:05:06 GMT
+                - Fri, 13 Feb 2026 09:09:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 281.026292ms
+        duration: 1.143815792s
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwu016vvTFjtR31d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjdcphboX7cJm1d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 14 Mar 2025 03:05:07 GMT
+                - Fri, 13 Feb 2026 09:09:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 910.316834ms
+        duration: 2.496209375s

--- a/test/fixtures/vcr/idaas/TestAccDataSourceOktaLogStream_read/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccDataSourceOktaLogStream_read/oie-00.yaml
@@ -7,14 +7,9 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 303
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_530667077 Splunk","settings":{"edition":"aws","host":"acme.splunkcloud.com","token":"58A7C8D6-4E2F-4C3B-8F5B-D4E2F3A4B5C6"},"status":"ACTIVE","type":"splunk_cloud_logstreaming"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -28,37 +23,30 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwqm58obyFbtQI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjgg5wQHgVbuQ1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:18 GMT
+                - Fri, 13 Feb 2026 09:10:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 266.722042ms
+        duration: 1.352725333s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 287
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_530667077 AWS","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"status":"ACTIVE","type":"aws_eventbridge"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -72,77 +60,61 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:18 GMT
+                - Fri, 13 Feb 2026 09:10:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.121807541s
+        duration: 1.944828166s
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:19 GMT
+                - Fri, 13 Feb 2026 09:10:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 217.292167ms
+        duration: 1.198026459s
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -154,329 +126,197 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwqm58obyFbtQI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '[{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzjgg5wQHgVbuQ1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7/lifecycle/deactivate","method":"POST"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:19 GMT
+                - Fri, 13 Feb 2026 09:10:41 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 235.925542ms
+        duration: 1.258040917s
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '[{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzjgg5wQHgVbuQ1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7/lifecycle/deactivate","method":"POST"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:19 GMT
+                - Fri, 13 Feb 2026 09:10:42 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 218.234667ms
+        duration: 1.300738708s
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwqm58obyFbtQI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:19 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
+                - Fri, 13 Feb 2026 09:10:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 234.033709ms
+        duration: 2.071957833s
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:19 GMT
+                - Fri, 13 Feb 2026 09:10:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 199.253792ms
+        duration: 1.244129875s
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwqm58obyFbtQI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjgg5wQHgVbuQ1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:19 GMT
+                - Fri, 13 Feb 2026 09:10:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 202.517917ms
+        duration: 1.2922715s
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwqm58obyFbtQI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:20 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
+                - Fri, 13 Feb 2026 09:10:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 232.004ms
+        duration: 1.218832542s
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 13 Mar 2025 23:25:20 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 442.152125ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 13 Mar 2025 23:25:20 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 211.717375ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -488,53 +328,110 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oakwqsuht7LV72UU1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oakwqm58obyFbtQI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2025-03-13T23:25:18.000Z","created":"2025-03-13T23:25:18.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7/lifecycle/deactivate","method":"POST"}}}]'
+        body: '[{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzjgg5wQHgVbuQ1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7/lifecycle/deactivate","method":"POST"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:25:20 GMT
+                - Fri, 13 Feb 2026 09:10:46 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 548.926417ms
+        duration: 1.270318s
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/logStreams
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}},{"id":"0oauzjgg5wQHgVbuQ1d7","type":"splunk_cloud_logstreaming","name":"testAcc_530667077 Splunk","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7/lifecycle/deactivate","method":"POST"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 13 Feb 2026 09:10:47 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/logStreams?limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.07094525s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oauzjfv68Wkk35rY1d7","type":"aws_eventbridge","name":"testAcc_530667077 AWS","lastUpdated":"2026-02-13T09:10:39.000Z","created":"2026-02-13T09:10:39.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_530667077_AWS","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 13 Feb 2026 09:10:47 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.242031667s
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -542,40 +439,31 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Thu, 13 Mar 2025 23:25:21 GMT
+                - Fri, 13 Feb 2026 09:10:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 235.742875ms
+        duration: 1.083570666s
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -583,87 +471,69 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Thu, 13 Mar 2025 23:25:21 GMT
+                - Fri, 13 Feb 2026 09:10:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 239.763583ms
+        duration: 1.092620042s
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqm58obyFbtQI1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjfv68Wkk35rY1d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Thu, 13 Mar 2025 23:25:21 GMT
+                - Fri, 13 Feb 2026 09:10:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 279.587417ms
+        duration: 1.805738375s
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwqsuht7LV72UU1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjgg5wQHgVbuQ1d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Thu, 13 Mar 2025 23:25:22 GMT
+                - Fri, 13 Feb 2026 09:10:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 917.826125ms
+        duration: 1.948658875s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaLogStream_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaLogStream_crud/classic-00.yaml
@@ -7,14 +7,9 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 305
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_244785732 Splunk","settings":{"edition":"aws","host":"acme.splunkcloud.com","token":"58A7C8D6-4E2F-4C3B-8F5B-D4E2F3A4B5C6"},"status":"INACTIVE","type":"splunk_cloud_logstreaming"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -28,51 +23,77 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj034ObaTlJI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2025-03-14T03:16:47.000Z","created":"2025-03-14T03:16:47.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzje728ydDjPlT1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2026-02-13T09:07:42.000Z","created":"2026-02-13T09:07:42.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:47 GMT
+                - Fri, 13 Feb 2026 09:07:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 530.203709ms
+        duration: 1.301966042s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
+        content_length: 291
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        body: |
+            {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_244785732 EventBridge","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"status":"ACTIVE","type":"aws_eventbridge"}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/deactivate
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/logStreams
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oauzjcze04iboFSh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2026-02-13T09:07:43.000Z","created":"2026-02-13T09:07:43.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 13 Feb 2026 09:07:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 2.100300666s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         content_length: 0
-        uncompressed: false
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
         body: ""
         headers:
             Accept-Ch:
@@ -80,234 +101,153 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 14 Mar 2025 03:16:48 GMT
+                - Fri, 13 Feb 2026 09:07:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 251.866333ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 291
-        transfer_encoding: []
-        trailer: {}
-        host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_244785732 EventBridge","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"status":"ACTIVE","type":"aws_eventbridge"}
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/logStreams
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oakwuj036aI2v4Dh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2025-03-14T03:16:48.000Z","created":"2025-03-14T03:16:48.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 14 Mar 2025 03:16:48 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.108842084s
+        duration: 1.082783208s
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj036aI2v4Dh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2025-03-14T03:16:48.000Z","created":"2025-03-14T03:16:48.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjcze04iboFSh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2026-02-13T09:07:43.000Z","created":"2026-02-13T09:07:43.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:49 GMT
+                - Fri, 13 Feb 2026 09:07:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 400.352042ms
+        duration: 1.212744s
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj034ObaTlJI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2025-03-14T03:16:48.000Z","created":"2025-03-14T03:16:47.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7","method":"GET"}}}'
+        body: '{"id":"0oauzje728ydDjPlT1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2026-02-13T09:07:43.000Z","created":"2026-02-13T09:07:42.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:49 GMT
+                - Fri, 13 Feb 2026 09:07:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 538.271875ms
+        duration: 1.290162167s
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj036aI2v4Dh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2025-03-14T03:16:48.000Z","created":"2025-03-14T03:16:48.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjcze04iboFSh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2026-02-13T09:07:43.000Z","created":"2026-02-13T09:07:43.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:51 GMT
+                - Fri, 13 Feb 2026 09:07:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 248.874833ms
+        duration: 1.036672541s
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj034ObaTlJI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2025-03-14T03:16:48.000Z","created":"2025-03-14T03:16:47.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7","method":"GET"}}}'
+        body: '{"id":"0oauzje728ydDjPlT1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2026-02-13T09:07:43.000Z","created":"2026-02-13T09:07:42.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:51 GMT
+                - Fri, 13 Feb 2026 09:07:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 393.743333ms
+        duration: 1.241352792s
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 173
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"name":"testAcc_244785732 EventBridge Updated","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"type":"aws_eventbridge"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -315,43 +255,36 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj036aI2v4Dh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2025-03-14T03:16:52.000Z","created":"2025-03-14T03:16:48.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjcze04iboFSh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2026-02-13T09:07:49.000Z","created":"2026-02-13T09:07:43.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:52 GMT
+                - Fri, 13 Feb 2026 09:07:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 514.334291ms
+        duration: 1.329802125s
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 138
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"name":"testAcc_244785732 Splunk Updated","settings":{"edition":"aws","host":"acme.splunkcloud.com"},"type":"splunk_cloud_logstreaming"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -359,57 +292,46 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj034ObaTlJI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2025-03-14T03:16:52.000Z","created":"2025-03-14T03:16:47.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7","method":"GET"}}}'
+        body: '{"id":"0oauzje728ydDjPlT1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2026-02-13T09:07:49.000Z","created":"2026-02-13T09:07:42.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:52 GMT
+                - Fri, 13 Feb 2026 09:07:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 672.431792ms
+        duration: 1.361466417s
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -417,40 +339,31 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 14 Mar 2025 03:16:52 GMT
+                - Fri, 13 Feb 2026 09:07:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 275.693041ms
+        duration: 1.087327917s
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -458,163 +371,130 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 14 Mar 2025 03:16:52 GMT
+                - Fri, 13 Feb 2026 09:07:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 291.89975ms
+        duration: 1.140171334s
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj036aI2v4Dh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2025-03-14T03:16:52.000Z","created":"2025-03-14T03:16:48.000Z","status":"INACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7","method":"GET"}}}'
+        body: '{"id":"0oauzje728ydDjPlT1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2026-02-13T09:07:51.000Z","created":"2026-02-13T09:07:42.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:53 GMT
+                - Fri, 13 Feb 2026 09:07:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 390.660375ms
+        duration: 1.031977667s
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj034ObaTlJI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2025-03-14T03:16:52.000Z","created":"2025-03-14T03:16:47.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjcze04iboFSh1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2026-02-13T09:07:51.000Z","created":"2026-02-13T09:07:43.000Z","status":"INACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:53 GMT
+                - Fri, 13 Feb 2026 09:07:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 534.050833ms
+        duration: 1.180602708s
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwuj034ObaTlJI1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2025-03-14T03:16:52.000Z","created":"2025-03-14T03:16:47.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzje728ydDjPlT1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2026-02-13T09:07:51.000Z","created":"2026-02-13T09:07:42.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7","method":"GET"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 14 Mar 2025 03:16:54 GMT
+                - Fri, 13 Feb 2026 09:07:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 248.472083ms
+        duration: 1.195127041s
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -622,40 +502,31 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 14 Mar 2025 03:16:54 GMT
+                - Fri, 13 Feb 2026 09:07:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 224.289875ms
+        duration: 1.123461208s
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -663,87 +534,69 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 14 Mar 2025 03:16:54 GMT
+                - Fri, 13 Feb 2026 09:07:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 226.844125ms
+        duration: 1.862126667s
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj034ObaTlJI1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzjcze04iboFSh1d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 14 Mar 2025 03:16:55 GMT
+                - Fri, 13 Feb 2026 09:07:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 399.437125ms
+        duration: 1.794116458s
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: classic-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oakwuj036aI2v4Dh1d7
+        url: https://classic-00.dne-okta.com/api/v1/logStreams/0oauzje728ydDjPlT1d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 14 Mar 2025 03:16:55 GMT
+                - Fri, 13 Feb 2026 09:07:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 837.301917ms
+        duration: 1.145657333s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaLogStream_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaLogStream_crud/oie-00.yaml
@@ -7,14 +7,9 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 305
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_244785732 Splunk","settings":{"edition":"aws","host":"acme.splunkcloud.com","token":"58A7C8D6-4E2F-4C3B-8F5B-D4E2F3A4B5C6"},"status":"INACTIVE","type":"splunk_cloud_logstreaming"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -28,51 +23,77 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr6xe4BMYWpKL1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2025-03-13T23:39:24.000Z","created":"2025-03-13T23:39:24.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzj9tf9V6RlC361d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2026-02-13T09:07:11.000Z","created":"2026-02-13T09:07:11.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:24 GMT
+                - Fri, 13 Feb 2026 09:07:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 514.345958ms
+        duration: 1.364265917s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
+        content_length: 291
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
+        body: |
+            {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_244785732 EventBridge","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"status":"ACTIVE","type":"aws_eventbridge"}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/deactivate
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/logStreams
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oauzjdchbN2joUZw1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2026-02-13T09:07:11.000Z","created":"2026-02-13T09:07:11.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 13 Feb 2026 09:07:11 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.91947825s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         content_length: 0
-        uncompressed: false
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
         body: ""
         headers:
             Accept-Ch:
@@ -80,234 +101,153 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Thu, 13 Mar 2025 23:39:24 GMT
+                - Fri, 13 Feb 2026 09:07:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 281.298833ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 291
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"_links":{"self":{"href":""}},"created":"0001-01-01T00:00:00Z","id":"","lastUpdated":"0001-01-01T00:00:00Z","name":"testAcc_244785732 EventBridge","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"status":"ACTIVE","type":"aws_eventbridge"}
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/logStreams
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oakwr78tjXNFUcrS1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2025-03-13T23:39:24.000Z","created":"2025-03-13T23:39:24.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 13 Mar 2025 23:39:24 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 924.9265ms
+        duration: 1.0908975s
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr78tjXNFUcrS1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2025-03-13T23:39:24.000Z","created":"2025-03-13T23:39:24.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdchbN2joUZw1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2026-02-13T09:07:11.000Z","created":"2026-02-13T09:07:11.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:25 GMT
+                - Fri, 13 Feb 2026 09:07:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 299.5755ms
+        duration: 1.2118815s
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr6xe4BMYWpKL1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2025-03-13T23:39:24.000Z","created":"2025-03-13T23:39:24.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7","method":"GET"}}}'
+        body: '{"id":"0oauzj9tf9V6RlC361d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2026-02-13T09:07:12.000Z","created":"2026-02-13T09:07:11.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:25 GMT
+                - Fri, 13 Feb 2026 09:07:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 381.630333ms
+        duration: 1.255216708s
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr78tjXNFUcrS1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2025-03-13T23:39:24.000Z","created":"2025-03-13T23:39:24.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdchbN2joUZw1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge","lastUpdated":"2026-02-13T09:07:11.000Z","created":"2026-02-13T09:07:11.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:28 GMT
+                - Fri, 13 Feb 2026 09:07:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 462.845542ms
+        duration: 1.212301708s
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr6xe4BMYWpKL1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2025-03-13T23:39:24.000Z","created":"2025-03-13T23:39:24.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7","method":"GET"}}}'
+        body: '{"id":"0oauzj9tf9V6RlC361d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk","lastUpdated":"2026-02-13T09:07:12.000Z","created":"2026-02-13T09:07:11.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:28 GMT
+                - Fri, 13 Feb 2026 09:07:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 463.055ms
+        duration: 1.272615083s
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 173
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"name":"testAcc_244785732 EventBridge Updated","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"type":"aws_eventbridge"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -315,43 +255,36 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr78tjXNFUcrS1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2025-03-13T23:39:28.000Z","created":"2025-03-13T23:39:24.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdchbN2joUZw1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2026-02-13T09:07:18.000Z","created":"2026-02-13T09:07:11.000Z","status":"ACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:28 GMT
+                - Fri, 13 Feb 2026 09:07:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 472.455667ms
+        duration: 1.299934542s
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 138
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
         body: |
             {"name":"testAcc_244785732 Splunk Updated","settings":{"edition":"aws","host":"acme.splunkcloud.com"},"type":"splunk_cloud_logstreaming"}
-        form: {}
         headers:
             Accept:
                 - application/json
@@ -359,57 +292,46 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7
         method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr6xe4BMYWpKL1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2025-03-13T23:39:29.000Z","created":"2025-03-13T23:39:24.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7","method":"GET"}}}'
+        body: '{"id":"0oauzj9tf9V6RlC361d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2026-02-13T09:07:18.000Z","created":"2026-02-13T09:07:11.000Z","status":"INACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:29 GMT
+                - Fri, 13 Feb 2026 09:07:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 547.416875ms
+        duration: 1.302574666s
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -417,40 +339,31 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Thu, 13 Mar 2025 23:39:29 GMT
+                - Fri, 13 Feb 2026 09:07:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 246.448292ms
+        duration: 1.071165042s
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -458,163 +371,130 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Thu, 13 Mar 2025 23:39:29 GMT
+                - Fri, 13 Feb 2026 09:07:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 284.840792ms
+        duration: 1.095473459s
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr6xe4BMYWpKL1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2025-03-13T23:39:29.000Z","created":"2025-03-13T23:39:24.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzjdchbN2joUZw1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2026-02-13T09:07:19.000Z","created":"2026-02-13T09:07:11.000Z","status":"INACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:29 GMT
+                - Fri, 13 Feb 2026 09:07:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 285.007125ms
+        duration: 1.209231083s
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr78tjXNFUcrS1d7","type":"aws_eventbridge","name":"testAcc_244785732 EventBridge Updated","lastUpdated":"2025-03-13T23:39:29.000Z","created":"2025-03-13T23:39:24.000Z","status":"INACTIVE","settings":{"accountId":"123456789012","eventSourceName":"testAcc_244785732","region":"eu-west-3"},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7/lifecycle/activate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7","method":"GET"}}}'
+        body: '{"id":"0oauzj9tf9V6RlC361d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2026-02-13T09:07:19.000Z","created":"2026-02-13T09:07:11.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:29 GMT
+                - Fri, 13 Feb 2026 09:07:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 396.4205ms
+        duration: 1.245529125s
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oakwr6xe4BMYWpKL1d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2025-03-13T23:39:29.000Z","created":"2025-03-13T23:39:24.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oauzj9tf9V6RlC361d7","type":"splunk_cloud_logstreaming","name":"testAcc_244785732 Splunk Updated","lastUpdated":"2026-02-13T09:07:19.000Z","created":"2026-02-13T09:07:11.000Z","status":"ACTIVE","settings":{"host":"acme.splunkcloud.com","edition":"aws"},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7","method":"GET"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Mar 2025 23:39:30 GMT
+                - Fri, 13 Feb 2026 09:07:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 248.412209ms
+        duration: 1.236901375s
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -622,40 +502,31 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Thu, 13 Mar 2025 23:39:30 GMT
+                - Fri, 13 Feb 2026 09:07:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 254.929708ms
+        duration: 1.104862458s
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
@@ -663,87 +534,69 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Thu, 13 Mar 2025 23:39:31 GMT
+                - Fri, 13 Feb 2026 09:07:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 394.803291ms
+        duration: 1.104857208s
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr6xe4BMYWpKL1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzj9tf9V6RlC361d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Thu, 13 Mar 2025 23:39:31 GMT
+                - Fri, 13 Feb 2026 09:07:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 350.737292ms
+        duration: 1.150069042s
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: []
-        trailer: {}
         host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oakwr78tjXNFUcrS1d7
+        url: https://oie-00.dne-okta.com/api/v1/logStreams/0oauzjdchbN2joUZw1d7
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
         content_length: 0
-        uncompressed: false
         body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Thu, 13 Mar 2025 23:39:31 GMT
+                - Fri, 13 Feb 2026 09:07:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 885.7165ms
+        duration: 1.727880959s


### PR DESCRIPTION
Fixes #1929 

### Root Cause
The applyLogStreamToState function had two issues:

Settings never written back to state: The function populated a local settings struct from the API response, but never assigned it back to `m.Settings`. The settings values were computed and then discarded.

`m.Settings.As()` fails silently during import: During terraform import, m.Settings is null (no prior state exists), so calling `m.Settings.As(ctx, settings, ...)` to deserialize it does nothing — the settings struct remains zero-valued. This also meant write-only sensitive values like the Splunk HEC token (which the API never returns) could not be preserved.

### Changes
resource_okta_log_stream.go

- Read prior settings safely: Before deserializing from m.Settings, check that it is not null/unknown (handles the import case where no prior state exists).

- Preserve write-only token: When the API response does not include the Splunk HEC token (it's write-only), preserve the value from the prior state to avoid "inconsistent values for sensitive attribute" errors.

- Write settings back to state: After populating the settings struct from the API response, construct a proper `types.Object` and assign it back to `m.Settings`. This is the core fix — without this, the computed settings were never persisted.

- Handle null attribute types during import: When m.Settings is null (import scenario), `m.Settings.AttributeTypes(ctx)` returns nil. Added a fallback that builds the attribute type map explicitly from the schema definition.

###VCR test fixtures
Re-recorded VCR cassettes for TestAccDataSourceOktaLogStream_read and TestAccResourceOktaLogStream_crud (classic and OIE) to match current API responses.

Before Fix: terraform import okta_log_stream.example <id> → settings imported as null → next plan forces replacement
After Fix: terraform import okta_log_stream.example <id> → settings populated correctly (account_id, region, event_source_name for EventBridge; edition, host for Splunk) → next plan shows no changes