### PR TITLE
prevents NPE if token is not set

### DIFF
--- a/okta/config/config.go
+++ b/okta/config/config.go
@@ -232,7 +232,10 @@ func (c *Config) LoadAPIClient() (err error) {
 		Scopes:         c.Scopes,
 	}
 
-	idaasClient, _ := api.NewOktaIDaaSAPIClient(iDaaSConfig)
+	idaasClient, err := api.NewOktaIDaaSAPIClient(iDaaSConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize IDaaS API client: %v", err)
+	}
 	governanceClient, err := api.NewOktaGovernanceAPIClient(iDaaSConfig)
 	if err != nil {
 		return err

--- a/okta/provider/provider.go
+++ b/okta/provider/provider.go
@@ -128,6 +128,14 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	log.Printf("[INFO] Initializing Okta client")
 	cfg := config.NewConfig(d)
+	if cfg.ApiToken == "" && cfg.AccessToken == "" && cfg.PrivateKey == "" {
+		return nil, diag.Errorf(
+			"[ERROR] no Okta credentials provided. Please set one of the following: " +
+				"'api_token' (or OKTA_API_TOKEN env var), " +
+				"'access_token' (or OKTA_ACCESS_TOKEN env var), or " +
+				"'private_key' + 'client_id' (or OKTA_API_PRIVATE_KEY + OKTA_API_CLIENT_ID env vars). " +
+				"See https://registry.terraform.io/providers/okta/okta/latest/docs for more information")
+	}
 	if err := cfg.LoadAPIClient(); err != nil {
 		return nil, diag.Errorf("[ERROR] failed to load sdk clients: %v", err)
 	}

--- a/okta/services/governance/governance_test.go
+++ b/okta/services/governance/governance_test.go
@@ -26,9 +26,14 @@ func init() {
 		}
 	}
 
-	// Initialize the shared governance client
-	t := &testing.T{}
-	governanceAPIClientForTestUtil = GovernanceClientForTest(t)
+	// Initialize the shared governance client only when running acceptance
+	// tests (TF_ACC=1). In unit-test or CI-lint runs where no Okta
+	// credentials are available, skip initialization to avoid a panic from
+	// calling Fatalf on a bare testing.T{}.
+	if os.Getenv("TF_ACC") != "" {
+		t := &testing.T{}
+		governanceAPIClientForTestUtil = GovernanceClientForTest(t)
+	}
 }
 
 // GovernanceClientForTest creates a governance API client for testing

--- a/okta/services/idaas/idaas_test.go
+++ b/okta/services/idaas/idaas_test.go
@@ -47,8 +47,14 @@ func init() {
 			os.Setenv("OKTA_ORG_NAME", os.Getenv("OKTA_VCR_CASSETTE"))
 		}
 	}
-	t := &testing.T{}
-	iDaaSAPIClientForTestUtil = IDaaSClientForTest(t)
+	// Initialize the shared IDaaS client only when running acceptance
+	// tests (TF_ACC=1). In unit-test or CI-lint runs where no Okta
+	// credentials are available, skip initialization to avoid a panic from
+	// calling Fatalf on a bare testing.T{}.
+	if os.Getenv("TF_ACC") != "" {
+		t := &testing.T{}
+		iDaaSAPIClientForTestUtil = IDaaSClientForTest(t)
+	}
 }
 
 // TestMain overridden main testing function. Package level BeforeAll and AfterAll.


### PR DESCRIPTION
Fixes #2588 
### Root Cause
Three contributing defects:

Swallowed error in config.go, silently discarded the error from IDaaS client initialization. When authentication fails, the client is stored as nil.

No credential validation: VerifyCredentials() only validates when [ApiToken != ""]. When no auth method is set at all, verification is silently skipped — the provider appears to start successfully with nil API clients.

Unsafe type assertion in framework_provider.go,`p.PluginSDKProvider.Meta().(*config.Config)` performs a direct type assertion on Meta() which returns nil when the SDK provider failed to configure. This yields a nil [*config.Config pointer that panics on first use.

### Changes
config.go

- Properly handle the error from api.NewOktaIDaaSAPIClient() instead of swallowing it with [_ =].
[provider.go]

- Add early credential validation in providerConfigure() — returns a clear diagnostic error listing all supported authentication methods before attempting to initialize SDK clients.

framework_provider.go

- Add nil check on Meta() return value before type assertion.

- Use safe two-value type assertion ([meta, ok := rawMeta.(*config.Config)] to prevent panics.

- Return descriptive error diagnostics in both failure cases.

governance_test.go & idaas_test.go
Guard test [init()] client initialization behind TF_ACC env var check. These init()( functions call LoadAPIClient() with bare testing.T{} objects and no real credentials — they should only run during acceptance tests.

### Behavior After Fix
Before: terraform plan → panic / crash
After: terraform plan →
```
Error: [ERROR] no Okta credentials provided. Please set one of the following:
'api_token' (or OKTA_API_TOKEN env var), 'access_token' (or OKTA_ACCESS_TOKEN env var),
or 'private_key' + 'client_id' (or OKTA_API_PRIVATE_KEY + OKTA_API_CLIENT_ID env vars).
See https://registry.terraform.io/providers/okta/okta/latest/docs for more information
```