### PR TITLE
adds condition to update DefaultExemptIPZone

### DIFF
--- a/docs/resources/network_zone.md
+++ b/docs/resources/network_zone.md
@@ -48,6 +48,7 @@ resource "okta_network_zone" "example" {
 - `proxies` (Set of String) Array of values in CIDR/range form depending on the way it's been declared (i.e. CIDR will contain /suffix). Please check API docs for examples. Can not be set if `usage` is set to `BLOCKLIST`. Use with type `IP`
 - `status` (String) Network Status - can either be `ACTIVE` or `INACTIVE` only
 - `usage` (String) Usage of the Network Zone - can be either `POLICY` or `BLOCKLIST`. By default, it is `POLICY`
+- `set_usage_as_exempt_list` (Boolean) Set this parameter to true in your request when you update the `DefaultExemptIpZone` to allow IPs through the blocklist.
 
 ### Read-Only
 

--- a/examples/resources/okta_network_zone/basic_issue_2271.tf
+++ b/examples/resources/okta_network_zone/basic_issue_2271.tf
@@ -1,0 +1,12 @@
+resource "okta_network_zone" "default" {
+  name                          = "DefaultExemptIpZone"
+  type                          = "IP"
+  set_usage_as_exempt_list = true
+  usage                         = "POLICY"
+  status                        = "ACTIVE"
+  gateways = [
+            "1.2.3.4/32",    # Cloudflare
+            "4.5.6.7/32",    # Cloudflare
+          ]
+  proxies = []
+}

--- a/examples/resources/okta_network_zone/basic_issue_2271.tf
+++ b/examples/resources/okta_network_zone/basic_issue_2271.tf
@@ -1,12 +1,12 @@
 resource "okta_network_zone" "default" {
-  name                          = "DefaultExemptIpZone"
-  type                          = "IP"
+  name                     = "DefaultExemptIpZone"
+  type                     = "IP"
   set_usage_as_exempt_list = true
-  usage                         = "POLICY"
-  status                        = "ACTIVE"
+  usage                    = "POLICY"
+  status                   = "ACTIVE"
   gateways = [
-            "1.2.3.4/32",    # Cloudflare
-            "4.5.6.7/32",    # Cloudflare
-          ]
+    "1.2.3.4/32", # Cloudflare
+    "4.5.6.7/32", # Cloudflare
+  ]
   proxies = []
 }

--- a/okta/services/idaas/resource_okta_network_zone.go
+++ b/okta/services/idaas/resource_okta_network_zone.go
@@ -101,7 +101,6 @@ func resourceNetworkZone() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Whether to set usage as exempt list. If true, the network zone will be used as an exempt list for policy evaluation. Only applicable to `IP` type zones (specifically `DefaultExemptIpZone`). To manage the built-in `DefaultExemptIpZone`, first import it using `terraform import`.",
-				Default:     false,
 			},
 		},
 	}
@@ -130,17 +129,21 @@ func resourceNetworkZoneCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 	d.SetId(nzID)
 	if d.Get("status").(string) == "ACTIVE" {
-		_, _, err := getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.ActivateNetworkZone(ctx, d.Id()).Execute()
+		zone, _, err = getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.ActivateNetworkZone(ctx, d.Id()).Execute()
 		if err != nil {
 			return diag.Errorf("failed to activate network zone: %v", err)
 		}
 	} else {
-		_, _, err := getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.DeactivateNetworkZone(ctx, d.Id()).Execute()
+		zone, _, err = getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.DeactivateNetworkZone(ctx, d.Id()).Execute()
 		if err != nil {
 			return diag.Errorf("failed to deactivate network zone: %v", err)
 		}
 	}
-	return resourceNetworkZoneRead(ctx, d, meta)
+	err = mapNetworkZoneToState(d, zone)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
 }
 
 func resourceNetworkZoneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -174,24 +177,30 @@ func resourceNetworkZoneUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	_, _, err = getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.ReplaceNetworkZone(ctx, d.Id()).Zone(payload).Execute()
+	updateNZResp, _, err := getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.ReplaceNetworkZone(ctx, d.Id()).Zone(payload).Execute()
 	if err != nil {
 		return diag.Errorf("failed to update network zone: %v", err)
 	}
 	if d.Get("name").(string) != "DefaultExemptIpZone" {
 		if d.Get("status").(string) == "ACTIVE" {
-			_, _, err := getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.ActivateNetworkZone(ctx, d.Id()).Execute()
+			updateNZResp, _, err = getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.ActivateNetworkZone(ctx, d.Id()).Execute()
 			if err != nil {
 				return diag.Errorf("failed to activate network zone: %v", err)
 			}
 		} else {
-			_, _, err := getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.DeactivateNetworkZone(ctx, d.Id()).Execute()
+			updateNZResp, _, err = getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.DeactivateNetworkZone(ctx, d.Id()).Execute()
 			if err != nil {
 				return diag.Errorf("failed to deactivate network zone: %v", err)
 			}
 		}
 	}
-	return resourceNetworkZoneRead(ctx, d, meta)
+	// Read the zone state from the API
+	err = mapNetworkZoneToState(d, updateNZResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// The GET API does not return useAsExemptList, so persist it from the config
+	return nil
 }
 
 func resourceNetworkZoneDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -229,7 +238,9 @@ func buildNetworkZone(d *schema.ResourceData) (v6okta.ListNetworkZones200Respons
 		if status, ok := d.GetOk("status"); ok {
 			ipnz.SetStatus(status.(string))
 		}
-		ipnz.SetUseAsExemptList(d.Get("set_usage_as_exempt_list").(bool))
+		if usageAsExemptList, ok := d.GetOk("set_usage_as_exempt_list"); ok {
+			ipnz.SetUseAsExemptList(usageAsExemptList.(bool))
+		}
 		resp.IPNetworkZone = &ipnz
 		return resp, nil
 	case "DYNAMIC":
@@ -431,7 +442,6 @@ func mapNetworkZoneToState(d *schema.ResourceData, data *v6okta.ListNetworkZones
 		_ = d.Set("type", v.GetType())
 		_ = d.Set("status", v.GetStatus())
 		_ = d.Set("usage", v.GetUsage())
-		_ = d.Set("set_usage_as_exempt_list", v.GetUseAsExemptList())
 		err = utils.SetNonPrimitives(d, map[string]interface{}{
 			"gateways": flattenAddresses(v.GetGateways()),
 			"proxies":  flattenAddresses(v.GetProxies()),

--- a/okta/services/idaas/resource_okta_network_zone_test.go
+++ b/okta/services/idaas/resource_okta_network_zone_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/okta/terraform-provider-okta/okta/acctest"
 	"github.com/okta/terraform-provider-okta/okta/resources"
@@ -108,40 +110,24 @@ func TestAccResourceOktaNetworkZone_issue_2578(t *testing.T) {
 }
 
 func TestAccResourceOktaNetworkZone_issue_2271(t *testing.T) {
-	// Look up the DefaultExemptIpZone ID dynamically — it's a built-in zone
-	// whose ID varies per org.
-	testClient := IDaaSClientForTest(t)
-	v6Client := testClient.OktaSDKClientV6()
-	zones, _, err := v6Client.NetworkZoneAPI.ListNetworkZones(context.Background()).Execute()
-	if err != nil {
-		t.Fatalf("failed to list network zones: %v", err)
-	}
-	var defaultExemptZoneID string
-	for _, z := range zones {
-		if z.IPNetworkZone != nil && z.IPNetworkZone.GetName() == "DefaultExemptIpZone" {
-			defaultExemptZoneID = z.IPNetworkZone.GetId()
-			break
-		}
-	}
-	if defaultExemptZoneID == "" {
-		t.Skip("DefaultExemptIpZone not found on this org, skipping test")
-	}
-
 	mgr := newFixtureManager("resources", resources.OktaIDaaSNetworkZone, t.Name())
 	config := mgr.GetFixtures("basic_issue_2271.tf", t)
+	// DefaultExemptIpZone is a built-in zone; we don't want CheckDestroy to
+	// fail when it still exists after the test, so use a no-op.
 	acctest.OktaResourceTest(t, resource.TestCase{
 		PreCheck:                 acctest.AccPreCheck(t),
 		ErrorCheck:               testAccErrorChecks(t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
-		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSNetworkZone, doesNetworkZoneExist),
+		CheckDestroy: func(state *terraform.State) error {
+			return nil
+		},
 		Steps: []resource.TestStep{
 			{
 				ImportState:        true,
 				ResourceName:       "okta_network_zone.default",
-				ImportStateId:      defaultExemptZoneID,
+				ImportStateId:      "nzotivlj3iItmtmnC1d7",
 				ImportStatePersist: true,
 				Config:             config,
-				PlanOnly:           true,
 			},
 			{
 				Config: config,

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaAppSignOnPolicyRule_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaAppSignOnPolicyRule_crud/classic-00.yaml
@@ -28,19 +28,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:18 GMT
+                - Wed, 18 Feb 2026 06:27:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.191236917s
+        duration: 1.984676834s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,12 +67,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:19 GMT
+                - Wed, 18 Feb 2026 06:27:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.043655042s
+        duration: 1.061816583s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"rstqq6ctn3WGXVqOm1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnaTuxncHq1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctndu1ew1qH1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnn8tuHBCM1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-10-07T06:36:59.000Z","lastUpdated":"2025-10-07T06:36:59.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctoglghkrHd1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:37:00.000Z","lastUpdated":"2025-10-07T06:37:00.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstrbe37w6NqDQtPR1d7","status":"ACTIVE","name":"Test Auth Policy 2 99901f4a-7865-4ece-a040-5c80537af9a4","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:49:07.000Z","lastUpdated":"2025-10-27T05:49:07.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeayf8TR9pqoD1d7","status":"ACTIVE","name":"Test Auth Policy 2 f74c8f29-5a1e-4d05-a08d-1462b49f96fc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:55:40.000Z","lastUpdated":"2025-10-27T05:55:40.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeegmpEjTf4xT1d7","status":"ACTIVE","name":"Test Auth Policy 2 0a4e7223-0ab9-4fa9-8b27-1e32d010b75f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:03:37.000Z","lastUpdated":"2025-10-27T06:03:37.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeo0d5bJl3g2O1d7","status":"ACTIVE","name":"Test Auth Policy 2 f9858ccb-493c-4d66-bd82-92dd4472efdc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:07:53.000Z","lastUpdated":"2025-10-27T06:07:53.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbf6tm2Bu9as9i1d7","status":"ACTIVE","name":"Test Auth Policy 2 f8276bf4-da87-43a0-a7c8-12feb003f565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:39:29.000Z","lastUpdated":"2025-10-27T06:39:29.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbffb2f8tLHhF51d7","status":"ACTIVE","name":"Test Auth Policy 2 58d68e55-6ca3-43e9-9537-49ed89fcc565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:48:32.000Z","lastUpdated":"2025-10-27T06:48:32.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbfjy846B3JtSW1d7","status":"ACTIVE","name":"Test Auth Policy 2 e36db953-7ef5-48ae-a9aa-bdc4c60d6697","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:52:16.000Z","lastUpdated":"2025-10-27T06:52:16.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbgd0utDtfjlrL1d7","status":"ACTIVE","name":"Test Auth Policy 2 ab0a7b85-ea65-47e1-811a-e06bcdf01143","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T07:13:13.000Z","lastUpdated":"2025-10-27T07:13:13.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbi7x9vn2vEmmr1d7","status":"ACTIVE","name":"Test Auth Policy 2 f395fe41-738f-4e18-b887-744eace24a6f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T08:22:54.000Z","lastUpdated":"2025-10-27T08:22:54.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrc8xldw9LwyuRj1d7","status":"ACTIVE","name":"Test Auth Policy 2 d6cb2e3b-685e-40b7-a220-2ab6213e1079","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T03:16:39.000Z","lastUpdated":"2025-10-28T03:16:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrcfjxduMxckk2y1d7","status":"ACTIVE","name":"Test Auth Policy 2 4a9ba426-0875-41b3-bca4-7385395604de","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T08:49:42.000Z","lastUpdated":"2025-10-28T08:49:42.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsaecoc1xOZYK5Z1d7","status":"ACTIVE","name":"Test Auth Policy 2 4d1c6630-85fa-4244-ae97-6a1b8aa1bf6d","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-02T05:55:20.000Z","lastUpdated":"2025-12-02T05:55:20.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstse090ssxEaNo7v1d7","status":"ACTIVE","name":"Test Auth Policy 2 6dae9a9a-4215-4604-a092-efa95469804e","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-05T04:13:12.000Z","lastUpdated":"2025-12-05T04:13:12.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsm94o12ejDiKmx1d7","status":"ACTIVE","name":"Test Auth Policy 2 a2c5e453-ff38-4a98-87c8-c0bd29442210","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-12T05:01:06.000Z","lastUpdated":"2025-12-12T05:01:06.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy4qpkf2zJl6wZ1d7","status":"ACTIVE","name":"Test Auth Policy 1714c80e-6f10-4bf3-a95b-35a7c16ceed8","description":"Test policy for ApplicationPoliciesApi integration tests","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:04:42.000Z","lastUpdated":"2025-12-22T08:04:42.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy5dc98cxHjulg1d7","status":"ACTIVE","name":"Test Auth Policy 2 dafe5b5a-40d3-4fe6-b841-2159d08bceb8","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:18:01.000Z","lastUpdated":"2025-12-22T08:18:01.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnpev3cs1vzqw61d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T02:00:23.000Z","lastUpdated":"2026-01-09T02:00:23.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
+        body: '[{"id":"rstqq6ctn3WGXVqOm1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnaTuxncHq1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctndu1ew1qH1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnn8tuHBCM1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-10-07T06:36:59.000Z","lastUpdated":"2025-10-07T06:36:59.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctoglghkrHd1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:37:00.000Z","lastUpdated":"2025-10-07T06:37:00.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstrbe37w6NqDQtPR1d7","status":"ACTIVE","name":"Test Auth Policy 2 99901f4a-7865-4ece-a040-5c80537af9a4","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:49:07.000Z","lastUpdated":"2025-10-27T05:49:07.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeayf8TR9pqoD1d7","status":"ACTIVE","name":"Test Auth Policy 2 f74c8f29-5a1e-4d05-a08d-1462b49f96fc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:55:40.000Z","lastUpdated":"2025-10-27T05:55:40.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeegmpEjTf4xT1d7","status":"ACTIVE","name":"Test Auth Policy 2 0a4e7223-0ab9-4fa9-8b27-1e32d010b75f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:03:37.000Z","lastUpdated":"2025-10-27T06:03:37.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeo0d5bJl3g2O1d7","status":"ACTIVE","name":"Test Auth Policy 2 f9858ccb-493c-4d66-bd82-92dd4472efdc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:07:53.000Z","lastUpdated":"2025-10-27T06:07:53.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbf6tm2Bu9as9i1d7","status":"ACTIVE","name":"Test Auth Policy 2 f8276bf4-da87-43a0-a7c8-12feb003f565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:39:29.000Z","lastUpdated":"2025-10-27T06:39:29.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbffb2f8tLHhF51d7","status":"ACTIVE","name":"Test Auth Policy 2 58d68e55-6ca3-43e9-9537-49ed89fcc565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:48:32.000Z","lastUpdated":"2025-10-27T06:48:32.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbfjy846B3JtSW1d7","status":"ACTIVE","name":"Test Auth Policy 2 e36db953-7ef5-48ae-a9aa-bdc4c60d6697","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:52:16.000Z","lastUpdated":"2025-10-27T06:52:16.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbgd0utDtfjlrL1d7","status":"ACTIVE","name":"Test Auth Policy 2 ab0a7b85-ea65-47e1-811a-e06bcdf01143","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T07:13:13.000Z","lastUpdated":"2025-10-27T07:13:13.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbi7x9vn2vEmmr1d7","status":"ACTIVE","name":"Test Auth Policy 2 f395fe41-738f-4e18-b887-744eace24a6f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T08:22:54.000Z","lastUpdated":"2025-10-27T08:22:54.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrc8xldw9LwyuRj1d7","status":"ACTIVE","name":"Test Auth Policy 2 d6cb2e3b-685e-40b7-a220-2ab6213e1079","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T03:16:39.000Z","lastUpdated":"2025-10-28T03:16:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrcfjxduMxckk2y1d7","status":"ACTIVE","name":"Test Auth Policy 2 4a9ba426-0875-41b3-bca4-7385395604de","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T08:49:42.000Z","lastUpdated":"2025-10-28T08:49:42.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsaecoc1xOZYK5Z1d7","status":"ACTIVE","name":"Test Auth Policy 2 4d1c6630-85fa-4244-ae97-6a1b8aa1bf6d","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-02T05:55:20.000Z","lastUpdated":"2025-12-02T05:55:20.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstse090ssxEaNo7v1d7","status":"ACTIVE","name":"Test Auth Policy 2 6dae9a9a-4215-4604-a092-efa95469804e","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-05T04:13:12.000Z","lastUpdated":"2025-12-05T04:13:12.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsm94o12ejDiKmx1d7","status":"ACTIVE","name":"Test Auth Policy 2 a2c5e453-ff38-4a98-87c8-c0bd29442210","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-12T05:01:06.000Z","lastUpdated":"2025-12-12T05:01:06.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy4qpkf2zJl6wZ1d7","status":"ACTIVE","name":"Test Auth Policy 1714c80e-6f10-4bf3-a95b-35a7c16ceed8","description":"Test policy for ApplicationPoliciesApi integration tests","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:04:42.000Z","lastUpdated":"2025-12-22T08:04:42.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy5dc98cxHjulg1d7","status":"ACTIVE","name":"Test Auth Policy 2 dafe5b5a-40d3-4fe6-b841-2159d08bceb8","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:18:01.000Z","lastUpdated":"2025-12-22T08:18:01.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnpev3cs1vzqw61d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T02:00:23.000Z","lastUpdated":"2026-01-09T02:00:23.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstu97sepplf0tzbS1d7","status":"ACTIVE","name":"Test Auth Policy 2 d427ec6e-3b9a-4dae-9fa3-66d0026a5369","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-01-27T06:56:38.000Z","lastUpdated":"2026-01-27T06:56:38.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstu97wjg9HCleLI01d7","status":"ACTIVE","name":"Test Auth Policy 2 31ea56b2-24ec-4e84-8247-c72401a4aedb","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-01-27T07:20:58.000Z","lastUpdated":"2026-01-27T07:20:58.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstu97yj7qQa6gDWq1d7","status":"ACTIVE","name":"Test Auth Policy 2 83aa828e-c8ff-44ad-9814-62ab45f0f2ae","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-01-27T07:09:55.000Z","lastUpdated":"2026-01-27T07:09:55.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstut5tbb0pDGWlxz1d7","status":"ACTIVE","name":"Test Auth Policy 2 b84e0b97-5379-4403-923d-fe80a7bcc85b","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-09T11:10:30.000Z","lastUpdated":"2026-02-09T11:10:30.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstuvw9da2J07oWLK1d7","status":"ACTIVE","name":"Test Auth Policy 2 4299e620-4b2a-4cf0-842b-fd29c673768a","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-11T06:38:46.000Z","lastUpdated":"2026-02-11T06:38:46.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstuw62fxiR11MJ3d1d7","status":"ACTIVE","name":"Test Auth Policy 2 ea7af3dd-879f-4bfb-a3e2-45fefac8e463","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-11T11:18:07.000Z","lastUpdated":"2026-02-11T11:18:07.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstuw8sqzpsXBq1gR1d7","status":"ACTIVE","name":"Test Auth Policy 2 dccdbbd3-4f15-42fd-9e04-b75c2af0c7e8","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-11T12:09:24.000Z","lastUpdated":"2026-02-11T12:09:24.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:20 GMT
+                - Wed, 18 Feb 2026 06:27:41 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.160849458s
+        duration: 1.158992292s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies/rstqq6ctnn8tuHBCM1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies/rstqq6ctnn8tuHBCM1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -135,12 +135,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:52:22 GMT
+                - Wed, 18 Feb 2026 06:27:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.160596042s
+        duration: 1.29714175s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:23 GMT
+                - Wed, 18 Feb 2026 06:27:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.278058375s
+        duration: 1.124902875s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,13 +183,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+                - Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata?kid=pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata?kid=Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,23 +197,23 @@ interactions:
         proto_minor: 0
         content_length: 2689
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52l54bjfZxldW1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4uf7oo8rtYU3h1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJ
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJ
             BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
             CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
             Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbH
-            MwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g
-            4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhw
-            Q285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHj
-            elJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8
-            fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgM
-            CZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3
-            RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+z
-            pgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4
+            aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+M
+            uCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gG
+            a36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbF
+            CXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVu
+            i+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5
+            tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG
+            6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ2
+            6kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -222,12 +222,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:52:24 GMT
+                - Wed, 18 Feb 2026 06:27:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.230795209s
+        duration: 1.3488325s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -248,19 +248,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:52:17.000Z","lastUpdated":"2026-01-23T08:52:17.000Z","expiresAt":"2036-01-23T08:52:17.000Z","kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbHMwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhwQ285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHjelJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgMCZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+zpgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs="],"x5t#S256":"QyOo6-itmIWDlemNc6br_DY8epoedx5rijdmiRyUJKs","e":"AQAB","n":"rlaXBKpF3z26InG2Y3xXzGBqTsyzqNlOCltoDnkSfat6I4rCgtz2pjzq5p_ybQyWxzMHR5GO0aXOSu2NgJYBIj7hwfilU6QMiiKRM1ToLhByST07TRcoFvPOux4EYt8PsdWeWzmSysp9IOD678GGokz741pKvjcSou2wohv-7_m1McaB7rvI4LVTNO-K2JGh6t5djvmCfE79FSP-LoJWrYJ4cENvOX8fI1fLOgc48o-hQWJAjrz_L3cIizzkJHC_n-hC-i46juCXuMl_OCG_4i04462_tfuJsPpB43pSRpEgPLSvV-DLEyZXETVBtf8O-Ca5tAdy-nCbcbjm7uYkgQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:27:38.000Z","lastUpdated":"2026-02-18T06:27:38.000Z","expiresAt":"2036-02-18T06:27:38.000Z","kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+MuCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gGa36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbFCXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVui+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ26kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w="],"x5t#S256":"g-r2RiaaWWBSnZL256ZbwUrGyVZVXZtkP6kdERvKOt8","e":"AQAB","n":"31odbMczYi3vFCPcDMYS8A6DL0FtPdiOWlYHFvQCk3giovSRhQTssUuuXzQWzsUBuGiQ2N3wJ01dyYol7XMbv2oSkOZ5Jkwu5l7SacMSx15MUKL-T0xotJEqivkBvAbxlxD2vgV5U6rfjLgr9jtGRO8G7r03oWgg1odBKoDdmvQAGF05Hf4tCgs75ZuslSStO030nTd_mND6n_zwVEImoN_4Bmt-m3B91KNw-BPQ7lyO96NHeB0Hor2IIas93fIbfuqXHGBWDiNUBVMmShZT-jm2xxPY_R6eX6LWxQlxnSXlK6vfZ7w2qN7nnsJhmYImrtNWlJ5cZ7DlgYUwrR9r6w"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:25 GMT
+                - Wed, 18 Feb 2026 06:27:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.2167055s
+        duration: 1.376183375s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -273,7 +273,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -281,19 +281,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:26 GMT
+                - Wed, 18 Feb 2026 06:27:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.104646542s
+        duration: 1.136958041s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -321,12 +321,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:27 GMT
+                - Wed, 18 Feb 2026 06:27:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.051816708s
+        duration: 1.208865583s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -351,19 +351,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:52:29.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:27:50.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:29 GMT
+                - Wed, 18 Feb 2026 06:27:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.199592958s
+        duration: 1.417328208s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -376,7 +376,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -384,19 +384,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:52:29.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:27:50.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:30 GMT
+                - Wed, 18 Feb 2026 06:27:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.053718791s
+        duration: 1.230683208s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -409,7 +409,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -417,19 +417,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:31 GMT
+                - Wed, 18 Feb 2026 06:27:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.073492791s
+        duration: 1.119093083s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -457,12 +457,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:32 GMT
+                - Wed, 18 Feb 2026 06:27:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.056927625s
+        duration: 1.104157541s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -475,7 +475,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -483,19 +483,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:33 GMT
+                - Wed, 18 Feb 2026 06:27:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.085650167s
+        duration: 1.26357225s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -505,13 +505,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+                - Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata?kid=pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata?kid=Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,23 +519,23 @@ interactions:
         proto_minor: 0
         content_length: 2689
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52l54bjfZxldW1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4uf7oo8rtYU3h1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJ
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJ
             BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
             CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
             Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbH
-            MwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g
-            4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhw
-            Q285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHj
-            elJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8
-            fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgM
-            CZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3
-            RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+z
-            pgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4
+            aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+M
+            uCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gG
+            a36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbF
+            CXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVu
+            i+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5
+            tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG
+            6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ2
+            6kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -544,12 +544,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:52:34 GMT
+                - Wed, 18 Feb 2026 06:27:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.333120875s
+        duration: 1.524781084s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,19 +570,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:52:17.000Z","lastUpdated":"2026-01-23T08:52:17.000Z","expiresAt":"2036-01-23T08:52:17.000Z","kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbHMwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhwQ285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHjelJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgMCZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+zpgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs="],"x5t#S256":"QyOo6-itmIWDlemNc6br_DY8epoedx5rijdmiRyUJKs","e":"AQAB","n":"rlaXBKpF3z26InG2Y3xXzGBqTsyzqNlOCltoDnkSfat6I4rCgtz2pjzq5p_ybQyWxzMHR5GO0aXOSu2NgJYBIj7hwfilU6QMiiKRM1ToLhByST07TRcoFvPOux4EYt8PsdWeWzmSysp9IOD678GGokz741pKvjcSou2wohv-7_m1McaB7rvI4LVTNO-K2JGh6t5djvmCfE79FSP-LoJWrYJ4cENvOX8fI1fLOgc48o-hQWJAjrz_L3cIizzkJHC_n-hC-i46juCXuMl_OCG_4i04462_tfuJsPpB43pSRpEgPLSvV-DLEyZXETVBtf8O-Ca5tAdy-nCbcbjm7uYkgQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:27:38.000Z","lastUpdated":"2026-02-18T06:27:38.000Z","expiresAt":"2036-02-18T06:27:38.000Z","kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+MuCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gGa36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbFCXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVui+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ26kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w="],"x5t#S256":"g-r2RiaaWWBSnZL256ZbwUrGyVZVXZtkP6kdERvKOt8","e":"AQAB","n":"31odbMczYi3vFCPcDMYS8A6DL0FtPdiOWlYHFvQCk3giovSRhQTssUuuXzQWzsUBuGiQ2N3wJ01dyYol7XMbv2oSkOZ5Jkwu5l7SacMSx15MUKL-T0xotJEqivkBvAbxlxD2vgV5U6rfjLgr9jtGRO8G7r03oWgg1odBKoDdmvQAGF05Hf4tCgs75ZuslSStO030nTd_mND6n_zwVEImoN_4Bmt-m3B91KNw-BPQ7lyO96NHeB0Hor2IIas93fIbfuqXHGBWDiNUBVMmShZT-jm2xxPY_R6eX6LWxQlxnSXlK6vfZ7w2qN7nnsJhmYImrtNWlJ5cZ7DlgYUwrR9r6w"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:36 GMT
+                - Wed, 18 Feb 2026 06:27:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.657389542s
+        duration: 1.255832125s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -595,7 +595,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -603,19 +603,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:37 GMT
+                - Wed, 18 Feb 2026 06:27:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.094185959s
+        duration: 1.119165917s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -643,12 +643,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:38 GMT
+                - Wed, 18 Feb 2026 06:28:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.40680425s
+        duration: 1.150917417s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -661,7 +661,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -669,19 +669,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:52:29.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:27:50.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:40 GMT
+                - Wed, 18 Feb 2026 06:28:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.044939958s
+        duration: 1.079827292s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -694,7 +694,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -702,19 +702,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:41 GMT
+                - Wed, 18 Feb 2026 06:28:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.065840209s
+        duration: 1.212510125s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -742,12 +742,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:42 GMT
+                - Wed, 18 Feb 2026 06:28:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.065229333s
+        duration: 1.099755959s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -768,19 +768,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:43 GMT
+                - Wed, 18 Feb 2026 06:28:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.055161375s
+        duration: 1.210775833s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -793,7 +793,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -801,19 +801,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:43 GMT
+                - Wed, 18 Feb 2026 06:28:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081874375s
+        duration: 1.209995625s
     - id: 23
       request:
         proto: HTTP/1.1
@@ -823,13 +823,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+                - Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata?kid=pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata?kid=Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         method: GET
       response:
         proto: HTTP/2.0
@@ -837,23 +837,23 @@ interactions:
         proto_minor: 0
         content_length: 2689
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52l54bjfZxldW1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4uf7oo8rtYU3h1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJ
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJ
             BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
             CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
             Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbH
-            MwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g
-            4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhw
-            Q285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHj
-            elJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8
-            fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgM
-            CZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3
-            RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+z
-            pgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4
+            aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+M
+            uCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gG
+            a36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbF
+            CXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVu
+            i+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5
+            tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG
+            6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ2
+            6kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -862,12 +862,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:52:45 GMT
+                - Wed, 18 Feb 2026 06:28:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.745714542s
+        duration: 1.246073542s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -880,7 +880,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -888,19 +888,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:52:17.000Z","lastUpdated":"2026-01-23T08:52:17.000Z","expiresAt":"2036-01-23T08:52:17.000Z","kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbHMwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhwQ285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHjelJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgMCZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+zpgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs="],"x5t#S256":"QyOo6-itmIWDlemNc6br_DY8epoedx5rijdmiRyUJKs","e":"AQAB","n":"rlaXBKpF3z26InG2Y3xXzGBqTsyzqNlOCltoDnkSfat6I4rCgtz2pjzq5p_ybQyWxzMHR5GO0aXOSu2NgJYBIj7hwfilU6QMiiKRM1ToLhByST07TRcoFvPOux4EYt8PsdWeWzmSysp9IOD678GGokz741pKvjcSou2wohv-7_m1McaB7rvI4LVTNO-K2JGh6t5djvmCfE79FSP-LoJWrYJ4cENvOX8fI1fLOgc48o-hQWJAjrz_L3cIizzkJHC_n-hC-i46juCXuMl_OCG_4i04462_tfuJsPpB43pSRpEgPLSvV-DLEyZXETVBtf8O-Ca5tAdy-nCbcbjm7uYkgQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:27:38.000Z","lastUpdated":"2026-02-18T06:27:38.000Z","expiresAt":"2036-02-18T06:27:38.000Z","kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+MuCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gGa36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbFCXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVui+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ26kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w="],"x5t#S256":"g-r2RiaaWWBSnZL256ZbwUrGyVZVXZtkP6kdERvKOt8","e":"AQAB","n":"31odbMczYi3vFCPcDMYS8A6DL0FtPdiOWlYHFvQCk3giovSRhQTssUuuXzQWzsUBuGiQ2N3wJ01dyYol7XMbv2oSkOZ5Jkwu5l7SacMSx15MUKL-T0xotJEqivkBvAbxlxD2vgV5U6rfjLgr9jtGRO8G7r03oWgg1odBKoDdmvQAGF05Hf4tCgs75ZuslSStO030nTd_mND6n_zwVEImoN_4Bmt-m3B91KNw-BPQ7lyO96NHeB0Hor2IIas93fIbfuqXHGBWDiNUBVMmShZT-jm2xxPY_R6eX6LWxQlxnSXlK6vfZ7w2qN7nnsJhmYImrtNWlJ5cZ7DlgYUwrR9r6w"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:46 GMT
+                - Wed, 18 Feb 2026 06:28:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.35205225s
+        duration: 1.367878s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -913,7 +913,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -921,19 +921,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:47 GMT
+                - Wed, 18 Feb 2026 06:28:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.078083375s
+        duration: 1.123975208s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -961,12 +961,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:49 GMT
+                - Wed, 18 Feb 2026 06:28:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.246313917s
+        duration: 1.13365275s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -979,7 +979,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -987,19 +987,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:52:29.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:27:50.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:52 GMT
+                - Wed, 18 Feb 2026 06:28:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.156439291s
+        duration: 1.150901375s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1020,19 +1020,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:53 GMT
+                - Wed, 18 Feb 2026 06:28:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.084185709s
+        duration: 1.170639s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1045,7 +1045,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1053,19 +1053,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:53 GMT
+                - Wed, 18 Feb 2026 06:28:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.088592167s
+        duration: 1.217388s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1093,12 +1093,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:54 GMT
+                - Wed, 18 Feb 2026 06:28:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.191539125s
+        duration: 1.241894541s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1123,19 +1123,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52q4uiAgArO271d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/apps"}}}'
+        body: '{"id":"00gv4ukfyjrMWxXR71d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:56 GMT
+                - Wed, 18 Feb 2026 06:28:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.679914333s
+        duration: 1.126293625s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1160,57 +1160,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou52za2zfPh8P5J1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uks9ktI1f7gf1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:56 GMT
+                - Wed, 18 Feb 2026 06:28:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.684559833s
+        duration: 1.128105791s
     - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 59
-        host: classic-00.dne-okta.com
-        body: |
-            {"profile":{"name":"testAcc_1","description":"testAcc_1"}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/groups
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu535xoiua0Hr651d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:56 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.689464125s
-    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1234,131 +1197,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy3xd8fsnMx1d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/apps"}}}'
+        body: '{"id":"00gv4ukkesYNfL3wR1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:56 GMT
+                - Wed, 18 Feb 2026 06:28:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.698093334s
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: classic-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_4@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_4@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52tcjhrztgtdP1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:56 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.020970542s
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: classic-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_0@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_0@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52sjwtMsTlytc1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:56 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.043942708s
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: classic-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_3@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_3@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52nmndk6dvysl1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:56 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.3326525s
-    - id: 38
+        duration: 1.133328584s
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1382,605 +1234,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52t7hnp5dKTQI1d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:52:57.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:52:57.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52t7hnp5dKTQI1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4uiu1hyRiGbmL1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:28:14.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:28:14.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4uiu1hyRiGbmL1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
+                - Wed, 18 Feb 2026 06:28:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.514080542s
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 149
-        host: classic-00.dne-okta.com
-        body: |
-            {"description":"Terraform Acceptance Test User Type Updated","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/meta/types/user
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.515598833s
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu535xoiua0Hr651d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.037386625s
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/activate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou52za2zfPh8P5J1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.0465195s
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52xy3xd8fsnMx1d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.06319s
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: classic-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_1@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_1@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52odicFkJMMxO1d7","status":"PROVISIONED","created":"2026-01-23T08:52:57.000Z","activated":"2026-01-23T08:52:57.000Z","statusChanged":"2026-01-23T08:52:57.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:57.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.837382958s
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52q4uiAgArO271d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.305854833s
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52tcjhrztgtdP1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.245425625s
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52sjwtMsTlytc1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:57 GMT
-            Etag:
-                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.223142458s
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.0500225s
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52nmndk6dvysl1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Etag:
-                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.243642541s
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu535xoiua0Hr651d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.048387584s
-    - id: 50
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou52za2zfPh8P5J1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.062450584s
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52xy3xd8fsnMx1d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.043442333s
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52q4uiAgArO271d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.049653334s
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: classic-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_2@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_2@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52l3j7T3fA1tu1d7","status":"PROVISIONED","created":"2026-01-23T08:52:58.000Z","activated":"2026-01-23T08:52:58.000Z","statusChanged":"2026-01-23T08:52:58.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:58.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.516079375s
-    - id: 54
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52odicFkJMMxO1d7","status":"PROVISIONED","created":"2026-01-23T08:52:57.000Z","activated":"2026-01-23T08:52:57.000Z","statusChanged":"2026-01-23T08:52:57.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:57.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Etag:
-                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.231740416s
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 59
-        host: classic-00.dne-okta.com
-        body: |
-            {"profile":{"name":"testAcc_4","description":"testAcc_4"}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/groups
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52xy45BWpDKip1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.040415583s
-    - id: 56
+        duration: 1.140347s
+    - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2004,20 +1271,205 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52sgmrt1YxzdR1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/apps"}}}'
+        body: '{"id":"00gv4uf39pI2Vz6PI1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:58 GMT
+                - Wed, 18 Feb 2026 06:28:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.058384292s
-    - id: 57
+        duration: 1.141272s
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 149
+        host: classic-00.dne-okta.com
+        body: |
+            {"description":"Terraform Acceptance Test User Type Updated","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/meta/types/user
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.146158333s
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: classic-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_0@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_0@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4ullloJAYoWpe1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.552852584s
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: classic-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_1@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_1@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uglbb5wjWFUv1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.560730042s
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: classic-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_3@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_3@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4ujme479FZDyw1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.563799583s
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: classic-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_2@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_2@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uks9l59iQGLj1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.594684375s
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2029,7 +1481,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2037,21 +1489,567 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52l3j7T3fA1tu1d7","status":"PROVISIONED","created":"2026-01-23T08:52:58.000Z","activated":"2026-01-23T08:52:58.000Z","statusChanged":"2026-01-23T08:52:58.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:58.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4ukkesYNfL3wR1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:52:59 GMT
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.065299834s
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uf39pI2Vz6PI1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.066246625s
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4uks9ktI1f7gf1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.084235333s
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.071386291s
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ukfyjrMWxXR71d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.096597625s
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 59
+        host: classic-00.dne-okta.com
+        body: |
+            {"profile":{"name":"testAcc_1","description":"testAcc_1"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ujtegSywpFLd1d7","created":"2026-02-18T06:28:15.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","lastMembershipUpdated":"2026-02-18T06:28:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.109587375s
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4ullloJAYoWpe1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
+            Etag:
+                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.146705833s
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4ujme479FZDyw1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
+            Etag:
+                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.150412459s
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uglbb5wjWFUv1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
+            Etag:
+                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.311174125s
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uks9l59iQGLj1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
             Etag:
                 - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.060284125s
+        duration: 1.2831205s
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ukkesYNfL3wR1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.067485709s
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uf39pI2Vz6PI1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.07238975s
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ukfyjrMWxXR71d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.059151458s
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4uks9ktI1f7gf1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.088528084s
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ujtegSywpFLd1d7","created":"2026-02-18T06:28:15.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","lastMembershipUpdated":"2026-02-18T06:28:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:17 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.057659875s
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: classic-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_4@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_4@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uknjwViT79Hd1d7","status":"PROVISIONED","created":"2026-02-18T06:28:16.000Z","activated":"2026-02-18T06:28:17.000Z","statusChanged":"2026-02-18T06:28:17.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:17.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:17 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.424848834s
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 59
+        host: classic-00.dne-okta.com
+        body: |
+            {"profile":{"name":"testAcc_4","description":"testAcc_4"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uglc9DM1imfL1d7","created":"2026-02-18T06:28:17.000Z","lastUpdated":"2026-02-18T06:28:17.000Z","lastMembershipUpdated":"2026-02-18T06:28:17.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:17 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.072467667s
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2064,7 +2062,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2072,19 +2070,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy45BWpDKip1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/apps"}}}'
+        body: '{"id":"00gv4ujtegSywpFLd1d7","created":"2026-02-18T06:28:15.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","lastMembershipUpdated":"2026-02-18T06:28:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:00 GMT
+                - Wed, 18 Feb 2026 06:28:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.042059666s
+        duration: 1.111869458s
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2097,7 +2095,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2105,19 +2103,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52sgmrt1YxzdR1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/apps"}}}'
+        body: '{"id":"00gv4uglc9DM1imfL1d7","created":"2026-02-18T06:28:17.000Z","lastUpdated":"2026-02-18T06:28:17.000Z","lastMembershipUpdated":"2026-02-18T06:28:17.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:00 GMT
+                - Wed, 18 Feb 2026 06:28:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.063488083s
+        duration: 1.09662s
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2130,7 +2128,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2138,19 +2136,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52sgmrt1YxzdR1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/apps"}}}'
+        body: '{"id":"00uv4uknjwViT79Hd1d7","status":"PROVISIONED","created":"2026-02-18T06:28:16.000Z","activated":"2026-02-18T06:28:17.000Z","statusChanged":"2026-02-18T06:28:17.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:17.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:01 GMT
+                - Wed, 18 Feb 2026 06:28:18 GMT
+            Etag:
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.720328833s
+        duration: 1.270034125s
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2163,7 +2163,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2171,19 +2171,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy45BWpDKip1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/apps"}}}'
+        body: '{"id":"00gv4uglc9DM1imfL1d7","created":"2026-02-18T06:28:17.000Z","lastUpdated":"2026-02-18T06:28:17.000Z","lastMembershipUpdated":"2026-02-18T06:28:17.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:01 GMT
+                - Wed, 18 Feb 2026 06:28:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.7732245s
+        duration: 1.181594542s
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2192,7 +2192,7 @@ interactions:
         content_length: 1513
         host: classic-00.dne-okta.com
         body: |
-            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","inactivityPeriod":"PT2H","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"people":{"groups":{"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"],"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"]},"users":{"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"],"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyu52xy42Me1XmVh1d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
+            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","inactivityPeriod":"PT2H","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"people":{"groups":{"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"],"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"]},"users":{"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"],"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyv4ugj12DEiBAiD1d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
         headers:
             Accept:
                 - application/json
@@ -2200,7 +2200,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2208,19 +2208,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:03.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:21.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:03 GMT
+                - Wed, 18 Feb 2026 06:28:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.437691958s
+        duration: 1.373278916s
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2233,7 +2233,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2241,19 +2241,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:03.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:21.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:07 GMT
+                - Wed, 18 Feb 2026 06:28:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 3.817456583s
+        duration: 1.081331375s
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2274,19 +2274,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:09 GMT
+                - Wed, 18 Feb 2026 06:28:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.552395292s
+        duration: 1.100114333s
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2299,7 +2299,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2307,19 +2307,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:10 GMT
+                - Wed, 18 Feb 2026 06:28:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 3.705884833s
+        duration: 1.099093458s
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2347,12 +2347,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:12 GMT
+                - Wed, 18 Feb 2026 06:28:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.678087417s
+        duration: 1.115091375s
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2365,7 +2365,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2373,19 +2373,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52t7hnp5dKTQI1d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:52:57.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:52:57.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52t7hnp5dKTQI1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uks9ktI1f7gf1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.038637167s
+        duration: 1.066978834s
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2398,7 +2398,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2406,19 +2406,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52sgmrt1YxzdR1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/apps"}}}'
+        body: '{"id":"00gv4uf39pI2Vz6PI1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.042929708s
+        duration: 1.07149175s
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2431,7 +2431,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2439,19 +2439,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou52za2zfPh8P5J1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"00gv4uglc9DM1imfL1d7","created":"2026-02-18T06:28:17.000Z","lastUpdated":"2026-02-18T06:28:17.000Z","lastMembershipUpdated":"2026-02-18T06:28:17.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.045495209s
+        duration: 1.072259667s
     - id: 70
       request:
         proto: HTTP/1.1
@@ -2464,7 +2464,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2472,19 +2472,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}'
+        body: '{"id":"00gv4ukfyjrMWxXR71d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.045740042s
+        duration: 1.075319291s
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2497,7 +2497,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7
+        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2505,19 +2505,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy3xd8fsnMx1d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/apps"}}}'
+        body: '{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.047154875s
+        duration: 1.076594792s
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2530,7 +2530,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2538,19 +2538,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52q4uiAgArO271d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/apps"}}}'
+        body: '{"id":"00gv4ujtegSywpFLd1d7","created":"2026-02-18T06:28:15.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","lastMembershipUpdated":"2026-02-18T06:28:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.056457041s
+        duration: 1.07891425s
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2563,7 +2563,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7
+        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2571,19 +2571,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy45BWpDKip1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/apps"}}}'
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4uiu1hyRiGbmL1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:28:14.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:28:14.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4uiu1hyRiGbmL1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.062551208s
+        duration: 1.081274875s
     - id: 74
       request:
         proto: HTTP/1.1
@@ -2596,7 +2596,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2604,53 +2604,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:13 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.100690792s
+        duration: 1.081921s
     - id: 75
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu535xoiua0Hr651d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:53:14 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.807172667s
-    - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2670,20 +2637,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:14 GMT
+                - Wed, 18 Feb 2026 06:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.839138625s
-    - id: 77
+        duration: 1.095443333s
+    - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2695,7 +2662,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2703,21 +2670,73 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52l3j7T3fA1tu1d7","status":"PROVISIONED","created":"2026-01-23T08:52:58.000Z","activated":"2026-01-23T08:52:58.000Z","statusChanged":"2026-01-23T08:52:58.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:58.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4ukkesYNfL3wR1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:14 GMT
-            Etag:
-                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
+                - Wed, 18 Feb 2026 06:28:26 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.223988542s
+        duration: 1.929338167s
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            kid:
+                - Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
+        headers:
+            Accept:
+                - application/xml
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata?kid=Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2689
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4uf7oo8rtYU3h1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJ
+            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
+            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
+            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+            ggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4
+            aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+M
+            uCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gG
+            a36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbF
+            CXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVu
+            i+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5
+            tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG
+            6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ2
+            6kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2689"
+            Content-Type:
+                - application/xml;charset=ISO-8859-1
+            Date:
+                - Wed, 18 Feb 2026 06:28:27 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.311693292s
     - id: 78
       request:
         proto: HTTP/1.1
@@ -2730,7 +2749,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2738,21 +2757,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52odicFkJMMxO1d7","status":"PROVISIONED","created":"2026-01-23T08:52:57.000Z","activated":"2026-01-23T08:52:57.000Z","statusChanged":"2026-01-23T08:52:57.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:57.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4uglbb5wjWFUv1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:14 GMT
+                - Wed, 18 Feb 2026 06:28:27 GMT
             Etag:
                 - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.231844791s
+        duration: 1.353470708s
     - id: 79
       request:
         proto: HTTP/1.1
@@ -2765,7 +2784,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2773,21 +2792,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52sjwtMsTlytc1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4uknjwViT79Hd1d7","status":"PROVISIONED","created":"2026-02-18T06:28:16.000Z","activated":"2026-02-18T06:28:17.000Z","statusChanged":"2026-02-18T06:28:17.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:17.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:14 GMT
+                - Wed, 18 Feb 2026 06:28:27 GMT
             Etag:
-                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.244398916s
+        duration: 1.944683041s
     - id: 80
       request:
         proto: HTTP/1.1
@@ -2800,7 +2819,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2808,21 +2827,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52tcjhrztgtdP1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4uks9l59iQGLj1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:14 GMT
+                - Wed, 18 Feb 2026 06:28:27 GMT
             Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
+                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.246973208s
+        duration: 1.954237375s
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2830,53 +2849,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            kid:
-                - pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
         headers:
             Accept:
-                - application/xml
+                - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata?kid=pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2689
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52l54bjfZxldW1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJ
-            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
-            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
-            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbH
-            MwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g
-            4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhw
-            Q285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHj
-            elJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8
-            fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgM
-            CZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3
-            RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+z
-            pgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4ullloJAYoWpe1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2689"
             Content-Type:
-                - application/xml;charset=ISO-8859-1
+                - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:15 GMT
+                - Wed, 18 Feb 2026 06:28:27 GMT
+            Etag:
+                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.23723575s
+        duration: 2.110742792s
     - id: 82
       request:
         proto: HTTP/1.1
@@ -2889,7 +2889,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2897,21 +2897,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52nmndk6dvysl1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4ujme479FZDyw1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:15 GMT
+                - Wed, 18 Feb 2026 06:28:27 GMT
             Etag:
                 - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.295537083s
+        duration: 2.123318584s
     - id: 83
       request:
         proto: HTTP/1.1
@@ -2924,7 +2924,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -2932,19 +2932,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:52:17.000Z","lastUpdated":"2026-01-23T08:52:17.000Z","expiresAt":"2036-01-23T08:52:17.000Z","kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbHMwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhwQ285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHjelJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgMCZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+zpgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs="],"x5t#S256":"QyOo6-itmIWDlemNc6br_DY8epoedx5rijdmiRyUJKs","e":"AQAB","n":"rlaXBKpF3z26InG2Y3xXzGBqTsyzqNlOCltoDnkSfat6I4rCgtz2pjzq5p_ybQyWxzMHR5GO0aXOSu2NgJYBIj7hwfilU6QMiiKRM1ToLhByST07TRcoFvPOux4EYt8PsdWeWzmSysp9IOD678GGokz741pKvjcSou2wohv-7_m1McaB7rvI4LVTNO-K2JGh6t5djvmCfE79FSP-LoJWrYJ4cENvOX8fI1fLOgc48o-hQWJAjrz_L3cIizzkJHC_n-hC-i46juCXuMl_OCG_4i04462_tfuJsPpB43pSRpEgPLSvV-DLEyZXETVBtf8O-Ca5tAdy-nCbcbjm7uYkgQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:27:38.000Z","lastUpdated":"2026-02-18T06:27:38.000Z","expiresAt":"2036-02-18T06:27:38.000Z","kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+MuCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gGa36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbFCXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVui+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ26kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w="],"x5t#S256":"g-r2RiaaWWBSnZL256ZbwUrGyVZVXZtkP6kdERvKOt8","e":"AQAB","n":"31odbMczYi3vFCPcDMYS8A6DL0FtPdiOWlYHFvQCk3giovSRhQTssUuuXzQWzsUBuGiQ2N3wJ01dyYol7XMbv2oSkOZ5Jkwu5l7SacMSx15MUKL-T0xotJEqivkBvAbxlxD2vgV5U6rfjLgr9jtGRO8G7r03oWgg1odBKoDdmvQAGF05Hf4tCgs75ZuslSStO030nTd_mND6n_zwVEImoN_4Bmt-m3B91KNw-BPQ7lyO96NHeB0Hor2IIas93fIbfuqXHGBWDiNUBVMmShZT-jm2xxPY_R6eX6LWxQlxnSXlK6vfZ7w2qN7nnsJhmYImrtNWlJ5cZ7DlgYUwrR9r6w"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:16 GMT
+                - Wed, 18 Feb 2026 06:28:28 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.059307334s
+        duration: 1.266392334s
     - id: 84
       request:
         proto: HTTP/1.1
@@ -2957,7 +2957,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2965,19 +2965,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:17 GMT
+                - Wed, 18 Feb 2026 06:28:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.077471s
+        duration: 1.128587916s
     - id: 85
       request:
         proto: HTTP/1.1
@@ -3005,12 +3005,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:19 GMT
+                - Wed, 18 Feb 2026 06:28:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.147862834s
+        duration: 1.06968475s
     - id: 86
       request:
         proto: HTTP/1.1
@@ -3023,7 +3023,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3031,19 +3031,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:03.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:21.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:20 GMT
+                - Wed, 18 Feb 2026 06:28:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.11929675s
+        duration: 1.140227167s
     - id: 87
       request:
         proto: HTTP/1.1
@@ -3056,7 +3056,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3064,19 +3064,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:22 GMT
+                - Wed, 18 Feb 2026 06:28:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.664615875s
+        duration: 1.187445791s
     - id: 88
       request:
         proto: HTTP/1.1
@@ -3097,19 +3097,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:22 GMT
+                - Wed, 18 Feb 2026 06:28:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.41365975s
+        duration: 1.964942375s
     - id: 89
       request:
         proto: HTTP/1.1
@@ -3137,12 +3137,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:23 GMT
+                - Wed, 18 Feb 2026 06:28:34 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.457018667s
+        duration: 1.080539959s
     - id: 90
       request:
         proto: HTTP/1.1
@@ -3155,7 +3155,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7
+        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3163,19 +3163,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou52za2zfPh8P5J1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4uiu1hyRiGbmL1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:28:14.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:28:14.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4uiu1hyRiGbmL1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:25 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.042577709s
+        duration: 1.062736292s
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3188,7 +3188,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3196,19 +3196,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52q4uiAgArO271d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/apps"}}}'
+        body: '{"id":"00gv4uglc9DM1imfL1d7","created":"2026-02-18T06:28:17.000Z","lastUpdated":"2026-02-18T06:28:17.000Z","lastMembershipUpdated":"2026-02-18T06:28:17.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:25 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.043856s
+        duration: 1.067083958s
     - id: 92
       request:
         proto: HTTP/1.1
@@ -3221,7 +3221,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3229,19 +3229,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy45BWpDKip1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/apps"}}}'
+        body: '{"id":"00gv4ujtegSywpFLd1d7","created":"2026-02-18T06:28:15.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","lastMembershipUpdated":"2026-02-18T06:28:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:25 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.047082917s
+        duration: 1.074139834s
     - id: 93
       request:
         proto: HTTP/1.1
@@ -3254,7 +3254,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3262,19 +3262,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}'
+        body: '{"type":"IP","id":"nzov4uks9ktI1f7gf1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:25 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.055525084s
+        duration: 1.075341959s
     - id: 94
       request:
         proto: HTTP/1.1
@@ -3287,7 +3287,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7
+        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3295,20 +3295,53 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy3xd8fsnMx1d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/apps"}}}'
+        body: '{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:25 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.062102833s
+        duration: 1.077495833s
     - id: 95
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ukkesYNfL3wR1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:35 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.077601959s
+    - id: 96
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3328,52 +3361,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:25 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.063362875s
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:53:25 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.090987209s
+        duration: 1.08016875s
     - id: 97
       request:
         proto: HTTP/1.1
@@ -3386,7 +3386,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3394,19 +3394,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52sgmrt1YxzdR1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/apps"}}}'
+        body: '{"id":"00gv4ukfyjrMWxXR71d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:26 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.807271s
+        duration: 1.080060417s
     - id: 98
       request:
         proto: HTTP/1.1
@@ -3419,7 +3419,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3427,19 +3427,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52t7hnp5dKTQI1d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:52:57.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:52:57.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52t7hnp5dKTQI1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"id":"00gv4uf39pI2Vz6PI1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:26 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.8110335s
+        duration: 1.081615875s
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3452,7 +3452,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3460,19 +3460,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu535xoiua0Hr651d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/apps"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:26 GMT
+                - Wed, 18 Feb 2026 06:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.825821167s
+        duration: 1.120674541s
     - id: 100
       request:
         proto: HTTP/1.1
@@ -3480,34 +3480,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
+        form:
+            kid:
+                - Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata?kid=Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52l3j7T3fA1tu1d7","status":"PROVISIONED","created":"2026-01-23T08:52:58.000Z","activated":"2026-01-23T08:52:58.000Z","statusChanged":"2026-01-23T08:52:58.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:58.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/deactivate","method":"POST"}}}'
+        content_length: 2689
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4uf7oo8rtYU3h1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJ
+            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
+            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
+            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+            ggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4
+            aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+M
+            uCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gG
+            a36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbF
+            CXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVu
+            i+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5
+            tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG
+            6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ2
+            6kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2689"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:53:26 GMT
-            Etag:
-                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
+                - Wed, 18 Feb 2026 06:28:36 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.172158417s
+        duration: 1.06205175s
     - id: 101
       request:
         proto: HTTP/1.1
@@ -3520,7 +3539,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3528,21 +3547,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52tcjhrztgtdP1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4ujme479FZDyw1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:26 GMT
+                - Wed, 18 Feb 2026 06:28:36 GMT
             Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
+                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.165730334s
+        duration: 1.253284792s
     - id: 102
       request:
         proto: HTTP/1.1
@@ -3555,7 +3574,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3563,21 +3582,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52nmndk6dvysl1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4uknjwViT79Hd1d7","status":"PROVISIONED","created":"2026-02-18T06:28:16.000Z","activated":"2026-02-18T06:28:17.000Z","statusChanged":"2026-02-18T06:28:17.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:17.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:27 GMT
+                - Wed, 18 Feb 2026 06:28:36 GMT
             Etag:
-                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.245599542s
+        duration: 1.265225166s
     - id: 103
       request:
         proto: HTTP/1.1
@@ -3590,7 +3609,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3598,21 +3617,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52sjwtMsTlytc1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4ullloJAYoWpe1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:27 GMT
+                - Wed, 18 Feb 2026 06:28:36 GMT
             Etag:
                 - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.256929625s
+        duration: 1.2797865s
     - id: 104
       request:
         proto: HTTP/1.1
@@ -3625,7 +3644,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3633,21 +3652,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52odicFkJMMxO1d7","status":"PROVISIONED","created":"2026-01-23T08:52:57.000Z","activated":"2026-01-23T08:52:57.000Z","statusChanged":"2026-01-23T08:52:57.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:57.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4uks9l59iQGLj1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:27 GMT
+                - Wed, 18 Feb 2026 06:28:36 GMT
             Etag:
-                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
+                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.242312083s
+        duration: 1.285153583s
     - id: 105
       request:
         proto: HTTP/1.1
@@ -3655,53 +3674,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            kid:
-                - pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
         headers:
             Accept:
-                - application/xml
+                - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata?kid=pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2689
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52l54bjfZxldW1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJ
-            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
-            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
-            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbH
-            MwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g
-            4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhw
-            Q285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHj
-            elJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8
-            fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgM
-            CZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3
-            RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+z
-            pgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uglbb5wjWFUv1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2689"
             Content-Type:
-                - application/xml;charset=ISO-8859-1
+                - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:27 GMT
+                - Wed, 18 Feb 2026 06:28:36 GMT
+            Etag:
+                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.221263625s
+        duration: 1.279046542s
     - id: 106
       request:
         proto: HTTP/1.1
@@ -3714,7 +3714,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -3722,19 +3722,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:52:17.000Z","lastUpdated":"2026-01-23T08:52:17.000Z","expiresAt":"2036-01-23T08:52:17.000Z","kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbHMwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhwQ285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHjelJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgMCZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+zpgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs="],"x5t#S256":"QyOo6-itmIWDlemNc6br_DY8epoedx5rijdmiRyUJKs","e":"AQAB","n":"rlaXBKpF3z26InG2Y3xXzGBqTsyzqNlOCltoDnkSfat6I4rCgtz2pjzq5p_ybQyWxzMHR5GO0aXOSu2NgJYBIj7hwfilU6QMiiKRM1ToLhByST07TRcoFvPOux4EYt8PsdWeWzmSysp9IOD678GGokz741pKvjcSou2wohv-7_m1McaB7rvI4LVTNO-K2JGh6t5djvmCfE79FSP-LoJWrYJ4cENvOX8fI1fLOgc48o-hQWJAjrz_L3cIizzkJHC_n-hC-i46juCXuMl_OCG_4i04462_tfuJsPpB43pSRpEgPLSvV-DLEyZXETVBtf8O-Ca5tAdy-nCbcbjm7uYkgQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:27:38.000Z","lastUpdated":"2026-02-18T06:27:38.000Z","expiresAt":"2036-02-18T06:27:38.000Z","kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+MuCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gGa36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbFCXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVui+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ26kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w="],"x5t#S256":"g-r2RiaaWWBSnZL256ZbwUrGyVZVXZtkP6kdERvKOt8","e":"AQAB","n":"31odbMczYi3vFCPcDMYS8A6DL0FtPdiOWlYHFvQCk3giovSRhQTssUuuXzQWzsUBuGiQ2N3wJ01dyYol7XMbv2oSkOZ5Jkwu5l7SacMSx15MUKL-T0xotJEqivkBvAbxlxD2vgV5U6rfjLgr9jtGRO8G7r03oWgg1odBKoDdmvQAGF05Hf4tCgs75ZuslSStO030nTd_mND6n_zwVEImoN_4Bmt-m3B91KNw-BPQ7lyO96NHeB0Hor2IIas93fIbfuqXHGBWDiNUBVMmShZT-jm2xxPY_R6eX6LWxQlxnSXlK6vfZ7w2qN7nnsJhmYImrtNWlJ5cZ7DlgYUwrR9r6w"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:28 GMT
+                - Wed, 18 Feb 2026 06:28:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.223271292s
+        duration: 1.352508333s
     - id: 107
       request:
         proto: HTTP/1.1
@@ -3747,7 +3747,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3755,19 +3755,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:29 GMT
+                - Wed, 18 Feb 2026 06:28:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.087207375s
+        duration: 1.140781792s
     - id: 108
       request:
         proto: HTTP/1.1
@@ -3795,12 +3795,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:30 GMT
+                - Wed, 18 Feb 2026 06:28:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.054824583s
+        duration: 1.091745667s
     - id: 109
       request:
         proto: HTTP/1.1
@@ -3813,7 +3813,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3821,19 +3821,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:03.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:21.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:31 GMT
+                - Wed, 18 Feb 2026 06:28:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.051094209s
+        duration: 1.10790475s
     - id: 110
       request:
         proto: HTTP/1.1
@@ -3854,19 +3854,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:32 GMT
+                - Wed, 18 Feb 2026 06:28:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.066408291s
+        duration: 1.197263292s
     - id: 111
       request:
         proto: HTTP/1.1
@@ -3879,7 +3879,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3887,19 +3887,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:32 GMT
+                - Wed, 18 Feb 2026 06:28:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.072198625s
+        duration: 1.194199125s
     - id: 112
       request:
         proto: HTTP/1.1
@@ -3927,12 +3927,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:33 GMT
+                - Wed, 18 Feb 2026 06:28:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.056809291s
+        duration: 1.122325125s
     - id: 113
       request:
         proto: HTTP/1.1
@@ -3941,7 +3941,7 @@ interactions:
         content_length: 1487
         host: classic-00.dne-okta.com
         body: |
-            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"people":{"groups":{"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"],"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"]},"users":{"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"],"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyu52xy42Me1XmVh1d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
+            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"people":{"groups":{"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"],"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"]},"users":{"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"],"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyv4ugj12DEiBAiD1d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
         headers:
             Accept:
                 - application/json
@@ -3949,7 +3949,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3957,19 +3957,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:35.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:44.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:35 GMT
+                - Wed, 18 Feb 2026 06:28:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.19484775s
+        duration: 1.208113792s
     - id: 114
       request:
         proto: HTTP/1.1
@@ -3982,7 +3982,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3990,19 +3990,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:35.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:44.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:36 GMT
+                - Wed, 18 Feb 2026 06:28:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.133178667s
+        duration: 1.1457675s
     - id: 115
       request:
         proto: HTTP/1.1
@@ -4015,7 +4015,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4023,19 +4023,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:38 GMT
+                - Wed, 18 Feb 2026 06:28:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.125206209s
+        duration: 1.134183291s
     - id: 116
       request:
         proto: HTTP/1.1
@@ -4056,19 +4056,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:38 GMT
+                - Wed, 18 Feb 2026 06:28:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.13001575s
+        duration: 1.90669675s
     - id: 117
       request:
         proto: HTTP/1.1
@@ -4096,12 +4096,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:40 GMT
+                - Wed, 18 Feb 2026 06:28:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.236219583s
+        duration: 1.076564416s
     - id: 118
       request:
         proto: HTTP/1.1
@@ -4114,7 +4114,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4122,19 +4122,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy45BWpDKip1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7/apps"}}}'
+        body: '{"type":"IP","id":"nzov4uks9ktI1f7gf1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
+                - Wed, 18 Feb 2026 06:28:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.038276459s
+        duration: 1.064279875s
     - id: 119
       request:
         proto: HTTP/1.1
@@ -4147,7 +4147,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4155,19 +4155,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52xy3xd8fsnMx1d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7/apps"}}}'
+        body: '{"id":"00gv4ujtegSywpFLd1d7","created":"2026-02-18T06:28:15.000Z","lastUpdated":"2026-02-18T06:28:15.000Z","lastMembershipUpdated":"2026-02-18T06:28:15.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
+                - Wed, 18 Feb 2026 06:28:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.041169125s
+        duration: 1.068437958s
     - id: 120
       request:
         proto: HTTP/1.1
@@ -4180,7 +4180,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4188,19 +4188,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}'
+        body: '{"id":"00gv4uf39pI2Vz6PI1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
+                - Wed, 18 Feb 2026 06:28:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.042124625s
+        duration: 1.072487042s
     - id: 121
       request:
         proto: HTTP/1.1
@@ -4213,7 +4213,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4221,119 +4221,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52q4uiAgArO271d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7/apps"}}}'
+        body: '{"id":"00gv4ukkesYNfL3wR1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
+                - Wed, 18 Feb 2026 06:28:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.047814875s
+        duration: 1.075099292s
     - id: 122
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52t7hnp5dKTQI1d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:52:57.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:52:57.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52t7hnp5dKTQI1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.051031833s
-    - id: 123
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52sgmrt1YxzdR1d7","created":"2026-01-23T08:52:58.000Z","lastUpdated":"2026-01-23T08:52:58.000Z","lastMembershipUpdated":"2026-01-23T08:52:58.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.055193208s
-    - id: 124
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu535xoiua0Hr651d7","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:56.000Z","lastMembershipUpdated":"2026-01-23T08:52:56.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.059360834s
-    - id: 125
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4353,19 +4254,122 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
+                - Wed, 18 Feb 2026 06:28:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.060837834s
+        duration: 1.077597s
+    - id: 123
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uglc9DM1imfL1d7","created":"2026-02-18T06:28:17.000Z","lastUpdated":"2026-02-18T06:28:17.000Z","lastMembershipUpdated":"2026-02-18T06:28:17.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.078137s
+    - id: 124
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4ujme479FZDyw1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:49 GMT
+            Etag:
+                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.323501666s
+    - id: 125
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uglbb5wjWFUv1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:28:49 GMT
+            Etag:
+                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.324191666s
     - id: 126
       request:
         proto: HTTP/1.1
@@ -4378,7 +4382,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4386,19 +4390,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"00uv4uknjwViT79Hd1d7","status":"PROVISIONED","created":"2026-02-18T06:28:16.000Z","activated":"2026-02-18T06:28:17.000Z","statusChanged":"2026-02-18T06:28:17.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:17.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:41 GMT
+                - Wed, 18 Feb 2026 06:28:49 GMT
+            Etag:
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.06856425s
+        duration: 1.332634375s
     - id: 127
       request:
         proto: HTTP/1.1
@@ -4411,7 +4417,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4419,21 +4425,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52sjwtMsTlytc1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4ukfyjrMWxXR71d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","lastMembershipUpdated":"2026-02-18T06:28:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:42 GMT
-            Etag:
-                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
+                - Wed, 18 Feb 2026 06:28:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.002715833s
+        duration: 1.892551375s
     - id: 128
       request:
         proto: HTTP/1.1
@@ -4446,7 +4450,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7
+        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4454,19 +4458,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou52za2zfPh8P5J1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4uiu1hyRiGbmL1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:28:14.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:28:14.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4uiu1hyRiGbmL1d7","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:42 GMT
+                - Wed, 18 Feb 2026 06:28:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.039944708s
+        duration: 1.115765541s
     - id: 129
       request:
         proto: HTTP/1.1
@@ -4479,7 +4483,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7
+        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4487,21 +4491,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52nmndk6dvysl1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:42 GMT
-            Etag:
-                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+                - Wed, 18 Feb 2026 06:28:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.058333375s
+        duration: 1.116735959s
     - id: 130
       request:
         proto: HTTP/1.1
@@ -4509,53 +4511,34 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            kid:
-                - pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
         headers:
             Accept:
-                - application/xml
+                - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata?kid=pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2689
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52l54bjfZxldW1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJ
-            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
-            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
-            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbH
-            MwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g
-            4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhw
-            Q285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHj
-            elJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8
-            fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgM
-            CZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3
-            RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+z
-            pgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_10/exku52l54bjfZxldW1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uks9l59iQGLj1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2689"
             Content-Type:
-                - application/xml;charset=ISO-8859-1
+                - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:42 GMT
+                - Wed, 18 Feb 2026 06:28:50 GMT
+            Etag:
+                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.048772s
+        duration: 1.127648625s
     - id: 131
       request:
         proto: HTTP/1.1
@@ -4568,7 +4551,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4576,21 +4559,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52l3j7T3fA1tu1d7","status":"PROVISIONED","created":"2026-01-23T08:52:58.000Z","activated":"2026-01-23T08:52:58.000Z","statusChanged":"2026-01-23T08:52:58.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:58.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4ullloJAYoWpe1d7","status":"PROVISIONED","created":"2026-02-18T06:28:14.000Z","activated":"2026-02-18T06:28:15.000Z","statusChanged":"2026-02-18T06:28:15.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:28:15.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:43 GMT
+                - Wed, 18 Feb 2026 06:28:50 GMT
             Etag:
-                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
+                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.233624833s
+        duration: 1.129424542s
     - id: 132
       request:
         proto: HTTP/1.1
@@ -4603,7 +4586,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4611,21 +4594,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52odicFkJMMxO1d7","status":"PROVISIONED","created":"2026-01-23T08:52:57.000Z","activated":"2026-01-23T08:52:57.000Z","statusChanged":"2026-01-23T08:52:57.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:57.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:43 GMT
-            Etag:
-                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
+                - Wed, 18 Feb 2026 06:28:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.226241125s
+        duration: 1.160956083s
     - id: 133
       request:
         proto: HTTP/1.1
@@ -4633,34 +4614,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
+        form:
+            kid:
+                - Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata?kid=Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52tcjhrztgtdP1d7","status":"PROVISIONED","created":"2026-01-23T08:52:56.000Z","activated":"2026-01-23T08:52:56.000Z","statusChanged":"2026-01-23T08:52:56.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:52:56.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7/lifecycle/deactivate","method":"POST"}}}'
+        content_length: 2689
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4uf7oo8rtYU3h1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJ
+            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
+            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
+            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+            ggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4
+            aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+M
+            uCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gG
+            a36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbF
+            CXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVu
+            i+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5
+            tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG
+            6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ2
+            6kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc987182423_11/exkv4uf7oo8rtYU3h1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2689"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:53:43 GMT
-            Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
+                - Wed, 18 Feb 2026 06:28:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.265095541s
+        duration: 1.307178791s
     - id: 134
       request:
         proto: HTTP/1.1
@@ -4673,7 +4673,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -4681,19 +4681,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:52:17.000Z","lastUpdated":"2026-01-23T08:52:17.000Z","expiresAt":"2036-01-23T08:52:17.000Z","kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqDeWDMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NTExN1oXDTM2MDEyMzA4NTIxN1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCuVpcEqkXfPboicbZjfFfMYGpOzLOo2U4KW2gOeRJ9q3ojisKC3PamPOrmn/JtDJbHMwdHkY7Rpc5K7Y2AlgEiPuHB+KVTpAyKIpEzVOguEHJJPTtNFygW8867HgRi3w+x1Z5bOZLKyn0g4PrvwYaiTPvjWkq+NxKi7bCiG/7v+bUxxoHuu8jgtVM074rYkaHq3l2O+YJ8Tv0VI/4uglatgnhwQ285fx8jV8s6Bzjyj6FBYkCOvP8vdwiLPOQkcL+f6EL6LjqO4Je4yX84Ib/iLTjjrb+1+4mw+kHjelJGkSA8tK9X4MsTJlcRNUG1/w74Jrm0B3L6cJtxuObu5iSBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGDLb1VMNZitPnZbmpRl8YvpHMIgNsWSKow/tlny/2CuXCM/vMmAQW2KeNZqBmw9bqacDEZ8fQtS8AhcjgJSEXrU4Dk7ogleDqtds0m3AOMtxE+cL6TKBmjjQLrYe0QH5NNhn9Sywtavpy2iPBgMCZlypFw4lODboWM0eS0R0jw+HgqpxA1NkOoG0GN7zKTMGSkWFm6nsS5uespfwf9Qit2ycDFlfnd3RJC08/BdU1xmlfMX77F2pkeXmFenLPCOd7FbdMJqxHxCCYYilr6tDfObjcSd+GESf0AjLGhTps+zpgo92ZFzkYeZQ+JO9vUUxRbzHZmeshUUGlVI90X+BRs="],"x5t#S256":"QyOo6-itmIWDlemNc6br_DY8epoedx5rijdmiRyUJKs","e":"AQAB","n":"rlaXBKpF3z26InG2Y3xXzGBqTsyzqNlOCltoDnkSfat6I4rCgtz2pjzq5p_ybQyWxzMHR5GO0aXOSu2NgJYBIj7hwfilU6QMiiKRM1ToLhByST07TRcoFvPOux4EYt8PsdWeWzmSysp9IOD678GGokz741pKvjcSou2wohv-7_m1McaB7rvI4LVTNO-K2JGh6t5djvmCfE79FSP-LoJWrYJ4cENvOX8fI1fLOgc48o-hQWJAjrz_L3cIizzkJHC_n-hC-i46juCXuMl_OCG_4i04462_tfuJsPpB43pSRpEgPLSvV-DLEyZXETVBtf8O-Ca5tAdy-nCbcbjm7uYkgQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:27:38.000Z","lastUpdated":"2026-02-18T06:27:38.000Z","expiresAt":"2036-02-18T06:27:38.000Z","kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvbs2aMA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjYzOFoXDTM2MDIxODA2MjczOFowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfWh1sxzNiLe8UI9wMxhLwDoMvQW092I5aVgcW9AKTeCKi9JGFBOyxS65fNBbOxQG4aJDY3fAnTV3JiiXtcxu/ahKQ5nkmTC7mXtJpwxLHXkxQov5PTGi0kSqK+QG8BvGXEPa+BXlTqt+MuCv2O0ZE7wbuvTehaCDWh0EqgN2a9AAYXTkd/i0KCzvlm6yVJK07TfSdN3+Y0Pqf/PBUQiag3/gGa36bcH3Uo3D4E9DuXI73o0d4HQeivYghqz3d8ht+6pccYFYOI1QFUyZKFlP6ObbHE9j9Hp5fotbFCXGdJeUrq99nvDao3ueewmGZgiau01aUnlxnsOWBhTCtH2vrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBANKoplPb0WbQowYE+RTW2WeTj62YIdv/El40ZBE2V4b8/ASk9tT/vbSziULUfFKbf5OqInVui+WnYWfYlpqXT9lTu2SCg9RdzLyK5Mf7dICqGWOcoH919T2BE+P6kjL7/s5/tW3L8qTe49SQmga5tZaWtSup712w01Hx8nKtRlQndB9g3tcYqkFeuongcaILdLx1s+11K2L/zxSQxFlbf3K5bLtZzjBG6i2/WWnt4N/onDzY19dG5uuyalQfZdrfrpC8OJA4oNy5EuN4IDsFvexAakNS6G2hRWAeuRw9ECJ26kzZV+3/eHPmTPRSqa/DeGHakeS+vx7eAp4OWk3kA/w="],"x5t#S256":"g-r2RiaaWWBSnZL256ZbwUrGyVZVXZtkP6kdERvKOt8","e":"AQAB","n":"31odbMczYi3vFCPcDMYS8A6DL0FtPdiOWlYHFvQCk3giovSRhQTssUuuXzQWzsUBuGiQ2N3wJ01dyYol7XMbv2oSkOZ5Jkwu5l7SacMSx15MUKL-T0xotJEqivkBvAbxlxD2vgV5U6rfjLgr9jtGRO8G7r03oWgg1odBKoDdmvQAGF05Hf4tCgs75ZuslSStO030nTd_mND6n_zwVEImoN_4Bmt-m3B91KNw-BPQ7lyO96NHeB0Hor2IIas93fIbfuqXHGBWDiNUBVMmShZT-jm2xxPY_R6eX6LWxQlxnSXlK6vfZ7w2qN7nnsJhmYImrtNWlJ5cZ7DlgYUwrR9r6w"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:43 GMT
+                - Wed, 18 Feb 2026 06:28:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.055307709s
+        duration: 1.245223333s
     - id: 135
       request:
         proto: HTTP/1.1
@@ -4706,7 +4706,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4714,19 +4714,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:45 GMT
+                - Wed, 18 Feb 2026 06:28:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.087198584s
+        duration: 1.156870875s
     - id: 136
       request:
         proto: HTTP/1.1
@@ -4754,12 +4754,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:46 GMT
+                - Wed, 18 Feb 2026 06:28:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.040813917s
+        duration: 1.114671084s
     - id: 137
       request:
         proto: HTTP/1.1
@@ -4772,7 +4772,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4780,19 +4780,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:35.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:44.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:48 GMT
+                - Wed, 18 Feb 2026 06:28:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.876484833s
+        duration: 1.129562167s
     - id: 138
       request:
         proto: HTTP/1.1
@@ -4813,19 +4813,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:50 GMT
+                - Wed, 18 Feb 2026 06:28:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.68009475s
+        duration: 1.109355333s
     - id: 139
       request:
         proto: HTTP/1.1
@@ -4838,7 +4838,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4846,19 +4846,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52l54c3YDQ6zy1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_10:0oau52l54c3YDQ6zy1d7","name":"classic-00_testacc987182423_10","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:52:18.000Z","created":"2026-01-23T08:52:17.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_10_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"pbjiygaPsDFxYrB4j29scbAPxIYYOZsWY5olFFhYn5A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_10_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_10/0oau52l54c3YDQ6zy1d7/alnu53fk7lBjWUgqv1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4uf7opHpEXCFT1d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:classic-00_testacc987182423_11:0oav4uf7opHpEXCFT1d7","name":"classic-00_testacc987182423_11","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:27:38.000Z","created":"2026-02-18T06:27:38.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc987182423_11_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Isvae65tc0xaN4xaVAba3pqOTT_nZX1NB_pq7ercn3A"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc987182423_11_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc987182423_11/0oav4uf7opHpEXCFT1d7/alnv4uo2zxhpr7jH21d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:50 GMT
+                - Wed, 18 Feb 2026 06:28:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.673197833s
+        duration: 1.919236042s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -4886,12 +4886,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:52 GMT
+                - Wed, 18 Feb 2026 06:28:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.933243792s
+        duration: 1.155777375s
     - id: 141
       request:
         proto: HTTP/1.1
@@ -4912,19 +4912,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52xy42Me1XmVh1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:52:57.000Z","lastUpdated":"2026-01-23T08:52:57.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscu52xy42Me1XmVh1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4ugj12DEiBAiD1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:28:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscv4ugj12DEiBAiD1d7","method":"GET"},"self":{"rel":"self","href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:54 GMT
+                - Wed, 18 Feb 2026 06:29:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.135451875s
+        duration: 1.105880708s
     - id: 142
       request:
         proto: HTTP/1.1
@@ -4937,7 +4937,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4945,19 +4945,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu5301hudMRW4ni1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:52:29.000Z","lastUpdated":"2026-01-23T08:53:35.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52sjwtMsTlytc1d7","00uu52odicFkJMMxO1d7"],"exclude":["00uu52tcjhrztgtdP1d7","00uu52nmndk6dvysl1d7","00uu52l3j7T3fA1tu1d7"]},"groups":{"include":["00gu535xoiua0Hr651d7","00gu52sgmrt1YxzdR1d7"],"exclude":["00gu52xy3xd8fsnMx1d7","00gu52q4uiAgArO271d7","00gu52xy45BWpDKip1d7"]}},"network":{"connection":"ZONE","include":["nzou52za2zfPh8P5J1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52t7hnp5dKTQI1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52xy42Me1XmVh1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4ug9neNw7qt7I1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:27:50.000Z","lastUpdated":"2026-02-18T06:28:44.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4ullloJAYoWpe1d7","00uv4uglbb5wjWFUv1d7"],"exclude":["00uv4uknjwViT79Hd1d7","00uv4uks9l59iQGLj1d7","00uv4ujme479FZDyw1d7"]},"groups":{"include":["00gv4ujtegSywpFLd1d7","00gv4uf39pI2Vz6PI1d7"],"exclude":["00gv4ukkesYNfL3wR1d7","00gv4uglc9DM1imfL1d7","00gv4ukfyjrMWxXR71d7"]}},"network":{"connection":"ZONE","include":["nzov4uks9ktI1f7gf1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4uiu1hyRiGbmL1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4ugj12DEiBAiD1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:55 GMT
+                - Wed, 18 Feb 2026 06:29:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.741321583s
+        duration: 1.121149417s
     - id: 143
       request:
         proto: HTTP/1.1
@@ -4970,7 +4970,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu5301hudMRW4ni1d7
+        url: https://classic-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4ug9neNw7qt7I1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4982,12 +4982,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:53:57 GMT
+                - Wed, 18 Feb 2026 06:29:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.682262916s
+        duration: 1.159009792s
     - id: 144
       request:
         proto: HTTP/1.1
@@ -5000,24 +5000,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52sgmrt1YxzdR1d7
-        method: DELETE
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4uks9ktI1f7gf1d7","name":"testAcc_987182423","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:28:14.000Z","lastUpdated":"2026-02-18T06:29:04.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
             Date:
-                - Fri, 23 Jan 2026 08:53:58 GMT
+                - Wed, 18 Feb 2026 06:29:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.083165708s
+        status: 200 OK
+        code: 200
+        duration: 1.167739208s
     - id: 145
       request:
         proto: HTTP/1.1
@@ -5030,7 +5033,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52q4uiAgArO271d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukfyjrMWxXR71d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5042,12 +5045,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:53:58 GMT
+                - Wed, 18 Feb 2026 06:29:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.088864875s
+        duration: 1.17142225s
     - id: 146
       request:
         proto: HTTP/1.1
@@ -5060,7 +5063,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uf39pI2Vz6PI1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5072,12 +5075,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:53:58 GMT
+                - Wed, 18 Feb 2026 06:29:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.107727542s
+        duration: 1.183894083s
     - id: 147
       request:
         proto: HTTP/1.1
@@ -5090,7 +5093,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5102,12 +5105,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:53:58 GMT
+                - Wed, 18 Feb 2026 06:29:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.147317792s
+        duration: 1.20804075s
     - id: 148
       request:
         proto: HTTP/1.1
@@ -5120,7 +5123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5132,12 +5135,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:53:58 GMT
+                - Wed, 18 Feb 2026 06:29:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.157542125s
+        duration: 1.213469209s
     - id: 149
       request:
         proto: HTTP/1.1
@@ -5150,7 +5153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daeu52t7hnp5dKTQI1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5162,12 +5165,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:53:58 GMT
+                - Wed, 18 Feb 2026 06:29:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.164343125s
+        duration: 1.264341625s
     - id: 150
       request:
         proto: HTTP/1.1
@@ -5180,7 +5183,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7
+        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyv4ugj12DEiBAiD1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5192,12 +5195,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:53:58 GMT
+                - Wed, 18 Feb 2026 06:29:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.1644s
+        duration: 2.006768375s
     - id: 151
       request:
         proto: HTTP/1.1
@@ -5210,370 +5213,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou52za2zfPh8P5J1d7","name":"testAcc_987182423","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T08:52:56.000Z","lastUpdated":"2026-01-23T08:53:59.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.814108292s
-    - id: 152
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.873690917s
-    - id: 153
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy45BWpDKip1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.04981825s
-    - id: 154
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu52xy3xd8fsnMx1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.06229875s
-    - id: 155
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/groups/00gu535xoiua0Hr651d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.075944333s
-    - id: 156
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52tcjhrztgtdP1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.191936666s
-    - id: 157
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52odicFkJMMxO1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.160608917s
-    - id: 158
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52sjwtMsTlytc1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:53:59 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.178897708s
-    - id: 159
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52l3j7T3fA1tu1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:54:00 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.223192041s
-    - id: 160
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/meta/types/user/otyu52xy42Me1XmVh1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:54:00 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 2.557611708s
-    - id: 161
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou52za2zfPh8P5J1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:54:00 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.075764458s
-    - id: 162
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/users/00uu52nmndk6dvysl1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:54:00 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.212152s
-    - id: 163
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -5588,12 +5228,372 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:54:00 GMT
+                - Wed, 18 Feb 2026 06:29:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.084898416s
+        duration: 2.045475458s
+    - id: 152
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ukkesYNfL3wR1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.103157417s
+    - id: 153
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uks9ktI1f7gf1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.140680417s
+    - id: 154
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uks9l59iQGLj1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.18386025s
+    - id: 155
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/device-assurances/daev4uiu1hyRiGbmL1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.227899292s
+    - id: 156
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ullloJAYoWpe1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.200976416s
+    - id: 157
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uknjwViT79Hd1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.218307417s
+    - id: 158
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 2.873411375s
+    - id: 159
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 2.881995625s
+    - id: 160
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4uglc9DM1imfL1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.073748125s
+    - id: 161
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oav4uf7opHpEXCFT1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.301418625s
+    - id: 162
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gv4ujtegSywpFLd1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.086375166s
+    - id: 163
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4uglbb5wjWFUv1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:29:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.173987875s
     - id: 164
       request:
         proto: HTTP/1.1
@@ -5606,7 +5606,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oau52l54c3YDQ6zy1d7
+        url: https://classic-00.dne-okta.com/api/v1/users/00uv4ujme479FZDyw1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5618,9 +5618,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:54:02 GMT
+                - Wed, 18 Feb 2026 06:29:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.842020958s
+        duration: 1.986968041s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaAppSignOnPolicyRule_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaAppSignOnPolicyRule_crud/oie-00.yaml
@@ -28,19 +28,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:27 GMT
+                - Wed, 18 Feb 2026 06:30:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.740854916s
+        duration: 1.878236125s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,12 +67,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:29 GMT
+                - Wed, 18 Feb 2026 06:30:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.036249334s
+        duration: 1.057267459s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"rstqq6ctn3WGXVqOm1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnaTuxncHq1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctndu1ew1qH1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnn8tuHBCM1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-10-07T06:36:59.000Z","lastUpdated":"2025-10-07T06:36:59.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctoglghkrHd1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:37:00.000Z","lastUpdated":"2025-10-07T06:37:00.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstrbe37w6NqDQtPR1d7","status":"ACTIVE","name":"Test Auth Policy 2 99901f4a-7865-4ece-a040-5c80537af9a4","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:49:07.000Z","lastUpdated":"2025-10-27T05:49:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeayf8TR9pqoD1d7","status":"ACTIVE","name":"Test Auth Policy 2 f74c8f29-5a1e-4d05-a08d-1462b49f96fc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:55:40.000Z","lastUpdated":"2025-10-27T05:55:40.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeegmpEjTf4xT1d7","status":"ACTIVE","name":"Test Auth Policy 2 0a4e7223-0ab9-4fa9-8b27-1e32d010b75f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:03:37.000Z","lastUpdated":"2025-10-27T06:03:37.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeo0d5bJl3g2O1d7","status":"ACTIVE","name":"Test Auth Policy 2 f9858ccb-493c-4d66-bd82-92dd4472efdc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:07:53.000Z","lastUpdated":"2025-10-27T06:07:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbf6tm2Bu9as9i1d7","status":"ACTIVE","name":"Test Auth Policy 2 f8276bf4-da87-43a0-a7c8-12feb003f565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:39:29.000Z","lastUpdated":"2025-10-27T06:39:29.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbffb2f8tLHhF51d7","status":"ACTIVE","name":"Test Auth Policy 2 58d68e55-6ca3-43e9-9537-49ed89fcc565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:48:32.000Z","lastUpdated":"2025-10-27T06:48:32.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbfjy846B3JtSW1d7","status":"ACTIVE","name":"Test Auth Policy 2 e36db953-7ef5-48ae-a9aa-bdc4c60d6697","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:52:16.000Z","lastUpdated":"2025-10-27T06:52:16.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbgd0utDtfjlrL1d7","status":"ACTIVE","name":"Test Auth Policy 2 ab0a7b85-ea65-47e1-811a-e06bcdf01143","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T07:13:13.000Z","lastUpdated":"2025-10-27T07:13:13.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbi7x9vn2vEmmr1d7","status":"ACTIVE","name":"Test Auth Policy 2 f395fe41-738f-4e18-b887-744eace24a6f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T08:22:54.000Z","lastUpdated":"2025-10-27T08:22:54.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrc8xldw9LwyuRj1d7","status":"ACTIVE","name":"Test Auth Policy 2 d6cb2e3b-685e-40b7-a220-2ab6213e1079","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T03:16:39.000Z","lastUpdated":"2025-10-28T03:16:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrcfjxduMxckk2y1d7","status":"ACTIVE","name":"Test Auth Policy 2 4a9ba426-0875-41b3-bca4-7385395604de","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T08:49:42.000Z","lastUpdated":"2025-10-28T08:49:42.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsaecoc1xOZYK5Z1d7","status":"ACTIVE","name":"Test Auth Policy 2 4d1c6630-85fa-4244-ae97-6a1b8aa1bf6d","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-02T05:55:20.000Z","lastUpdated":"2025-12-02T05:55:20.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstse090ssxEaNo7v1d7","status":"ACTIVE","name":"Test Auth Policy 2 6dae9a9a-4215-4604-a092-efa95469804e","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-05T04:13:12.000Z","lastUpdated":"2025-12-05T04:13:12.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsm94o12ejDiKmx1d7","status":"ACTIVE","name":"Test Auth Policy 2 a2c5e453-ff38-4a98-87c8-c0bd29442210","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-12T05:01:06.000Z","lastUpdated":"2025-12-12T05:01:06.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy4qpkf2zJl6wZ1d7","status":"ACTIVE","name":"Test Auth Policy 1714c80e-6f10-4bf3-a95b-35a7c16ceed8","description":"Test policy for ApplicationPoliciesApi integration tests","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:04:42.000Z","lastUpdated":"2025-12-22T08:04:42.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy5dc98cxHjulg1d7","status":"ACTIVE","name":"Test Auth Policy 2 dafe5b5a-40d3-4fe6-b841-2159d08bceb8","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:18:01.000Z","lastUpdated":"2025-12-22T08:18:01.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnpev3cs1vzqw61d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T02:00:23.000Z","lastUpdated":"2026-01-09T02:00:23.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
+        body: '[{"id":"rstqq6ctn3WGXVqOm1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctn3WGXVqOm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnaTuxncHq1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnaTuxncHq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctndu1ew1qH1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:36:58.000Z","lastUpdated":"2025-10-07T06:36:58.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctndu1ew1qH1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctnn8tuHBCM1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-10-07T06:36:59.000Z","lastUpdated":"2025-10-07T06:36:59.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqq6ctoglghkrHd1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-10-07T06:37:00.000Z","lastUpdated":"2025-10-07T06:37:00.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctoglghkrHd1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstrbe37w6NqDQtPR1d7","status":"ACTIVE","name":"Test Auth Policy 2 99901f4a-7865-4ece-a040-5c80537af9a4","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:49:07.000Z","lastUpdated":"2025-10-27T05:49:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbe37w6NqDQtPR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeayf8TR9pqoD1d7","status":"ACTIVE","name":"Test Auth Policy 2 f74c8f29-5a1e-4d05-a08d-1462b49f96fc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T05:55:40.000Z","lastUpdated":"2025-10-27T05:55:40.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeayf8TR9pqoD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeegmpEjTf4xT1d7","status":"ACTIVE","name":"Test Auth Policy 2 0a4e7223-0ab9-4fa9-8b27-1e32d010b75f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:03:37.000Z","lastUpdated":"2025-10-27T06:03:37.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeegmpEjTf4xT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbeo0d5bJl3g2O1d7","status":"ACTIVE","name":"Test Auth Policy 2 f9858ccb-493c-4d66-bd82-92dd4472efdc","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:07:53.000Z","lastUpdated":"2025-10-27T06:07:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbeo0d5bJl3g2O1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbf6tm2Bu9as9i1d7","status":"ACTIVE","name":"Test Auth Policy 2 f8276bf4-da87-43a0-a7c8-12feb003f565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:39:29.000Z","lastUpdated":"2025-10-27T06:39:29.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbf6tm2Bu9as9i1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbffb2f8tLHhF51d7","status":"ACTIVE","name":"Test Auth Policy 2 58d68e55-6ca3-43e9-9537-49ed89fcc565","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:48:32.000Z","lastUpdated":"2025-10-27T06:48:32.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbffb2f8tLHhF51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbfjy846B3JtSW1d7","status":"ACTIVE","name":"Test Auth Policy 2 e36db953-7ef5-48ae-a9aa-bdc4c60d6697","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T06:52:16.000Z","lastUpdated":"2025-10-27T06:52:16.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbfjy846B3JtSW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbgd0utDtfjlrL1d7","status":"ACTIVE","name":"Test Auth Policy 2 ab0a7b85-ea65-47e1-811a-e06bcdf01143","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T07:13:13.000Z","lastUpdated":"2025-10-27T07:13:13.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbgd0utDtfjlrL1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrbi7x9vn2vEmmr1d7","status":"ACTIVE","name":"Test Auth Policy 2 f395fe41-738f-4e18-b887-744eace24a6f","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-27T08:22:54.000Z","lastUpdated":"2025-10-27T08:22:54.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrbi7x9vn2vEmmr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrc8xldw9LwyuRj1d7","status":"ACTIVE","name":"Test Auth Policy 2 d6cb2e3b-685e-40b7-a220-2ab6213e1079","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T03:16:39.000Z","lastUpdated":"2025-10-28T03:16:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrc8xldw9LwyuRj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrcfjxduMxckk2y1d7","status":"ACTIVE","name":"Test Auth Policy 2 4a9ba426-0875-41b3-bca4-7385395604de","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-10-28T08:49:42.000Z","lastUpdated":"2025-10-28T08:49:42.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrcfjxduMxckk2y1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsaecoc1xOZYK5Z1d7","status":"ACTIVE","name":"Test Auth Policy 2 4d1c6630-85fa-4244-ae97-6a1b8aa1bf6d","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-02T05:55:20.000Z","lastUpdated":"2025-12-02T05:55:20.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsaecoc1xOZYK5Z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstse090ssxEaNo7v1d7","status":"ACTIVE","name":"Test Auth Policy 2 6dae9a9a-4215-4604-a092-efa95469804e","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-05T04:13:12.000Z","lastUpdated":"2025-12-05T04:13:12.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstse090ssxEaNo7v1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsm94o12ejDiKmx1d7","status":"ACTIVE","name":"Test Auth Policy 2 a2c5e453-ff38-4a98-87c8-c0bd29442210","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-12T05:01:06.000Z","lastUpdated":"2025-12-12T05:01:06.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsm94o12ejDiKmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy4qpkf2zJl6wZ1d7","status":"ACTIVE","name":"Test Auth Policy 1714c80e-6f10-4bf3-a95b-35a7c16ceed8","description":"Test policy for ApplicationPoliciesApi integration tests","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:04:42.000Z","lastUpdated":"2025-12-22T08:04:42.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy4qpkf2zJl6wZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsy5dc98cxHjulg1d7","status":"ACTIVE","name":"Test Auth Policy 2 dafe5b5a-40d3-4fe6-b841-2159d08bceb8","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2025-12-22T08:18:01.000Z","lastUpdated":"2025-12-22T08:18:01.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsy5dc98cxHjulg1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnpev3cs1vzqw61d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T02:00:23.000Z","lastUpdated":"2026-01-09T02:00:23.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnpev3cs1vzqw61d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstu97sepplf0tzbS1d7","status":"ACTIVE","name":"Test Auth Policy 2 d427ec6e-3b9a-4dae-9fa3-66d0026a5369","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-01-27T06:56:38.000Z","lastUpdated":"2026-01-27T06:56:38.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97sepplf0tzbS1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstu97wjg9HCleLI01d7","status":"ACTIVE","name":"Test Auth Policy 2 31ea56b2-24ec-4e84-8247-c72401a4aedb","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-01-27T07:20:58.000Z","lastUpdated":"2026-01-27T07:20:58.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97wjg9HCleLI01d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstu97yj7qQa6gDWq1d7","status":"ACTIVE","name":"Test Auth Policy 2 83aa828e-c8ff-44ad-9814-62ab45f0f2ae","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-01-27T07:09:55.000Z","lastUpdated":"2026-01-27T07:09:55.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstu97yj7qQa6gDWq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstut5tbb0pDGWlxz1d7","status":"ACTIVE","name":"Test Auth Policy 2 b84e0b97-5379-4403-923d-fe80a7bcc85b","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-09T11:10:30.000Z","lastUpdated":"2026-02-09T11:10:30.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstut5tbb0pDGWlxz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstuvw9da2J07oWLK1d7","status":"ACTIVE","name":"Test Auth Policy 2 4299e620-4b2a-4cf0-842b-fd29c673768a","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-11T06:38:46.000Z","lastUpdated":"2026-02-11T06:38:46.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuvw9da2J07oWLK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstuw62fxiR11MJ3d1d7","status":"ACTIVE","name":"Test Auth Policy 2 ea7af3dd-879f-4bfb-a3e2-45fefac8e463","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-11T11:18:07.000Z","lastUpdated":"2026-02-11T11:18:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw62fxiR11MJ3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstuw8sqzpsXBq1gR1d7","status":"ACTIVE","name":"Test Auth Policy 2 dccdbbd3-4f15-42fd-9e04-b75c2af0c7e8","description":"Second test policy","priority":1,"system":false,"conditions":null,"created":"2026-02-11T12:09:24.000Z","lastUpdated":"2026-02-11T12:09:24.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuw8sqzpsXBq1gR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:30 GMT
+                - Wed, 18 Feb 2026 06:30:16 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.095530083s
+        duration: 1.262589s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies/rstqq6ctnn8tuHBCM1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies/rstqq6ctnn8tuHBCM1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -135,12 +135,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:49:31 GMT
+                - Wed, 18 Feb 2026 06:30:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.11963525s
+        duration: 1.169992125s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:32 GMT
+                - Wed, 18 Feb 2026 06:30:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.479034416s
+        duration: 1.143379792s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,51 +183,51 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+                - Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata?kid=zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata?kid=Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2685
+        content_length: 2689
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52r8ngU3CmT5P1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4umno9NtAslgJ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJ
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJ
             BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
             CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
             Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8
-            PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diE
-            Cv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7m
-            NKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnv
-            t2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ
-            +UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQj
-            TtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1i
-            AUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEU
-            Z3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdA
+            Cbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl
+            2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFY
+            pRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq
+            9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqduf
+            BAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nn
+            bcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9E
+            caa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1G
+            dBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Length:
-                - "2685"
+                - "2689"
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:49:34 GMT
+                - Wed, 18 Feb 2026 06:30:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.345607959s
+        duration: 1.279436208s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -248,19 +248,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:49:27.000Z","lastUpdated":"2026-01-23T08:49:27.000Z","expiresAt":"2036-01-23T08:49:26.000Z","kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diECv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7mNKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnvt2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ+UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQjTtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1iAUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEUZ3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI="],"x5t#S256":"gSxzdOq_2evgY8ztkNqSrye7fhzAKjaQq-omt53quV0","e":"AQAB","n":"x35V4BMZR0pfzIxC-eofdsVJUuQdS7utDGZRF-Dj2vYg51VwEwjmq1nDaJ9CBIJk_D0xETIFtS-FqLxXBoo_qztOX8hNuJP6ySpZITDI44g-k_zhjc-zlaYByRwXiNgstrwPeQPl6uHYhAr9965tU0K7rPXQ-5hbDts_QY1kjIatv1lWTqzHq01myt4z3IqfjSMBUxCqwV9MnYATmrN1Ccke5jSpbFt_aTpNOLH0M8sDDrPcP-jWjyvsMrVqak9IbDG__s5iPdoXjokJErVM98unfM5oOz9oQuk577dqU-8E8vp-sGRNecJjjcJRFCF2ZBZZoFOb6DzZf0gBQjsSVQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:30:14.000Z","lastUpdated":"2026-02-18T06:30:14.000Z","expiresAt":"2036-02-18T06:30:13.000Z","kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdACbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFYpRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqdufBAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nnbcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9Ecaa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1GdBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4="],"x5t#S256":"dxAeIKWPEt_Nal249ZkGi-CqBwCC80W2c8GZAM9Bxb0","e":"AQAB","n":"8iwpEgwqM-L37S_UDYynIXSADS0SB6M0GDJ7hMrConuNUgd7bjwZFrIYzSw3ishnQAm3ZM9YXQKiXFaYLJs3fprdkOsp3XcnI87KXSpG9heJPKZDwUnpfiPaZJcs7tXUdPzArmnaSeI5Jdlo4XnjanNtE8omgAIZ8SfZG9pyfd2UcrCt7sWHFLgMXvXW9mLBL-fjOXOaA6wCG9JauGRWHsIxWKUQfJ3hUip_z4aT4yFjzQ3VJ0i4-91FjL1tplyn2wIgN0O9T2Q_Qhy9pQrprcsN6LCkMuxBMsFQKvYxgQ4ikYH_M4hVgLMXSOLXIYuUSud-uQWeOQ9KLdRmwXZ8dw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:36 GMT
+                - Wed, 18 Feb 2026 06:30:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.523328958s
+        duration: 1.260566333s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -273,7 +273,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -281,19 +281,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:37 GMT
+                - Wed, 18 Feb 2026 06:30:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.218767916s
+        duration: 1.138886708s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -321,12 +321,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:39 GMT
+                - Wed, 18 Feb 2026 06:30:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.049817125s
+        duration: 1.130186667s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -351,19 +351,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:49:40.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:25.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:40 GMT
+                - Wed, 18 Feb 2026 06:30:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.984204833s
+        duration: 1.174433167s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -376,7 +376,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -384,19 +384,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:49:40.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:25.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:42 GMT
+                - Wed, 18 Feb 2026 06:30:26 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.484782333s
+        duration: 1.112070125s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -409,7 +409,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -417,19 +417,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:43 GMT
+                - Wed, 18 Feb 2026 06:30:27 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.533267167s
+        duration: 1.095526542s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -457,12 +457,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:45 GMT
+                - Wed, 18 Feb 2026 06:30:28 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.061017s
+        duration: 1.141037375s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -475,7 +475,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -483,19 +483,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:46 GMT
+                - Wed, 18 Feb 2026 06:30:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.265233s
+        duration: 1.1442105s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -505,51 +505,51 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+                - Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata?kid=zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata?kid=Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2685
+        content_length: 2689
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52r8ngU3CmT5P1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4umno9NtAslgJ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJ
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJ
             BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
             CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
             Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8
-            PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diE
-            Cv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7m
-            NKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnv
-            t2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ
-            +UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQj
-            TtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1i
-            AUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEU
-            Z3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdA
+            Cbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl
+            2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFY
+            pRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq
+            9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqduf
+            BAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nn
+            bcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9E
+            caa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1G
+            dBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Length:
-                - "2685"
+                - "2689"
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:49:49 GMT
+                - Wed, 18 Feb 2026 06:30:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 3.239792459s
+        duration: 1.302757542s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -562,7 +562,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,19 +570,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:49:27.000Z","lastUpdated":"2026-01-23T08:49:27.000Z","expiresAt":"2036-01-23T08:49:26.000Z","kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diECv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7mNKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnvt2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ+UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQjTtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1iAUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEUZ3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI="],"x5t#S256":"gSxzdOq_2evgY8ztkNqSrye7fhzAKjaQq-omt53quV0","e":"AQAB","n":"x35V4BMZR0pfzIxC-eofdsVJUuQdS7utDGZRF-Dj2vYg51VwEwjmq1nDaJ9CBIJk_D0xETIFtS-FqLxXBoo_qztOX8hNuJP6ySpZITDI44g-k_zhjc-zlaYByRwXiNgstrwPeQPl6uHYhAr9965tU0K7rPXQ-5hbDts_QY1kjIatv1lWTqzHq01myt4z3IqfjSMBUxCqwV9MnYATmrN1Ccke5jSpbFt_aTpNOLH0M8sDDrPcP-jWjyvsMrVqak9IbDG__s5iPdoXjokJErVM98unfM5oOz9oQuk577dqU-8E8vp-sGRNecJjjcJRFCF2ZBZZoFOb6DzZf0gBQjsSVQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:30:14.000Z","lastUpdated":"2026-02-18T06:30:14.000Z","expiresAt":"2036-02-18T06:30:13.000Z","kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdACbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFYpRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqdufBAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nnbcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9Ecaa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1GdBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4="],"x5t#S256":"dxAeIKWPEt_Nal249ZkGi-CqBwCC80W2c8GZAM9Bxb0","e":"AQAB","n":"8iwpEgwqM-L37S_UDYynIXSADS0SB6M0GDJ7hMrConuNUgd7bjwZFrIYzSw3ishnQAm3ZM9YXQKiXFaYLJs3fprdkOsp3XcnI87KXSpG9heJPKZDwUnpfiPaZJcs7tXUdPzArmnaSeI5Jdlo4XnjanNtE8omgAIZ8SfZG9pyfd2UcrCt7sWHFLgMXvXW9mLBL-fjOXOaA6wCG9JauGRWHsIxWKUQfJ3hUip_z4aT4yFjzQ3VJ0i4-91FjL1tplyn2wIgN0O9T2Q_Qhy9pQrprcsN6LCkMuxBMsFQKvYxgQ4ikYH_M4hVgLMXSOLXIYuUSud-uQWeOQ9KLdRmwXZ8dw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:51 GMT
+                - Wed, 18 Feb 2026 06:30:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.290249042s
+        duration: 1.2763875s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -595,7 +595,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -603,19 +603,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:53 GMT
+                - Wed, 18 Feb 2026 06:30:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0656345s
+        duration: 1.159888666s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -643,12 +643,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:54 GMT
+                - Wed, 18 Feb 2026 06:30:34 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0626165s
+        duration: 1.183458667s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -661,7 +661,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -669,19 +669,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:49:40.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:25.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:55 GMT
+                - Wed, 18 Feb 2026 06:30:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.52028025s
+        duration: 1.068951292s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -694,7 +694,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -702,19 +702,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:57 GMT
+                - Wed, 18 Feb 2026 06:30:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.476146708s
+        duration: 1.098185208s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -742,12 +742,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:49:58 GMT
+                - Wed, 18 Feb 2026 06:30:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.661175542s
+        duration: 1.070754542s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -768,19 +768,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:00 GMT
+                - Wed, 18 Feb 2026 06:30:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.125397291s
+        duration: 1.071513625s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -793,7 +793,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -801,19 +801,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:00 GMT
+                - Wed, 18 Feb 2026 06:30:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.12098575s
+        duration: 1.096711375s
     - id: 23
       request:
         proto: HTTP/1.1
@@ -823,51 +823,51 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+                - Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata?kid=zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata?kid=Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2685
+        content_length: 2689
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52r8ngU3CmT5P1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4umno9NtAslgJ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJ
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJ
             BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
             CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
             Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8
-            PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diE
-            Cv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7m
-            NKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnv
-            t2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ
-            +UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQj
-            TtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1i
-            AUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEU
-            Z3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdA
+            Cbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl
+            2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFY
+            pRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq
+            9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqduf
+            BAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nn
+            bcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9E
+            caa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1G
+            dBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Length:
-                - "2685"
+                - "2689"
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:50:01 GMT
+                - Wed, 18 Feb 2026 06:30:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.221308583s
+        duration: 1.259593834s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -880,7 +880,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -888,19 +888,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:49:27.000Z","lastUpdated":"2026-01-23T08:49:27.000Z","expiresAt":"2036-01-23T08:49:26.000Z","kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diECv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7mNKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnvt2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ+UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQjTtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1iAUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEUZ3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI="],"x5t#S256":"gSxzdOq_2evgY8ztkNqSrye7fhzAKjaQq-omt53quV0","e":"AQAB","n":"x35V4BMZR0pfzIxC-eofdsVJUuQdS7utDGZRF-Dj2vYg51VwEwjmq1nDaJ9CBIJk_D0xETIFtS-FqLxXBoo_qztOX8hNuJP6ySpZITDI44g-k_zhjc-zlaYByRwXiNgstrwPeQPl6uHYhAr9965tU0K7rPXQ-5hbDts_QY1kjIatv1lWTqzHq01myt4z3IqfjSMBUxCqwV9MnYATmrN1Ccke5jSpbFt_aTpNOLH0M8sDDrPcP-jWjyvsMrVqak9IbDG__s5iPdoXjokJErVM98unfM5oOz9oQuk577dqU-8E8vp-sGRNecJjjcJRFCF2ZBZZoFOb6DzZf0gBQjsSVQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:30:14.000Z","lastUpdated":"2026-02-18T06:30:14.000Z","expiresAt":"2036-02-18T06:30:13.000Z","kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdACbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFYpRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqdufBAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nnbcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9Ecaa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1GdBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4="],"x5t#S256":"dxAeIKWPEt_Nal249ZkGi-CqBwCC80W2c8GZAM9Bxb0","e":"AQAB","n":"8iwpEgwqM-L37S_UDYynIXSADS0SB6M0GDJ7hMrConuNUgd7bjwZFrIYzSw3ishnQAm3ZM9YXQKiXFaYLJs3fprdkOsp3XcnI87KXSpG9heJPKZDwUnpfiPaZJcs7tXUdPzArmnaSeI5Jdlo4XnjanNtE8omgAIZ8SfZG9pyfd2UcrCt7sWHFLgMXvXW9mLBL-fjOXOaA6wCG9JauGRWHsIxWKUQfJ3hUip_z4aT4yFjzQ3VJ0i4-91FjL1tplyn2wIgN0O9T2Q_Qhy9pQrprcsN6LCkMuxBMsFQKvYxgQ4ikYH_M4hVgLMXSOLXIYuUSud-uQWeOQ9KLdRmwXZ8dw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:03 GMT
+                - Wed, 18 Feb 2026 06:30:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.769448792s
+        duration: 1.25452675s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -913,7 +913,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -921,19 +921,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:05 GMT
+                - Wed, 18 Feb 2026 06:30:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.451299791s
+        duration: 1.0990265s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -961,12 +961,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:06 GMT
+                - Wed, 18 Feb 2026 06:30:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.082299583s
+        duration: 1.081973s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -979,7 +979,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -987,19 +987,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:49:40.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423","priority":0,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:25.000Z","system":false,"conditions":{"people":{"users":{"exclude":[]}},"network":{"connection":"ANYWHERE"},"platform":{"include":[{"type":"DESKTOP","os":{"type":"OTHER","expression":""}}],"exclude":[]},"riskScore":{"level":"LOW"},"userType":{"include":[],"exclude":[]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT2H"},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:08 GMT
+                - Wed, 18 Feb 2026 06:30:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.014620333s
+        duration: 1.08443675s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1020,19 +1020,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:09 GMT
+                - Wed, 18 Feb 2026 06:30:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.045476792s
+        duration: 1.074129125s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1045,7 +1045,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1053,19 +1053,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:09 GMT
+                - Wed, 18 Feb 2026 06:30:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.064871958s
+        duration: 1.12426075s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1093,12 +1093,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:10 GMT
+                - Wed, 18 Feb 2026 06:30:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.06992675s
+        duration: 1.153181708s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1123,19 +1123,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqjAPlRmVK1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/apps"}}}'
+        body: '{"id":"00gv4uoqex0SJpLHo1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
+                - Wed, 18 Feb 2026 06:30:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.056180833s
+        duration: 1.056582125s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1160,621 +1160,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52n7uvhRNz1Qs1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/apps"}}}'
+        body: '{"id":"00gv4ulzapeJL27I81d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
+                - Wed, 18 Feb 2026 06:30:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.056015791s
+        duration: 1.069911584s
     - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 263
-        host: oie-00.dne-okta.com
-        body: |
-            {"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"name":"testAcc_987182423","proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou52xfeyNyUBRZT1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.056207625s
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 97
-        host: oie-00.dne-okta.com
-        body: |
-            {"jailbreak":false,"name":"testAcc-987182423","osVersion":{"minimum":"12"},"platform":"ANDROID"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/device-assurances
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52jze09buvZt01d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:50:12.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:50:12.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52jze09buvZt01d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.077363541s
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 149
-        host: oie-00.dne-okta.com
-        body: |
-            {"description":"Terraform Acceptance Test User Type Updated","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/meta/types/user
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.088560208s
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: oie-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_4@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_4@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52mol2tifbjLc1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.400527875s
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: oie-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_2@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_2@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52prqbaarpmlP1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.401286542s
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: oie-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_1@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_1@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52ibacjgKhnrT1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:12 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.417022833s
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: oie-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_3@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_3@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52wqmcrRgtPcy1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.024840584s
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52jkqjAPlRmVK1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.049848375s
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 59
-        host: oie-00.dne-okta.com
-        body: |
-            {"profile":{"name":"testAcc_0","description":"testAcc_0"}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/groups
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52p5q3jHugiCV1d7","created":"2026-01-23T08:50:13.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","lastMembershipUpdated":"2026-01-23T08:50:13.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.108250583s
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.040559625s
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/activate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou52xfeyNyUBRZT1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.197634709s
-    - id: 44
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 170
-        host: oie-00.dne-okta.com
-        body: |
-            {"credentials":{"password":{}},"profile":{"email":"testAcc_0@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_0@example.com","postalAddress":null}}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/users
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52op1iqG4Tcft1d7","status":"PROVISIONED","created":"2026-01-23T08:50:13.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.502568542s
-    - id: 45
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52prqbaarpmlP1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Etag:
-                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.241880833s
-    - id: 46
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52mol2tifbjLc1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:13 GMT
-            Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.301330208s
-    - id: 47
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52n7uvhRNz1Qs1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.802689334s
-    - id: 48
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52jkqjAPlRmVK1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.0480295s
-    - id: 49
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52p5q3jHugiCV1d7","created":"2026-01-23T08:50:13.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","lastMembershipUpdated":"2026-01-23T08:50:13.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.047759792s
-    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1798,123 +1197,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqk5wiLoKD1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/apps"}}}'
+        body: '{"id":"00gv4uovmlFmUndjg1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
+                - Wed, 18 Feb 2026 06:30:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.051918833s
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52wqmcrRgtPcy1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
-            Etag:
-                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.231786875s
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou52xfeyNyUBRZT1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.039342458s
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52ibacjgKhnrT1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
-            Etag:
-                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.001534625s
-    - id: 54
+        duration: 1.069781459s
+    - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1938,20 +1234,242 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52rjhcWWTblzH1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/apps"}}}'
+        body: '{"id":"00gv4umd44U7u8VcV1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
+                - Wed, 18 Feb 2026 06:30:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0553835s
-    - id: 55
+        duration: 1.07848125s
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 263
+        host: oie-00.dne-okta.com
+        body: |
+            {"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"name":"testAcc_987182423","proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4unkr4lbUXArb1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.093296791s
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 149
+        host: oie-00.dne-okta.com
+        body: |
+            {"description":"Terraform Acceptance Test User Type Updated","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/meta/types/user
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.113287375s
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 97
+        host: oie-00.dne-okta.com
+        body: |
+            {"jailbreak":false,"name":"testAcc-987182423","osVersion":{"minimum":"12"},"platform":"ANDROID"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/device-assurances
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4unk3os2g8umr1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:30:48.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:30:48.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4unk3os2g8umr1d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.131957583s
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_4@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_4@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uo2hrCS8t4421d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.299504625s
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_0@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_0@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uopo5bMI0oxR1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.383678958s
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_1@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_1@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4umdt3UXAvlxa1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:49.000Z","statusChanged":"2026-02-18T06:30:49.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:49.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.47053275s
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1963,7 +1481,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1971,21 +1489,495 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52op1iqG4Tcft1d7","status":"PROVISIONED","created":"2026-01-23T08:50:13.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4ulzapeJL27I81d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:14 GMT
+                - Wed, 18 Feb 2026 06:30:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.067701958s
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uovmlFmUndjg1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.11902575s
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uoqex0SJpLHo1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.134039583s
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4unkr4lbUXArb1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:50.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.336360584s
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uo2hrCS8t4421d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Etag:
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.259990291s
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 170
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_3@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_3@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uoetyGbmo4uv1d7","status":"PROVISIONED","created":"2026-02-18T06:30:49.000Z","activated":"2026-02-18T06:30:50.000Z","statusChanged":"2026-02-18T06:30:50.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:50.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.438387958s
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uopo5bMI0oxR1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
             Etag:
                 - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.252455041s
+        duration: 1.251629041s
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.569218166s
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4umdt3UXAvlxa1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:49.000Z","statusChanged":"2026-02-18T06:30:49.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:49.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Etag:
+                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.2807315s
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4umd44U7u8VcV1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.890257292s
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ulzapeJL27I81d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.0957075s
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uoqex0SJpLHo1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.071290125s
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uovmlFmUndjg1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.074562958s
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4unkr4lbUXArb1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:50.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:51 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.10168375s
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 59
+        host: oie-00.dne-okta.com
+        body: |
+            {"profile":{"name":"testAcc_0","description":"testAcc_0"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4unx5uObfT1iQ1d7","created":"2026-02-18T06:30:51.000Z","lastUpdated":"2026-02-18T06:30:51.000Z","lastMembershipUpdated":"2026-02-18T06:30:51.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:51 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.074873334s
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1998,7 +1990,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2006,19 +1998,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52n7uvhRNz1Qs1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/apps"}}}'
+        body: '{"id":"00uv4uoetyGbmo4uv1d7","status":"PROVISIONED","created":"2026-02-18T06:30:49.000Z","activated":"2026-02-18T06:30:50.000Z","statusChanged":"2026-02-18T06:30:50.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:50.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:15 GMT
+                - Wed, 18 Feb 2026 06:30:51 GMT
+            Etag:
+                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.046535042s
+        duration: 1.255982125s
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2031,7 +2025,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2039,52 +2033,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52p5q3jHugiCV1d7","created":"2026-01-23T08:50:13.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","lastMembershipUpdated":"2026-01-23T08:50:13.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/apps"}}}'
+        body: '{"id":"00gv4umd44U7u8VcV1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:15 GMT
+                - Wed, 18 Feb 2026 06:30:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.040611916s
+        duration: 1.074611125s
     - id: 58
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 170
         host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc_2@example.com","firstName":"TestAcc","lastName":"Smith","login":"testAcc_2@example.com","postalAddress":null}}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7
-        method: GET
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqk5wiLoKD1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/apps"}}}'
+        body: '{"id":"00uv4un9eg54xsS6E1d7","status":"PROVISIONED","created":"2026-02-18T06:30:51.000Z","activated":"2026-02-18T06:30:51.000Z","statusChanged":"2026-02-18T06:30:51.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:51.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:15 GMT
+                - Wed, 18 Feb 2026 06:30:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.044239333s
+        duration: 1.606258125s
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2097,7 +2095,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2105,19 +2103,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52rjhcWWTblzH1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/apps"}}}'
+        body: '{"id":"00gv4unx5uObfT1iQ1d7","created":"2026-02-18T06:30:51.000Z","lastUpdated":"2026-02-18T06:30:51.000Z","lastMembershipUpdated":"2026-02-18T06:30:51.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:15 GMT
+                - Wed, 18 Feb 2026 06:30:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.040923791s
+        duration: 1.10754125s
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2130,7 +2128,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2138,19 +2136,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqk5wiLoKD1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/apps"}}}'
+        body: '{"id":"00uv4un9eg54xsS6E1d7","status":"PROVISIONED","created":"2026-02-18T06:30:51.000Z","activated":"2026-02-18T06:30:51.000Z","statusChanged":"2026-02-18T06:30:51.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:51.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:16 GMT
+                - Wed, 18 Feb 2026 06:30:53 GMT
+            Etag:
+                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.048625833s
+        duration: 1.31763125s
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2163,7 +2163,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2171,19 +2171,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52rjhcWWTblzH1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/apps"}}}'
+        body: '{"id":"00gv4unx5uObfT1iQ1d7","created":"2026-02-18T06:30:51.000Z","lastUpdated":"2026-02-18T06:30:51.000Z","lastMembershipUpdated":"2026-02-18T06:30:51.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:16 GMT
+                - Wed, 18 Feb 2026 06:30:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.058698375s
+        duration: 1.12511025s
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2192,7 +2192,7 @@ interactions:
         content_length: 1513
         host: oie-00.dne-okta.com
         body: |
-            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","inactivityPeriod":"PT2H","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daeu52jze09buvZt01d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"people":{"groups":{"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"],"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"]},"users":{"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"],"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyu52sjpiZfyGTFZ1d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
+            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","inactivityPeriod":"PT2H","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daev4unk3os2g8umr1d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"people":{"groups":{"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"],"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"]},"users":{"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"],"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyv4uneu0eGa2gW31d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
         headers:
             Accept:
                 - application/json
@@ -2200,7 +2200,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -2208,19 +2208,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:54.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:19 GMT
+                - Wed, 18 Feb 2026 06:30:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.832459791s
+        duration: 1.340222375s
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2233,7 +2233,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2241,19 +2241,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:54.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:21 GMT
+                - Wed, 18 Feb 2026 06:30:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.534688042s
+        duration: 1.156177875s
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2274,19 +2274,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:22 GMT
+                - Wed, 18 Feb 2026 06:30:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.043893375s
+        duration: 1.092240459s
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2299,7 +2299,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2307,19 +2307,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:22 GMT
+                - Wed, 18 Feb 2026 06:30:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081611417s
+        duration: 1.109508166s
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2347,12 +2347,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:23 GMT
+                - Wed, 18 Feb 2026 06:30:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.056849166s
+        duration: 1.160647833s
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2365,7 +2365,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2373,19 +2373,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52jze09buvZt01d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:50:12.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:50:12.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52jze09buvZt01d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4unkr4lbUXArb1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:50.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:30:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.040039875s
+        duration: 1.062452541s
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2398,7 +2398,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7
+        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2406,19 +2406,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}'
+        body: '{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:30:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.041900375s
+        duration: 1.078136s
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2431,7 +2431,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2439,19 +2439,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqjAPlRmVK1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/apps"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:30:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.044569666s
+        duration: 1.137242708s
     - id: 70
       request:
         proto: HTTP/1.1
@@ -2464,7 +2464,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2472,19 +2472,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou52xfeyNyUBRZT1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"00uv4uopo5bMI0oxR1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:30:59 GMT
+            Etag:
+                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0487975s
+        duration: 1.262884375s
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2497,7 +2499,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2505,19 +2507,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52p5q3jHugiCV1d7","created":"2026-01-23T08:50:13.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","lastMembershipUpdated":"2026-01-23T08:50:13.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/apps"}}}'
+        body: '{"id":"00uv4uo2hrCS8t4421d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:30:59 GMT
+            Etag:
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0523605s
+        duration: 1.267139s
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2530,7 +2534,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2538,19 +2542,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqk5wiLoKD1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/apps"}}}'
+        body: '{"id":"00uv4umdt3UXAvlxa1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:49.000Z","statusChanged":"2026-02-18T06:30:49.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:49.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:30:59 GMT
+            Etag:
+                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.058616917s
+        duration: 1.267669208s
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2563,7 +2569,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2571,20 +2577,57 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52rjhcWWTblzH1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/apps"}}}'
+        body: '{"id":"00uv4uoetyGbmo4uv1d7","status":"PROVISIONED","created":"2026-02-18T06:30:49.000Z","activated":"2026-02-18T06:30:50.000Z","statusChanged":"2026-02-18T06:30:50.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:50.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:30:59 GMT
+            Etag:
+                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.069399125s
+        duration: 1.268344542s
     - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4un9eg54xsS6E1d7","status":"PROVISIONED","created":"2026-02-18T06:30:51.000Z","activated":"2026-02-18T06:30:51.000Z","statusChanged":"2026-02-18T06:30:51.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:51.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:30:59 GMT
+            Etag:
+                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.290449875s
+    - id: 75
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2604,52 +2647,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.090021s
-    - id: 75
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:24 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.098581458s
+        duration: 1.864894208s
     - id: 76
       request:
         proto: HTTP/1.1
@@ -2662,7 +2672,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7
+        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2670,19 +2680,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52n7uvhRNz1Qs1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/apps"}}}'
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4unk3os2g8umr1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:30:48.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:30:48.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4unk3os2g8umr1d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:25 GMT
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.812965625s
+        duration: 1.8801325s
     - id: 77
       request:
         proto: HTTP/1.1
@@ -2695,7 +2705,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2703,21 +2713,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52wqmcrRgtPcy1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4unx5uObfT1iQ1d7","created":"2026-02-18T06:30:51.000Z","lastUpdated":"2026-02-18T06:30:51.000Z","lastMembershipUpdated":"2026-02-18T06:30:51.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:25 GMT
-            Etag:
-                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.066476667s
+        duration: 1.068357417s
     - id: 78
       request:
         proto: HTTP/1.1
@@ -2730,7 +2738,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2738,21 +2746,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52ibacjgKhnrT1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4uoqex0SJpLHo1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:26 GMT
-            Etag:
-                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.24329675s
+        duration: 1.083537708s
     - id: 79
       request:
         proto: HTTP/1.1
@@ -2760,34 +2766,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
+        form:
+            kid:
+                - Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata?kid=Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52prqbaarpmlP1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/deactivate","method":"POST"}}}'
+        content_length: 2689
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4umno9NtAslgJ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJ
+            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
+            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
+            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+            ggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdA
+            Cbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl
+            2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFY
+            pRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq
+            9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqduf
+            BAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nn
+            bcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9E
+            caa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1G
+            dBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2689"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:50:26 GMT
-            Etag:
-                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.239866375s
+        duration: 1.076672417s
     - id: 80
       request:
         proto: HTTP/1.1
@@ -2800,7 +2825,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2808,21 +2833,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52mol2tifbjLc1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4uovmlFmUndjg1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:26 GMT
-            Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.247989583s
+        duration: 1.054512917s
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2830,53 +2853,32 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            kid:
-                - zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
         headers:
             Accept:
-                - application/xml
+                - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata?kid=zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2685
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52r8ngU3CmT5P1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJ
-            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
-            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
-            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8
-            PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diE
-            Cv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7m
-            NKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnv
-            t2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ
-            +UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQj
-            TtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1i
-            AUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEU
-            Z3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ulzapeJL27I81d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2685"
             Content-Type:
-                - application/xml;charset=ISO-8859-1
+                - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:26 GMT
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.22740825s
+        duration: 1.072316792s
     - id: 82
       request:
         proto: HTTP/1.1
@@ -2889,7 +2891,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2897,21 +2899,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52op1iqG4Tcft1d7","status":"PROVISIONED","created":"2026-01-23T08:50:13.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4umd44U7u8VcV1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:26 GMT
-            Etag:
-                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
+                - Wed, 18 Feb 2026 06:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.991590542s
+        duration: 1.078611792s
     - id: 83
       request:
         proto: HTTP/1.1
@@ -2924,7 +2924,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -2932,19 +2932,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:49:27.000Z","lastUpdated":"2026-01-23T08:49:27.000Z","expiresAt":"2036-01-23T08:49:26.000Z","kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diECv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7mNKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnvt2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ+UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQjTtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1iAUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEUZ3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI="],"x5t#S256":"gSxzdOq_2evgY8ztkNqSrye7fhzAKjaQq-omt53quV0","e":"AQAB","n":"x35V4BMZR0pfzIxC-eofdsVJUuQdS7utDGZRF-Dj2vYg51VwEwjmq1nDaJ9CBIJk_D0xETIFtS-FqLxXBoo_qztOX8hNuJP6ySpZITDI44g-k_zhjc-zlaYByRwXiNgstrwPeQPl6uHYhAr9965tU0K7rPXQ-5hbDts_QY1kjIatv1lWTqzHq01myt4z3IqfjSMBUxCqwV9MnYATmrN1Ccke5jSpbFt_aTpNOLH0M8sDDrPcP-jWjyvsMrVqak9IbDG__s5iPdoXjokJErVM98unfM5oOz9oQuk577dqU-8E8vp-sGRNecJjjcJRFCF2ZBZZoFOb6DzZf0gBQjsSVQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:30:14.000Z","lastUpdated":"2026-02-18T06:30:14.000Z","expiresAt":"2036-02-18T06:30:13.000Z","kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdACbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFYpRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqdufBAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nnbcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9Ecaa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1GdBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4="],"x5t#S256":"dxAeIKWPEt_Nal249ZkGi-CqBwCC80W2c8GZAM9Bxb0","e":"AQAB","n":"8iwpEgwqM-L37S_UDYynIXSADS0SB6M0GDJ7hMrConuNUgd7bjwZFrIYzSw3ishnQAm3ZM9YXQKiXFaYLJs3fprdkOsp3XcnI87KXSpG9heJPKZDwUnpfiPaZJcs7tXUdPzArmnaSeI5Jdlo4XnjanNtE8omgAIZ8SfZG9pyfd2UcrCt7sWHFLgMXvXW9mLBL-fjOXOaA6wCG9JauGRWHsIxWKUQfJ3hUip_z4aT4yFjzQ3VJ0i4-91FjL1tplyn2wIgN0O9T2Q_Qhy9pQrprcsN6LCkMuxBMsFQKvYxgQ4ikYH_M4hVgLMXSOLXIYuUSud-uQWeOQ9KLdRmwXZ8dw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:28 GMT
+                - Wed, 18 Feb 2026 06:31:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.419774083s
+        duration: 1.138890542s
     - id: 84
       request:
         proto: HTTP/1.1
@@ -2957,7 +2957,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2965,19 +2965,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:29 GMT
+                - Wed, 18 Feb 2026 06:31:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.970645166s
+        duration: 1.085689s
     - id: 85
       request:
         proto: HTTP/1.1
@@ -3005,12 +3005,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:31 GMT
+                - Wed, 18 Feb 2026 06:31:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.043376959s
+        duration: 1.165483042s
     - id: 86
       request:
         proto: HTTP/1.1
@@ -3023,7 +3023,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3031,19 +3031,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:54.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:32 GMT
+                - Wed, 18 Feb 2026 06:31:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.399831042s
+        duration: 1.213071959s
     - id: 87
       request:
         proto: HTTP/1.1
@@ -3064,19 +3064,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:34 GMT
+                - Wed, 18 Feb 2026 06:31:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.064925334s
+        duration: 1.098983s
     - id: 88
       request:
         proto: HTTP/1.1
@@ -3089,7 +3089,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3097,19 +3097,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:34 GMT
+                - Wed, 18 Feb 2026 06:31:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.074977917s
+        duration: 1.100151834s
     - id: 89
       request:
         proto: HTTP/1.1
@@ -3137,12 +3137,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:35 GMT
+                - Wed, 18 Feb 2026 06:31:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.324149917s
+        duration: 1.113715792s
     - id: 90
       request:
         proto: HTTP/1.1
@@ -3155,7 +3155,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3163,19 +3163,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52jze09buvZt01d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:50:12.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:50:12.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52jze09buvZt01d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"id":"00gv4unx5uObfT1iQ1d7","created":"2026-02-18T06:30:51.000Z","lastUpdated":"2026-02-18T06:30:51.000Z","lastMembershipUpdated":"2026-02-18T06:30:51.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:37 GMT
+                - Wed, 18 Feb 2026 06:31:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.944408334s
+        duration: 1.104576041s
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3188,7 +3188,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3196,20 +3196,53 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou52xfeyNyUBRZT1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"00gv4ulzapeJL27I81d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:37 GMT
+                - Wed, 18 Feb 2026 06:31:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.944932375s
+        duration: 1.106782125s
     - id: 92
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uovmlFmUndjg1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:08 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.1130975s
+    - id: 93
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3229,54 +3262,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:37 GMT
+                - Wed, 18 Feb 2026 06:31:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.946157125s
-    - id: 93
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52op1iqG4Tcft1d7","status":"PROVISIONED","created":"2026-01-23T08:50:13.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:37 GMT
-            Etag:
-                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.958499875s
+        duration: 1.118809625s
     - id: 94
       request:
         proto: HTTP/1.1
@@ -3289,7 +3287,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3297,19 +3295,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4unk3os2g8umr1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:30:48.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:30:48.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4unk3os2g8umr1d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:37 GMT
+                - Wed, 18 Feb 2026 06:31:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.960976292s
+        duration: 1.120291958s
     - id: 95
       request:
         proto: HTTP/1.1
@@ -3322,7 +3320,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3330,21 +3328,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52wqmcrRgtPcy1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00gv4umd44U7u8VcV1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:37 GMT
-            Etag:
-                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+                - Wed, 18 Feb 2026 06:31:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.12881425s
+        duration: 1.128918792s
     - id: 96
       request:
         proto: HTTP/1.1
@@ -3357,7 +3353,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7
+        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3365,19 +3361,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}'
+        body: '{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.72075775s
+        duration: 1.133376334s
     - id: 97
       request:
         proto: HTTP/1.1
@@ -3390,7 +3386,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3398,21 +3394,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52mol2tifbjLc1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4uoetyGbmo4uv1d7","status":"PROVISIONED","created":"2026-02-18T06:30:49.000Z","activated":"2026-02-18T06:30:50.000Z","statusChanged":"2026-02-18T06:30:50.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:50.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:08 GMT
             Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
+                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.92617375s
+        duration: 1.146492333s
     - id: 98
       request:
         proto: HTTP/1.1
@@ -3425,7 +3421,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3433,19 +3429,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52p5q3jHugiCV1d7","created":"2026-01-23T08:50:13.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","lastMembershipUpdated":"2026-01-23T08:50:13.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/apps"}}}'
+        body: '{"id":"00gv4uoqex0SJpLHo1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.048000917s
+        duration: 1.964604625s
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3458,7 +3454,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3466,19 +3462,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52rjhcWWTblzH1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/apps"}}}'
+        body: '{"id":"00uv4uo2hrCS8t4421d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:10 GMT
+            Etag:
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.053671875s
+        duration: 1.14102275s
     - id: 100
       request:
         proto: HTTP/1.1
@@ -3491,7 +3489,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3499,19 +3497,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqjAPlRmVK1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/apps"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.056272375s
+        duration: 1.157570416s
     - id: 101
       request:
         proto: HTTP/1.1
@@ -3524,7 +3522,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3532,19 +3530,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqk5wiLoKD1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/apps"}}}'
+        body: '{"id":"00uv4uopo5bMI0oxR1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:10 GMT
+            Etag:
+                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.050375042s
+        duration: 1.321083083s
     - id: 102
       request:
         proto: HTTP/1.1
@@ -3552,53 +3552,32 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            kid:
-                - zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
         headers:
             Accept:
-                - application/xml
+                - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata?kid=zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2685
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52r8ngU3CmT5P1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJ
-            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
-            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
-            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8
-            PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diE
-            Cv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7m
-            NKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnv
-            t2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ
-            +UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQj
-            TtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1i
-            AUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEU
-            Z3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4unkr4lbUXArb1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:50.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2685"
             Content-Type:
-                - application/xml;charset=ISO-8859-1
+                - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.216972667s
+        duration: 2.762855125s
     - id: 103
       request:
         proto: HTTP/1.1
@@ -3611,7 +3590,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3619,19 +3598,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52n7uvhRNz1Qs1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/apps"}}}'
+        body: '{"id":"00uv4un9eg54xsS6E1d7","status":"PROVISIONED","created":"2026-02-18T06:30:51.000Z","activated":"2026-02-18T06:30:51.000Z","statusChanged":"2026-02-18T06:30:51.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:51.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:38 GMT
+                - Wed, 18 Feb 2026 06:31:10 GMT
+            Etag:
+                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.054343875s
+        duration: 1.950173791s
     - id: 104
       request:
         proto: HTTP/1.1
@@ -3644,7 +3625,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3652,21 +3633,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52ibacjgKhnrT1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4umdt3UXAvlxa1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:49.000Z","statusChanged":"2026-02-18T06:30:49.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:49.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:39 GMT
+                - Wed, 18 Feb 2026 06:31:10 GMT
             Etag:
                 - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 3.674340917s
+        duration: 2.089013792s
     - id: 105
       request:
         proto: HTTP/1.1
@@ -3674,34 +3655,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
+        form:
+            kid:
+                - Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata?kid=Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52prqbaarpmlP1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/deactivate","method":"POST"}}}'
+        content_length: 2689
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4umno9NtAslgJ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJ
+            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
+            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
+            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+            ggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdA
+            Cbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl
+            2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFY
+            pRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq
+            9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqduf
+            BAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nn
+            bcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9E
+            caa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1G
+            dBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2689"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Fri, 23 Jan 2026 08:50:39 GMT
-            Etag:
-                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
+                - Wed, 18 Feb 2026 06:31:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 3.675503166s
+        duration: 1.076413375s
     - id: 106
       request:
         proto: HTTP/1.1
@@ -3714,7 +3714,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -3722,19 +3722,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:49:27.000Z","lastUpdated":"2026-01-23T08:49:27.000Z","expiresAt":"2036-01-23T08:49:26.000Z","kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diECv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7mNKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnvt2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ+UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQjTtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1iAUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEUZ3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI="],"x5t#S256":"gSxzdOq_2evgY8ztkNqSrye7fhzAKjaQq-omt53quV0","e":"AQAB","n":"x35V4BMZR0pfzIxC-eofdsVJUuQdS7utDGZRF-Dj2vYg51VwEwjmq1nDaJ9CBIJk_D0xETIFtS-FqLxXBoo_qztOX8hNuJP6ySpZITDI44g-k_zhjc-zlaYByRwXiNgstrwPeQPl6uHYhAr9965tU0K7rPXQ-5hbDts_QY1kjIatv1lWTqzHq01myt4z3IqfjSMBUxCqwV9MnYATmrN1Ccke5jSpbFt_aTpNOLH0M8sDDrPcP-jWjyvsMrVqak9IbDG__s5iPdoXjokJErVM98unfM5oOz9oQuk577dqU-8E8vp-sGRNecJjjcJRFCF2ZBZZoFOb6DzZf0gBQjsSVQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:30:14.000Z","lastUpdated":"2026-02-18T06:30:14.000Z","expiresAt":"2036-02-18T06:30:13.000Z","kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdACbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFYpRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqdufBAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nnbcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9Ecaa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1GdBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4="],"x5t#S256":"dxAeIKWPEt_Nal249ZkGi-CqBwCC80W2c8GZAM9Bxb0","e":"AQAB","n":"8iwpEgwqM-L37S_UDYynIXSADS0SB6M0GDJ7hMrConuNUgd7bjwZFrIYzSw3ishnQAm3ZM9YXQKiXFaYLJs3fprdkOsp3XcnI87KXSpG9heJPKZDwUnpfiPaZJcs7tXUdPzArmnaSeI5Jdlo4XnjanNtE8omgAIZ8SfZG9pyfd2UcrCt7sWHFLgMXvXW9mLBL-fjOXOaA6wCG9JauGRWHsIxWKUQfJ3hUip_z4aT4yFjzQ3VJ0i4-91FjL1tplyn2wIgN0O9T2Q_Qhy9pQrprcsN6LCkMuxBMsFQKvYxgQ4ikYH_M4hVgLMXSOLXIYuUSud-uQWeOQ9KLdRmwXZ8dw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:39 GMT
+                - Wed, 18 Feb 2026 06:31:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.2112945s
+        duration: 1.285901917s
     - id: 107
       request:
         proto: HTTP/1.1
@@ -3747,7 +3747,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3755,19 +3755,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:40 GMT
+                - Wed, 18 Feb 2026 06:31:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.093316875s
+        duration: 1.150069583s
     - id: 108
       request:
         proto: HTTP/1.1
@@ -3795,12 +3795,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:42 GMT
+                - Wed, 18 Feb 2026 06:31:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0696535s
+        duration: 1.141058s
     - id: 109
       request:
         proto: HTTP/1.1
@@ -3813,7 +3813,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3821,19 +3821,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:30:54.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","inactivityPeriod":"PT2H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:43 GMT
+                - Wed, 18 Feb 2026 06:31:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.054328s
+        duration: 1.165630833s
     - id: 110
       request:
         proto: HTTP/1.1
@@ -3854,19 +3854,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:44 GMT
+                - Wed, 18 Feb 2026 06:31:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0538305s
+        duration: 1.087449875s
     - id: 111
       request:
         proto: HTTP/1.1
@@ -3879,7 +3879,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3887,19 +3887,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:44 GMT
+                - Wed, 18 Feb 2026 06:31:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081703584s
+        duration: 1.114237208s
     - id: 112
       request:
         proto: HTTP/1.1
@@ -3927,12 +3927,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:45 GMT
+                - Wed, 18 Feb 2026 06:31:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.05056425s
+        duration: 1.087124s
     - id: 113
       request:
         proto: HTTP/1.1
@@ -3941,7 +3941,7 @@ interactions:
         content_length: 1487
         host: oie-00.dne-okta.com
         body: |
-            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daeu52jze09buvZt01d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"people":{"groups":{"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"],"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"]},"users":{"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"],"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyu52sjpiZfyGTFZ1d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
+            {"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"constraints":[{"knowledge":{"reauthenticateIn":"PT2H","types":["password"],"required":false},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"deviceBound":"REQUIRED","hardwareProtection":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}],"factorMode":"2FA","reauthenticateIn":"PT43800H","type":"ASSURANCE"}}},"conditions":{"device":{"assurance":{"include":["daev4unk3os2g8umr1d7"]},"managed":false,"registered":true},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"people":{"groups":{"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"],"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"]},"users":{"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"],"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"]}},"platform":{"include":[{"os":{"expression":null,"type":"MACOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"CHROMEOS"},"type":"DESKTOP"},{"os":{"expression":null,"type":"IOS"},"type":"MOBILE"},{"os":{"expression":null,"type":"ANDROID"},"type":"MOBILE"},{"os":{"expression":null,"type":"WINDOWS"},"type":"DESKTOP"}]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"exclude":["otyv4uneu0eGa2gW31d7"],"include":["otyqq6ctk459iqtED1d7"]}},"name":"testAcc_987182423_updated","priority":98,"type":"ACCESS_POLICY"}
         headers:
             Accept:
                 - application/json
@@ -3949,7 +3949,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3957,19 +3957,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:46.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:31:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:46 GMT
+                - Wed, 18 Feb 2026 06:31:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.212728375s
+        duration: 1.276315958s
     - id: 114
       request:
         proto: HTTP/1.1
@@ -3982,7 +3982,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -3990,19 +3990,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:46.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:31:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:47 GMT
+                - Wed, 18 Feb 2026 06:31:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.060433375s
+        duration: 1.183552667s
     - id: 115
       request:
         proto: HTTP/1.1
@@ -4023,19 +4023,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:48 GMT
+                - Wed, 18 Feb 2026 06:31:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.058136292s
+        duration: 1.095383292s
     - id: 116
       request:
         proto: HTTP/1.1
@@ -4048,7 +4048,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4056,19 +4056,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:48 GMT
+                - Wed, 18 Feb 2026 06:31:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.070363s
+        duration: 1.108400875s
     - id: 117
       request:
         proto: HTTP/1.1
@@ -4096,12 +4096,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:50 GMT
+                - Wed, 18 Feb 2026 06:31:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.840591333s
+        duration: 1.112386709s
     - id: 118
       request:
         proto: HTTP/1.1
@@ -4114,7 +4114,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4122,19 +4122,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52p5q3jHugiCV1d7","created":"2026-01-23T08:50:13.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","lastMembershipUpdated":"2026-01-23T08:50:13.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7/apps"}}}'
+        body: '{"type":"IP","id":"nzov4unkr4lbUXArb1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:50.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:52 GMT
+                - Wed, 18 Feb 2026 06:31:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.426769667s
+        duration: 1.073818167s
     - id: 119
       request:
         proto: HTTP/1.1
@@ -4147,7 +4147,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4155,19 +4155,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou52xfeyNyUBRZT1d7","name":"testAcc_987182423","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:13.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"00gv4unx5uObfT1iQ1d7","created":"2026-02-18T06:30:51.000Z","lastUpdated":"2026-02-18T06:30:51.000Z","lastMembershipUpdated":"2026-02-18T06:30:51.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_0","description":"testAcc_0"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:52 GMT
+                - Wed, 18 Feb 2026 06:31:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.442685125s
+        duration: 1.078721458s
     - id: 120
       request:
         proto: HTTP/1.1
@@ -4180,7 +4180,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7
+        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4188,19 +4188,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52rjhcWWTblzH1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7/apps"}}}'
+        body: '{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:52 GMT
+                - Wed, 18 Feb 2026 06:31:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.44402775s
+        duration: 1.081898958s
     - id: 121
       request:
         proto: HTTP/1.1
@@ -4213,7 +4213,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7
+        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4221,19 +4221,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00gu52jkqjAPlRmVK1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7/apps"}}}'
+        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daev4unk3os2g8umr1d7","osVersion":{"minimum":"12"},"jailbreak":false,"displayRemediationMode":"HIDE","createdDate":"2026-02-18T06:30:48.000Z","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdate":"2026-02-18T06:30:48.000Z","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daev4unk3os2g8umr1d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:52 GMT
+                - Wed, 18 Feb 2026 06:31:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.446010375s
+        duration: 1.08422325s
     - id: 122
       request:
         proto: HTTP/1.1
@@ -4246,7 +4246,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4254,346 +4254,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"00gv4uoqex0SJpLHo1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_4","description":"testAcc_4"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:52 GMT
+                - Wed, 18 Feb 2026 06:31:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.480248375s
+        duration: 1.083743667s
     - id: 123
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52n7uvhRNz1Qs1d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","lastMembershipUpdated":"2026-01-23T08:50:12.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.200189041s
-    - id: 124
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"testAcc-987182423","platform":"ANDROID","id":"daeu52jze09buvZt01d7","osVersion":{"minimum":"12"},"jailbreak":false,"createdDate":"2026-01-23T08:50:12.000Z","createdBy":"00usjkchhgt3fqkr41d7","lastUpdate":"2026-01-23T08:50:12.000Z","lastUpdatedBy":"00usjkchhgt3fqkr41d7","resourceType":"DeviceAssurancePolicyEntity","resourceDisplayName":{"value":"testAcc-987182423","sensitive":false},"resourceId":"daeu52jze09buvZt01d7","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.202924375s
-    - id: 125
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00gu52jkqk5wiLoKD1d7","created":"2026-01-23T08:50:14.000Z","lastUpdated":"2026-01-23T08:50:14.000Z","lastMembershipUpdated":"2026-01-23T08:50:14.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7/apps"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.209602208s
-    - id: 126
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 2.219582333s
-    - id: 127
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52prqbaarpmlP1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Etag:
-                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.069463375s
-    - id: 128
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52ibacjgKhnrT1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Etag:
-                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.080291792s
-    - id: 129
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        form:
-            kid:
-                - zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
-        headers:
-            Accept:
-                - application/xml
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata?kid=zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2685
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exku52r8ngU3CmT5P1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
-            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJ
-            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
-            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
-            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-            ggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8
-            PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diE
-            Cv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7m
-            NKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnv
-            t2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQAD
-            ggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ
-            +UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQj
-            TtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1i
-            AUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEU
-            Z3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_9/exku52r8ngU3CmT5P1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2685"
-            Content-Type:
-                - application/xml;charset=ISO-8859-1
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.210555s
-    - id: 130
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52mol2tifbjLc1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:12.000Z","statusChanged":"2026-01-23T08:50:12.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:12.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Etag:
-                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.246977417s
-    - id: 131
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"00uu52op1iqG4Tcft1d7","status":"PROVISIONED","created":"2026-01-23T08:50:13.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7/lifecycle/deactivate","method":"POST"}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
-            Etag:
-                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.260261125s
-    - id: 132
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4613,19 +4287,345 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:53 GMT
+                - Wed, 18 Feb 2026 06:31:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.987911375s
+        duration: 1.085186084s
+    - id: 124
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4ulzapeJL27I81d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_2","description":"testAcc_2"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.084968417s
+    - id: 125
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4umd44U7u8VcV1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_3","description":"testAcc_3"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.104018042s
+    - id: 126
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.191493958s
+    - id: 127
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gv4uovmlFmUndjg1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","lastMembershipUpdated":"2026-02-18T06:30:48.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_1","description":"testAcc_1"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:25 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.85326s
+    - id: 128
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4un9eg54xsS6E1d7","status":"PROVISIONED","created":"2026-02-18T06:30:51.000Z","activated":"2026-02-18T06:30:51.000Z","statusChanged":"2026-02-18T06:30:51.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:51.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_2@example.com","email":"testAcc_2@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:25 GMT
+            Etag:
+                - W/"82d7a15df46517fdd547f65635239223e9868736bc1dc51610aeaefc42666eb1"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.083103791s
+    - id: 129
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uoetyGbmo4uv1d7","status":"PROVISIONED","created":"2026-02-18T06:30:49.000Z","activated":"2026-02-18T06:30:50.000Z","statusChanged":"2026-02-18T06:30:50.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:50.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:25 GMT
+            Etag:
+                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.089424833s
+    - id: 130
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4umdt3UXAvlxa1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:49.000Z","statusChanged":"2026-02-18T06:30:49.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:49.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_1@example.com","email":"testAcc_1@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:25 GMT
+            Etag:
+                - W/"8a6495ea06dfeeda1af6ab87d9b5f7e63e7ffb95ae1604cc34166228e623e613"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.109056625s
+    - id: 131
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uv4uopo5bMI0oxR1d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_0@example.com","email":"testAcc_0@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:31:25 GMT
+            Etag:
+                - W/"db829d2deefbf4486f4eb944eeeb06e7ada74bf71b44d0629a76e68f50f28e56"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.285353417s
+    - id: 132
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            kid:
+                - Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
+        headers:
+            Accept:
+                - application/xml
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata?kid=Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2689
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkv4umno9NtAslgJ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcN
+            AQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJ
+            BgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0w
+            CwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1k
+            Y3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+            ggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdA
+            Cbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl
+            2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFY
+            pRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq
+            9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQAD
+            ggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqduf
+            BAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nn
+            bcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9E
+            caa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1G
+            dBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/slo/saml"/><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc987182423_12/exkv4umno9NtAslgJ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2689"
+            Content-Type:
+                - application/xml;charset=ISO-8859-1
+            Date:
+                - Wed, 18 Feb 2026 06:31:25 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.254430291s
     - id: 133
       request:
         proto: HTTP/1.1
@@ -4638,7 +4638,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4646,21 +4646,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"00uu52wqmcrRgtPcy1d7","status":"PROVISIONED","created":"2026-01-23T08:50:12.000Z","activated":"2026-01-23T08:50:13.000Z","statusChanged":"2026-01-23T08:50:13.000Z","lastLogin":null,"lastUpdated":"2026-01-23T08:50:13.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_3@example.com","email":"testAcc_3@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7/lifecycle/deactivate","method":"POST"}}}'
+        body: '{"id":"00uv4uo2hrCS8t4421d7","status":"PROVISIONED","created":"2026-02-18T06:30:48.000Z","activated":"2026-02-18T06:30:48.000Z","statusChanged":"2026-02-18T06:30:48.000Z","lastLogin":null,"lastUpdated":"2026-02-18T06:30:48.000Z","passwordChanged":null,"realmId":"guoqq6qu6vxx74CDh1d7","type":{"id":"otyqq6ctk459iqtED1d7"},"profile":{"firstName":"TestAcc","lastName":"Smith","mobilePhone":null,"secondEmail":null,"login":"testAcc_4@example.com","email":"testAcc_4@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7/lifecycle/deactivate","method":"POST"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:54 GMT
+                - Wed, 18 Feb 2026 06:31:26 GMT
             Etag:
-                - W/"f6d347738c7b63fcc00dc8db5775908e8bce8f71784bb6e59025a5f4ab2cb472"
+                - W/"a3d106b5a1a5121f8f6ffb657f8764a95586eddb1acd1236a328fbdf646fc14e"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.2320305s
+        duration: 1.868703959s
     - id: 134
       request:
         proto: HTTP/1.1
@@ -4673,7 +4673,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -4681,19 +4681,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2026-01-23T08:49:27.000Z","lastUpdated":"2026-01-23T08:49:27.000Z","expiresAt":"2036-01-23T08:49:26.000Z","kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZvqC0m9MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDEyMzA4NDgyNloXDTM2MDEyMzA4NDkyNlowgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHflXgExlHSl/MjEL56h92xUlS5B1Lu60MZlEX4OPa9iDnVXATCOarWcNon0IEgmT8PTERMgW1L4WovFcGij+rO05fyE24k/rJKlkhMMjjiD6T/OGNz7OVpgHJHBeI2Cy2vA95A+Xq4diECv33rm1TQrus9dD7mFsO2z9BjWSMhq2/WVZOrMerTWbK3jPcip+NIwFTEKrBX0ydgBOas3UJyR7mNKlsW39pOk04sfQzywMOs9w/6NaPK+wytWpqT0hsMb/+zmI92heOiQkStUz3y6d8zmg7P2hC6Tnvt2pT7wTy+n6wZE15wmONwlEUIXZkFlmgU5voPNl/SAFCOxJVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMZQpVBZJUWS+oCjzZ6DqBZtXEnhVHCJB+p0ag84B/jLJVrg7pWuLAO/xByg9+KrEiZbF3hJ+UecnnC+/HHT8WoHBWsLb1N118ptx1N5i8kGSoVJ1k5wBGDK0Q1EQqFVLUhIF6caNMuqjrO2RpQjTtSs0VMYk8hOCLWnv1JBkDGRLEgAwieyGMEGGP1pv7x/lhWfor3aTI0QtpmaNyTcfJj1NJVm7x1iAUZnQwHqVgyfyuRkzgFZqo/+1pt/I5eD4zKAlZcuw5WypWd/O0qg5NZxLj4m3mJiFY4XIeIs/uEUZ3rchREw8vNNjidkC8SY35xkwMtYvNJXNfSXK0kCiNI="],"x5t#S256":"gSxzdOq_2evgY8ztkNqSrye7fhzAKjaQq-omt53quV0","e":"AQAB","n":"x35V4BMZR0pfzIxC-eofdsVJUuQdS7utDGZRF-Dj2vYg51VwEwjmq1nDaJ9CBIJk_D0xETIFtS-FqLxXBoo_qztOX8hNuJP6ySpZITDI44g-k_zhjc-zlaYByRwXiNgstrwPeQPl6uHYhAr9965tU0K7rPXQ-5hbDts_QY1kjIatv1lWTqzHq01myt4z3IqfjSMBUxCqwV9MnYATmrN1Ccke5jSpbFt_aTpNOLH0M8sDDrPcP-jWjyvsMrVqak9IbDG__s5iPdoXjokJErVM98unfM5oOz9oQuk577dqU-8E8vp-sGRNecJjjcJRFCF2ZBZZoFOb6DzZf0gBQjsSVQ"}]'
+        body: '[{"kty":"RSA","created":"2026-02-18T06:30:14.000Z","lastUpdated":"2026-02-18T06:30:14.000Z","expiresAt":"2036-02-18T06:30:13.000Z","kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE","use":"sig","x5c":["MIIDrDCCApSgAwIBAgIGAZxvcS0+MA0GCSqGSIb3DQEBCwUAMIGWMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFzAVBgNVBAMMDmRvdG5ldC1zZGstZGNwMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDIxODA2MjkxNFoXDTM2MDIxODA2MzAxM1owgZYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEXMBUGA1UEAwwOZG90bmV0LXNkay1kY3AxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDyLCkSDCoz4vftL9QNjKchdIANLRIHozQYMnuEysKie41SB3tuPBkWshjNLDeKyGdACbdkz1hdAqJcVpgsmzd+mt2Q6ynddycjzspdKkb2F4k8pkPBSel+I9pklyzu1dR0/MCuadpJ4jkl2WjheeNqc20TyiaAAhnxJ9kb2nJ93ZRysK3uxYcUuAxe9db2YsEv5+M5c5oDrAIb0lq4ZFYewjFYpRB8neFSKn/PhpPjIWPNDdUnSLj73UWMvW2mXKfbAiA3Q71PZD9CHL2lCumtyw3osKQy7EEywVAq9jGBDiKRgf8ziFWAsxdI4tchi5RK5365BZ45D0ot1GbBdnx3AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAKkxZFRSFkYPD/q0z8EL6u9oFXBh+q3XvtpjzRSMhtmp/cT7BTirezqZvscPM+AnNQpcqdufBAuVcGWgy9Pw32ouUhOCM2+CLeUgOFh2gFjFAYq6DOZyQSvenQDM0TmFsIIK894xvpuw5BtMX3nnbcBGc114Tf7l1JFLqbmhBalDt0FAbWETtHAhmtx+bsVvmdvNeiiZx5z9Zk5fNAgQpjlP4g/LMY9Ecaa01ZlXYOlDCS07QfGXY9KU4+j2QGqEeGsARlHVNRgI4s+XiNeSWIIHwMfxQ7Am9dpGfbjBPa1GdBRz/ykXxuqP64TKg+OkT+kObljP6/akFjb0aQBc+n4="],"x5t#S256":"dxAeIKWPEt_Nal249ZkGi-CqBwCC80W2c8GZAM9Bxb0","e":"AQAB","n":"8iwpEgwqM-L37S_UDYynIXSADS0SB6M0GDJ7hMrConuNUgd7bjwZFrIYzSw3ishnQAm3ZM9YXQKiXFaYLJs3fprdkOsp3XcnI87KXSpG9heJPKZDwUnpfiPaZJcs7tXUdPzArmnaSeI5Jdlo4XnjanNtE8omgAIZ8SfZG9pyfd2UcrCt7sWHFLgMXvXW9mLBL-fjOXOaA6wCG9JauGRWHsIxWKUQfJ3hUip_z4aT4yFjzQ3VJ0i4-91FjL1tplyn2wIgN0O9T2Q_Qhy9pQrprcsN6LCkMuxBMsFQKvYxgQ4ikYH_M4hVgLMXSOLXIYuUSud-uQWeOQ9KLdRmwXZ8dw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:54 GMT
+                - Wed, 18 Feb 2026 06:31:26 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.212011833s
+        duration: 1.097451375s
     - id: 135
       request:
         proto: HTTP/1.1
@@ -4706,7 +4706,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4714,19 +4714,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:55 GMT
+                - Wed, 18 Feb 2026 06:31:28 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.063325375s
+        duration: 1.151847584s
     - id: 136
       request:
         proto: HTTP/1.1
@@ -4754,12 +4754,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:56 GMT
+                - Wed, 18 Feb 2026 06:31:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.03791075s
+        duration: 1.157450334s
     - id: 137
       request:
         proto: HTTP/1.1
@@ -4772,7 +4772,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4780,19 +4780,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:46.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:31:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:57 GMT
+                - Wed, 18 Feb 2026 06:31:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.051502625s
+        duration: 1.079267417s
     - id: 138
       request:
         proto: HTTP/1.1
@@ -4813,19 +4813,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:59 GMT
+                - Wed, 18 Feb 2026 06:31:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.060617083s
+        duration: 1.116312s
     - id: 139
       request:
         proto: HTTP/1.1
@@ -4838,7 +4838,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4846,19 +4846,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oau52r8nhyacAlm91d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_9:0oau52r8nhyacAlm91d7","name":"oie-00_testacc987182423_9","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-01-23T08:49:27.000Z","created":"2026-01-23T08:49:26.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_9_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"zryo-1xolNWTpAvUJ_XPbZklPDCFCxtQ0C5y5erNNFo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_9_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_9/0oau52r8nhyacAlm91d7/alnu53bxr8ekFBruf1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oav4umnoaFwXDHj61d7","orn":"orn:oktapreview:idp:00oqq6cti0hre4wUB1d7:apps:oie-00_testacc987182423_12:0oav4umnoaFwXDHj61d7","name":"oie-00_testacc987182423_12","label":"testAcc_987182423","status":"ACTIVE","lastUpdated":"2026-02-18T06:30:14.000Z","created":"2026-02-18T06:30:14.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc987182423_12_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"Hztkqij6FtsJLfTbreILHBzD0sgQ3ySsrSAq6NGhuGE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":"https://dunshire.okta.com","requestCompressed":false,"attributeStatements":[{"type":"GROUP","name":"groups","namespace":"urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified","filterType":"REGEX","filterValue":".*"}],"inlineHooks":[],"spCertificate":{"x5c":["MIIFnDCCA4QCCQDBSLbiON2T1zANBgkqhkiG9w0BAQsFADCBjzELMAkGA1UEBhMCVVMxDjAMBgNV\r\nBAgMBU1haW5lMRAwDgYDVQQHDAdDYXJpYm91MRcwFQYDVQQKDA5Tbm93bWFrZXJzIEluYzEUMBIG\r\nA1UECwwLRW5naW5lZXJpbmcxDTALBgNVBAMMBFNub3cxIDAeBgkqhkiG9w0BCQEWEWVtYWlsQGV4\r\nYW1wbGUuY29tMB4XDTIwMTIwMzIyNDY0M1oXDTMwMTIwMTIyNDY0M1owgY8xCzAJBgNVBAYTAlVT\r\nMQ4wDAYDVQQIDAVNYWluZTEQMA4GA1UEBwwHQ2FyaWJvdTEXMBUGA1UECgwOU25vd21ha2VycyBJ\r\nbmMxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQ0wCwYDVQQDDARTbm93MSAwHgYJKoZIhvcNAQkBFhFl\r\nbWFpbEBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANMmWDjXPdoa\r\nPyzIENqeY9njLan2FqCbQPSestWUUcb6NhDsJVGSQ7XR+ozQA5TaJzbP7cAJUj8vCcbqMZsgOQAu\r\nO/pzYyQEKptLmrGvPn7xkJ1A1xLkp2NY18cpDTeUPueJUoidZ9EJwEuyUZIktzxNNU1pA1lGijiu\r\n2XNxs9d9JR/hm3tCu9Im8qLVB4JtX80YUa6QtlRjWR/H8a373AYCOASdoB3c57fIPD8ATDNy2w/c\r\nfCVGiyKDMFB+GA/WTsZpOP3iohRp8ltAncSuzypcztb2iE+jijtTsiC9kUA2abAJqqpoCJubNShi\r\nVff4822czpziS44MV2guC9wANi8u3Uyl5MKsU95j01jzadKRP5S+2f0K+n8n4UoV9fnqZFyuGAKd\r\nCJi9K6NlSAP+TgPe/JP9FOSuxQOHWJfmdLHdJD+evoKi9E55sr5lRFK0xU1Fj5Ld7zjC0pXPhtJf\r\nsgjEZzD433AsHnRzvRT1KSNCPkLYomznZo5n9rWYgCQ8HcytlQDTesmKE+s05E/VSWNtH84XdDrt\r\nieXwfwhHfaABSu+WjZYxi9CXdFCSvXhsgufUcK4FbYAHl/ga/cJxZc52yFC7Pcq0u9O2BSCjYPdQ\r\nDAHs9dhT1RhwVLM8RmoAzgxyyzau0gxnAlgSBD9FMW6dXqIHIp8yAAg9cRXhYRTNAgMBAAEwDQYJ\r\nKoZIhvcNAQELBQADggIBADofEC1SvG8qa7pmKCjB/E9Sxhk3mvUO9Gq43xzwVb721Ng3VYf4vGU3\r\nwLUwJeLt0wggnj26NJweN5T3q9T8UMxZhHSWvttEU3+S1nArRB0beti716HSlOCDx4wTmBu/D1MG\r\nt/kZYFJw+zuzvAcbYct2pK69AQhD8xAIbQvqADJI7cCK3yRry+aWtppc58P81KYabUlCfFXfhJ9E\r\nP72ffN4jVHpX3lxxYh7FKAdiKbY2FYzjsc7RdgKI1R3iAAZUCGBTvezNzaetGzTUjjl/g1tcVYij\r\nltH9ZOQBPlUMI88lxUxqgRTerpPmAJH00CACx4JFiZrweLM1trZyy06wNDQgLrqHr3EOagBF/O2h\r\nhfTehNdVr6iq3YhKWBo4/+RL0RCzHMh4u86VbDDnDn4Y6HzLuyIAtBFoikoKM6UHTOa0Pqv2bBr5\r\nwbkRkVUxl9yJJw/HmTCdfnsM9dTOJUKzEglnGF2184Gg+qJDZB6fSf0EAO1F6sTqiSswl+uHQZiy\r\nDaZzyU7Gg5seKOZ20zTRaX3Ihj9Zij/ORnrARE7eM/usKMECp+7syUwAUKxDCZkGiUdskmOhhBGL\r\nJtbyK3F2UvoJoLsm3pIcvMak9KwMjSTGJB47ABUP1+w+zGcNk0D5Co3IJ6QekiLfWJyQ+kKsWLKt\r\nzOYQQatrnBagM7MI2/T4\r\n"]},"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":true,"issuer":"https://dunshire.okta.com","logoutUrl":"https://dunshire.okta.com/logout"}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc987182423_12_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc987182423_12/0oav4umnoaFwXDHj61d7/alnv4urqzwc1O94rG1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnpaOXS2D11d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:50:59 GMT
+                - Wed, 18 Feb 2026 06:31:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.068393958s
+        duration: 1.117329917s
     - id: 140
       request:
         proto: HTTP/1.1
@@ -4886,12 +4886,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:51:00 GMT
+                - Wed, 18 Feb 2026 06:31:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.041450666s
+        duration: 1.134366792s
     - id: 141
       request:
         proto: HTTP/1.1
@@ -4912,19 +4912,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2025-12-22T08:05:59.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyrcffq1zUfNKiZ11d7","displayName":"First Type","name":"test_type_fc92597a792240c","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-28T08:38:48.000Z","lastUpdated":"2025-10-28T08:38:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscrcffq1zUfNKiZ11d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyrcffq1zUfNKiZ11d7","method":"GET"}}},{"id":"otysadudrrHGvWpSJ1d7","displayName":"First Type","name":"test_type_26eee10059404a7","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-02T05:44:24.000Z","lastUpdated":"2025-12-02T05:44:24.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsadudrrHGvWpSJ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysadudrrHGvWpSJ1d7","method":"GET"}}},{"id":"otysdzugisaDrcXzr1d7","displayName":"First Type","name":"test_type_0e97919ce8414ee","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:01:35.000Z","lastUpdated":"2025-12-05T04:01:35.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsdzugisaDrcXzr1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysdzugisaDrcXzr1d7","method":"GET"}}},{"id":"otyse1784sDi3SbzE1d7","displayName":"First Type","name":"test_type_ad38689a0297412","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:51:13.000Z","lastUpdated":"2025-12-05T04:51:13.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1784sDi3SbzE1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1784sDi3SbzE1d7","method":"GET"}}},{"id":"otyse1bgqwSlXhNo31d7","displayName":"HttpInfo Replaced","name":"test_type_f8bfb902b859443","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:39.000Z","lastUpdated":"2025-12-05T04:54:45.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1bgqwSlXhNo31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1bgqwSlXhNo31d7","method":"GET"}}},{"id":"otyse1cwdyc86yFEP1d7","displayName":"Replaced Display Name","name":"test_type_cb7573175a494bf","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:27.000Z","lastUpdated":"2025-12-05T04:54:34.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1cwdyc86yFEP1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1cwdyc86yFEP1d7","method":"GET"}}},{"id":"otyse1faom9yWRyrO1d7","displayName":"First Type","name":"test_type_75b359b5aede4dd","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-05T04:54:58.000Z","lastUpdated":"2025-12-05T04:54:58.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscse1faom9yWRyrO1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyse1faom9yWRyrO1d7","method":"GET"}}},{"id":"otysm8nwc66X0u16X1d7","displayName":"Replaced Display Name","name":"test_type_f8498fdf1f9340e","description":"Replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-12-12T04:46:46.000Z","lastUpdated":"2025-12-12T04:46:49.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsm8nwc66X0u16X1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysm8nwc66X0u16X1d7","method":"GET"}}},{"id":"otyu52sjpiZfyGTFZ1d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00usjkchhgt3fqkr41d7","lastUpdatedBy":"00usjkchhgt3fqkr41d7","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:50:12.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscu52sjpiZfyGTFZ1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7","method":"GET"}}}]'
+        body: '[{"id":"otyqq6ctk459iqtED1d7","displayName":"User","name":"user","description":"Okta user profile template with default permission settings","createdBy":"sprqq6cti1x6lF25I1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2025-10-07T06:36:54.000Z","lastUpdated":"2026-02-11T12:02:41.000Z","default":true,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqq6ctk459iqtED1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqq6ctk459iqtED1d7","method":"GET"}}},{"id":"otyuwaqzvthVu77e31d7","displayName":"First Type","name":"test_type_8c8f4eb11eac4cc","description":"First description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:14.000Z","lastUpdated":"2026-02-11T12:54:14.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwaqzvthVu77e31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwaqzvthVu77e31d7","method":"GET"}}},{"id":"otyuwar7tsKoTYKWa1d7","displayName":"HttpInfo Replaced","name":"test_type_8abf3263f1a14b1","description":"HttpInfo replaced description","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-11T12:54:07.000Z","lastUpdated":"2026-02-11T12:54:10.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscuwar7tsKoTYKWa1d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyuwar7tsKoTYKWa1d7","method":"GET"}}},{"id":"otyv4uneu0eGa2gW31d7","displayName":"Terraform Acceptance Test User Type Updated","name":"testAcc_987182423","description":"Terraform Acceptance Test User Type Updated","createdBy":"00uqq6ctmb6vABZvJ1d7","lastUpdatedBy":"00uqq6ctmb6vABZvJ1d7","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:30:48.000Z","default":false,"_links":{"schema":{"rel":"schema","href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscv4uneu0eGa2gW31d7","method":"GET"},"self":{"rel":"self","href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7","method":"GET"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:51:01 GMT
+                - Wed, 18 Feb 2026 06:31:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.045162792s
+        duration: 1.108157875s
     - id: 142
       request:
         proto: HTTP/1.1
@@ -4937,7 +4937,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -4945,19 +4945,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"rulu52mxo5F35RjRR1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-01-23T08:49:40.000Z","lastUpdated":"2026-01-23T08:50:46.000Z","system":false,"conditions":{"people":{"users":{"include":["00uu52op1iqG4Tcft1d7","00uu52ibacjgKhnrT1d7"],"exclude":["00uu52wqmcrRgtPcy1d7","00uu52prqbaarpmlP1d7","00uu52mol2tifbjLc1d7"]},"groups":{"include":["00gu52jkqk5wiLoKD1d7","00gu52p5q3jHugiCV1d7"],"exclude":["00gu52jkqjAPlRmVK1d7","00gu52n7uvhRNz1Qs1d7","00gu52rjhcWWTblzH1d7"]}},"network":{"connection":"ZONE","include":["nzou52xfeyNyUBRZT1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daeu52jze09buvZt01d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyu52sjpiZfyGTFZ1d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
+        body: '{"id":"rulv4uo4yq2ZNyolp1d7","status":"ACTIVE","name":"testAcc_987182423_updated","priority":98,"created":"2026-02-18T06:30:25.000Z","lastUpdated":"2026-02-18T06:31:19.000Z","system":false,"conditions":{"people":{"users":{"include":["00uv4umdt3UXAvlxa1d7","00uv4uopo5bMI0oxR1d7"],"exclude":["00uv4uo2hrCS8t4421d7","00uv4uoetyGbmo4uv1d7","00uv4un9eg54xsS6E1d7"]},"groups":{"include":["00gv4unx5uObfT1iQ1d7","00gv4uovmlFmUndjg1d7"],"exclude":["00gv4umd44U7u8VcV1d7","00gv4uoqex0SJpLHo1d7","00gv4ulzapeJL27I81d7"]}},"network":{"connection":"ZONE","include":["nzov4unkr4lbUXArb1d7"]},"device":{"registered":true,"managed":false,"assurance":{"include":["daev4unk3os2g8umr1d7"]}},"platform":{"include":[{"type":"DESKTOP","os":{"type":"MACOS"}},{"type":"DESKTOP","os":{"type":"CHROMEOS"}},{"type":"MOBILE","os":{"type":"IOS"}},{"type":"MOBILE","os":{"type":"ANDROID"}},{"type":"DESKTOP","os":{"type":"WINDOWS"}}],"exclude":[]},"riskScore":{"level":"MEDIUM"},"elCondition":{"condition":"user.status == \"ACTIVE\""},"userType":{"include":["otyqq6ctk459iqtED1d7"],"exclude":["otyv4uneu0eGa2gW31d7"]}},"actions":{"appSignOn":{"access":"ALLOW","verificationMethod":{"factorMode":"2FA","type":"ASSURANCE","reauthenticateIn":"PT43800H","constraints":[{"knowledge":{"required":false,"types":["password"],"reauthenticateIn":"PT2H"},"possession":{"required":false,"deviceBound":"REQUIRED"}},{"possession":{"required":false,"hardwareProtection":"REQUIRED","deviceBound":"REQUIRED","userPresence":"OPTIONAL","userVerification":"OPTIONAL"}}]},"keepMeSignedIn":{"postAuth":"NOT_ALLOWED"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"ACCESS_POLICY"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:51:02 GMT
+                - Wed, 18 Feb 2026 06:31:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.069611042s
+        duration: 1.145046125s
     - id: 143
       request:
         proto: HTTP/1.1
@@ -4970,7 +4970,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulu52mxo5F35RjRR1d7
+        url: https://oie-00.dne-okta.com/api/v1/policies/rstqq6ctnn8tuHBCM1d7/rules/rulv4uo4yq2ZNyolp1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4982,12 +4982,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:04 GMT
+                - Wed, 18 Feb 2026 06:31:36 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.584174042s
+        duration: 1.151778958s
     - id: 144
       request:
         proto: HTTP/1.1
@@ -5000,7 +5000,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52rjhcWWTblzH1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4umd44U7u8VcV1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5012,12 +5012,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
+                - Wed, 18 Feb 2026 06:31:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.059966625s
+        duration: 1.154038625s
     - id: 145
       request:
         proto: HTTP/1.1
@@ -5030,7 +5030,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqjAPlRmVK1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4ulzapeJL27I81d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5042,12 +5042,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
+                - Wed, 18 Feb 2026 06:31:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.066906917s
+        duration: 1.15488075s
     - id: 146
       request:
         proto: HTTP/1.1
@@ -5060,7 +5060,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52n7uvhRNz1Qs1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uoqex0SJpLHo1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5072,12 +5072,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
+                - Wed, 18 Feb 2026 06:31:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.074553584s
+        duration: 1.1562945s
     - id: 147
       request:
         proto: HTTP/1.1
@@ -5090,24 +5090,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52p5q3jHugiCV1d7
-        method: DELETE
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4unkr4lbUXArb1d7","name":"testAcc_987182423","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:30:48.000Z","lastUpdated":"2026-02-18T06:31:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
             Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
+                - Wed, 18 Feb 2026 06:31:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.070442875s
+        status: 200 OK
+        code: 200
+        duration: 1.164477125s
     - id: 148
       request:
         proto: HTTP/1.1
@@ -5120,7 +5123,217 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4unx5uObfT1iQ1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:31:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.16193575s
+    - id: 149
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:31:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.199379667s
+    - id: 150
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:31:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.199928625s
+    - id: 151
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:31:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.219799291s
+    - id: 152
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:31:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.25287375s
+    - id: 153
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyv4uneu0eGa2gW31d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:31:38 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 2.198262417s
+    - id: 154
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4unkr4lbUXArb1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 18 Feb 2026 06:31:38 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.176378625s
+    - id: 155
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -5135,225 +5348,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
+                - Wed, 18 Feb 2026 06:31:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.08990625s
-    - id: 149
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.105259458s
-    - id: 150
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.108183875s
-    - id: 151
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:51:05 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.130290709s
-    - id: 152
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:51:06 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 2.505178625s
-    - id: 153
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00gu52jkqk5wiLoKD1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.644505333s
-    - id: 154
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou52xfeyNyUBRZT1d7","name":"testAcc_987182423","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T08:50:12.000Z","lastUpdated":"2026-01-23T08:51:07.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.647367375s
-    - id: 155
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.730091375s
+        duration: 1.160815542s
     - id: 156
       request:
         proto: HTTP/1.1
@@ -5366,7 +5366,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52mol2tifbjLc1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5378,12 +5378,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
+                - Wed, 18 Feb 2026 06:31:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.693371459s
+        duration: 1.174410875s
     - id: 157
       request:
         proto: HTTP/1.1
@@ -5396,7 +5396,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52op1iqG4Tcft1d7
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gv4uovmlFmUndjg1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5408,12 +5408,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
+                - Wed, 18 Feb 2026 06:31:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.69779s
+        duration: 1.164056541s
     - id: 158
       request:
         proto: HTTP/1.1
@@ -5426,7 +5426,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52prqbaarpmlP1d7
+        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daev4unk3os2g8umr1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5438,12 +5438,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
+                - Wed, 18 Feb 2026 06:31:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.71439125s
+        duration: 1.222016917s
     - id: 159
       request:
         proto: HTTP/1.1
@@ -5456,7 +5456,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oau52r8nhyacAlm91d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4un9eg54xsS6E1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5468,12 +5468,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
+                - Wed, 18 Feb 2026 06:31:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 2.155536458s
+        duration: 1.203713917s
     - id: 160
       request:
         proto: HTTP/1.1
@@ -5486,7 +5486,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/device-assurances/daeu52jze09buvZt01d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uopo5bMI0oxR1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5498,12 +5498,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
+                - Wed, 18 Feb 2026 06:31:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 3.349974625s
+        duration: 1.192604292s
     - id: 161
       request:
         proto: HTTP/1.1
@@ -5516,7 +5516,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52ibacjgKhnrT1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uoetyGbmo4uv1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5528,12 +5528,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:07 GMT
+                - Wed, 18 Feb 2026 06:31:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.147100042s
+        duration: 1.267437292s
     - id: 162
       request:
         proto: HTTP/1.1
@@ -5546,7 +5546,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou52xfeyNyUBRZT1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4uo2hrCS8t4421d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5558,12 +5558,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:08 GMT
+                - Wed, 18 Feb 2026 06:31:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.052549208s
+        duration: 2.063021417s
     - id: 163
       request:
         proto: HTTP/1.1
@@ -5576,7 +5576,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/users/00uu52wqmcrRgtPcy1d7
+        url: https://oie-00.dne-okta.com/api/v1/users/00uv4umdt3UXAvlxa1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5588,12 +5588,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:08 GMT
+                - Wed, 18 Feb 2026 06:31:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.2213975s
+        duration: 1.209916583s
     - id: 164
       request:
         proto: HTTP/1.1
@@ -5606,7 +5606,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/meta/types/user/otyu52sjpiZfyGTFZ1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oav4umnoaFwXDHj61d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5618,9 +5618,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 08:51:09 GMT
+                - Wed, 18 Feb 2026 06:31:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 4.33824525s
+        duration: 1.346045417s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/classic-00.yaml
@@ -25,94 +25,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:46.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:46 GMT
+                - Wed, 18 Feb 2026 06:26:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081395041s
+        duration: 1.076639334s
     - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 171
-        host: classic-00.dne-okta.com
-        body: |
-            {"locations":[{"country":"US"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic","proxyType":"","status":"ACTIVE","type":"DYNAMIC","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:46.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 07:16:46 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.086945s
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 266
-        host: classic-00.dne-okta.com
-        body: |
-            {"asns":{},"ipServiceCategories":{"exclude":["SURFSHARK_VPN"],"include":["ALL_IP_SERVICES"]},"locations":{"include":[{"country":"US"},{"country":"AF","region":"AF-BGL"}]},"name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:46.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 07:16:46 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.097671375s
-    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -136,19 +62,93 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:46.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:46 GMT
+                - Wed, 18 Feb 2026 06:26:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.89639725s
+        duration: 1.092348875s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 171
+        host: classic-00.dne-okta.com
+        body: |
+            {"locations":[{"country":"US"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic","proxyType":"","status":"ACTIVE","type":"DYNAMIC","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:26:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.099824417s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 266
+        host: classic-00.dne-okta.com
+        body: |
+            {"asns":{},"ipServiceCategories":{"exclude":["SURFSHARK_VPN"],"include":["ALL_IP_SERVICES"]},"locations":{"include":[{"country":"US"},{"country":"AF","region":"AF-BGL"}]},"name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:26:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.105024083s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -169,19 +169,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:47 GMT
+                - Wed, 18 Feb 2026 06:26:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0954875s
+        duration: 1.137228334s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,7 +194,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -202,19 +202,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:47 GMT
+                - Wed, 18 Feb 2026 06:26:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.086813875s
+        duration: 1.902720375s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -227,7 +227,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -235,19 +235,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:47 GMT
+                - Wed, 18 Feb 2026 06:26:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.12107925s
+        duration: 1.900304583s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -260,7 +260,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -268,19 +268,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:47 GMT
+                - Wed, 18 Feb 2026 06:26:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.099852833s
+        duration: 1.937705292s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -293,7 +293,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -301,19 +301,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:48 GMT
+                - Wed, 18 Feb 2026 06:26:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.076138917s
+        duration: 1.062952291s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -326,7 +326,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:48 GMT
+                - Wed, 18 Feb 2026 06:26:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.084936167s
+        duration: 1.109236708s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:48 GMT
+                - Wed, 18 Feb 2026 06:26:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.069714708s
+        duration: 1.113594208s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,19 +400,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:49 GMT
+                - Wed, 18 Feb 2026 06:26:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.058443958s
+        duration: 1.93017s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,19 +433,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:50 GMT
+                - Wed, 18 Feb 2026 06:26:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.067888916s
+        duration: 1.067661458s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -458,7 +458,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -466,19 +466,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:50 GMT
+                - Wed, 18 Feb 2026 06:26:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.068486167s
+        duration: 1.071869875s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -491,7 +491,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -499,19 +499,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:50 GMT
+                - Wed, 18 Feb 2026 06:26:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.068994s
+        duration: 1.077548458s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -524,7 +524,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -532,19 +532,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:50 GMT
+                - Wed, 18 Feb 2026 06:26:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.072644125s
+        duration: 1.103254417s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -557,7 +557,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -565,19 +565,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:51 GMT
+                - Wed, 18 Feb 2026 06:26:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.06587225s
+        duration: 1.1015625s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -590,7 +590,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -598,19 +598,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:51 GMT
+                - Wed, 18 Feb 2026 06:26:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.067804333s
+        duration: 1.101783375s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -623,7 +623,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,19 +631,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:51 GMT
+                - Wed, 18 Feb 2026 06:26:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079434291s
+        duration: 1.104661584s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -656,7 +656,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,28 +664,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:51 GMT
+                - Wed, 18 Feb 2026 06:26:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.113959042s
+        duration: 1.116191375s
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 231
+        content_length: 137
         host: classic-00.dne-okta.com
         body: |
-            {"asns":["2232"],"locations":[{"country":"US"},{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic Updated","proxyType":"","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
+            {"name":"testAcc_2777345018 Dynamic Proxy Updated","proxyType":"NotTorAnonymizer","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
         headers:
             Accept:
                 - application/json
@@ -693,7 +693,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -701,19 +701,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:52 GMT
+                - Wed, 18 Feb 2026 06:26:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0858785s
+        duration: 1.212011667s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -730,7 +730,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -738,57 +738,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:52 GMT
+                - Wed, 18 Feb 2026 06:26:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.091028084s
+        duration: 1.967050709s
     - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 137
-        host: classic-00.dne-okta.com
-        body: |
-            {"name":"testAcc_2777345018 Dynamic Proxy Updated","proxyType":"NotTorAnonymizer","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 07:16:52 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.1010705s
-    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -804,7 +767,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -812,19 +775,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:47.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:52 GMT
+                - Wed, 18 Feb 2026 06:26:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.109850292s
+        duration: 1.990229875s
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 231
+        host: classic-00.dne-okta.com
+        body: |
+            {"asns":["2232"],"locations":[{"country":"US"},{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic Updated","proxyType":"","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:26:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 2.001319292s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -837,7 +837,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -845,19 +845,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:15.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:53 GMT
+                - Wed, 18 Feb 2026 06:26:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.124435584s
+        duration: 1.086420208s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -870,7 +870,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -878,19 +878,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:53 GMT
+                - Wed, 18 Feb 2026 06:26:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.109430125s
+        duration: 1.086037167s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -903,7 +903,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -911,19 +911,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:53 GMT
+                - Wed, 18 Feb 2026 06:26:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.110106875s
+        duration: 1.076314208s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -936,7 +936,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -944,19 +944,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:54 GMT
+                - Wed, 18 Feb 2026 06:26:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.31878125s
+        duration: 1.080141292s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -969,7 +969,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -977,19 +977,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:15.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:55 GMT
+                - Wed, 18 Feb 2026 06:26:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.078365875s
+        duration: 1.067100625s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1002,7 +1002,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1010,19 +1010,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:55 GMT
+                - Wed, 18 Feb 2026 06:26:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.070520916s
+        duration: 1.078462125s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1035,7 +1035,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1043,19 +1043,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:55 GMT
+                - Wed, 18 Feb 2026 06:26:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.206283666s
+        duration: 1.071566416s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1068,7 +1068,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,19 +1076,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:55 GMT
+                - Wed, 18 Feb 2026 06:26:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.067352458s
+        duration: 1.089809334s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1101,7 +1101,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,19 +1109,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:15.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:56 GMT
+                - Wed, 18 Feb 2026 06:26:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.063153042s
+        duration: 1.153936834s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1134,7 +1134,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1142,19 +1142,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:56 GMT
+                - Wed, 18 Feb 2026 06:26:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.064222333s
+        duration: 1.156000667s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1167,7 +1167,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1175,19 +1175,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:56 GMT
+                - Wed, 18 Feb 2026 06:26:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.068786125s
+        duration: 1.160407833s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1200,7 +1200,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1208,19 +1208,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:53.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:56 GMT
+                - Wed, 18 Feb 2026 06:26:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.069290709s
+        duration: 1.160742917s
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1233,7 +1233,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1241,19 +1241,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4zbgwqMtyZWCJ1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:57.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:57 GMT
+                - Wed, 18 Feb 2026 06:26:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.078727958s
+        duration: 1.1777795s
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1266,7 +1266,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1274,19 +1274,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zagnxRhQ30El1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:57.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:57 GMT
+                - Wed, 18 Feb 2026 06:26:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.080584542s
+        duration: 1.31863125s
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1307,19 +1307,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z5fvgnFQlfn11d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:58.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:58 GMT
+                - Wed, 18 Feb 2026 06:26:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.920362625s
+        duration: 1.365845708s
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1332,7 +1332,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1340,19 +1340,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4z3t2dAvelxJz1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:46.000Z","lastUpdated":"2026-01-23T07:16:58.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:58 GMT
+                - Wed, 18 Feb 2026 06:26:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.921277709s
+        duration: 1.371952958s
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zbgwqMtyZWCJ1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1377,12 +1377,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:58 GMT
+                - Wed, 18 Feb 2026 06:26:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.086800208s
+        duration: 1.186259042s
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1395,7 +1395,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zagnxRhQ30El1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1407,12 +1407,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:58 GMT
+                - Wed, 18 Feb 2026 06:26:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.089207042s
+        duration: 1.119520208s
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1425,7 +1425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z3t2dAvelxJz1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1437,12 +1437,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:59 GMT
+                - Wed, 18 Feb 2026 06:26:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.087824625s
+        duration: 1.096611334s
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1455,7 +1455,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4z5fvgnFQlfn11d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1467,9 +1467,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:59 GMT
+                - Wed, 18 Feb 2026 06:26:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.10940575s
+        duration: 1.103696459s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/classic-00.yaml
@@ -6,80 +6,6 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 264
-        host: classic-00.dne-okta.com
-        body: |
-            {"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"name":"testAcc_2777345018","proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:06 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.076639334s
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 127
-        host: classic-00.dne-okta.com
-        body: |
-            {"name":"testAcc_2777345018 Dynamic Proxy","proxyType":"TorAnonymizer","status":"ACTIVE","type":"DYNAMIC","usage":"BLOCKLIST"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:06 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.092348875s
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
         content_length: 171
         host: classic-00.dne-okta.com
         body: |
@@ -99,20 +25,57 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:20.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:06 GMT
+                - Wed, 18 Feb 2026 08:28:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.099824417s
-    - id: 3
+        duration: 1.111681917s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 264
+        host: classic-00.dne-okta.com
+        body: |
+            {"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"name":"testAcc_2777345018","proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:20.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:20 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.117683708s
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -136,19 +99,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:06.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:20.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:06 GMT
+                - Wed, 18 Feb 2026 08:28:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.105024083s
+        duration: 1.126842125s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 127
+        host: classic-00.dne-okta.com
+        body: |
+            {"name":"testAcc_2777345018 Dynamic Proxy","proxyType":"TorAnonymizer","status":"ACTIVE","type":"DYNAMIC","usage":"BLOCKLIST"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:20.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:20 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.298201625s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -169,19 +169,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:07 GMT
+                - Wed, 18 Feb 2026 08:28:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.137228334s
+        duration: 1.0644735s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,7 +194,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -202,19 +202,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:08 GMT
+                - Wed, 18 Feb 2026 08:28:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.902720375s
+        duration: 1.073913833s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -227,7 +227,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -235,19 +235,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:08 GMT
+                - Wed, 18 Feb 2026 08:28:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.900304583s
+        duration: 1.101661291s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -260,7 +260,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -268,19 +268,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:08 GMT
+                - Wed, 18 Feb 2026 08:28:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.937705292s
+        duration: 1.073257833s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -293,7 +293,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -301,19 +301,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:09 GMT
+                - Wed, 18 Feb 2026 08:28:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.062952291s
+        duration: 1.136651333s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -326,7 +326,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:09 GMT
+                - Wed, 18 Feb 2026 08:28:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.109236708s
+        duration: 1.972204125s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:09 GMT
+                - Wed, 18 Feb 2026 08:28:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.113594208s
+        duration: 1.975678708s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,19 +400,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:10 GMT
+                - Wed, 18 Feb 2026 08:28:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.93017s
+        duration: 1.976568458s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,19 +433,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:11 GMT
+                - Wed, 18 Feb 2026 08:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.067661458s
+        duration: 1.05404425s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -458,7 +458,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -466,19 +466,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:11 GMT
+                - Wed, 18 Feb 2026 08:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071869875s
+        duration: 1.064277834s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -491,7 +491,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -499,19 +499,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:11 GMT
+                - Wed, 18 Feb 2026 08:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.077548458s
+        duration: 1.092807958s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -524,7 +524,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -532,152 +532,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:11 GMT
+                - Wed, 18 Feb 2026 08:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.103254417s
+        duration: 1.880196875s
     - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.1015625s
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.101783375s
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.104661584s
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:13 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.116191375s
-    - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -693,7 +561,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -701,20 +569,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:07.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:14 GMT
+                - Wed, 18 Feb 2026 08:28:27 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.212011667s
-    - id: 21
+        duration: 1.063752459s
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -730,7 +598,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -738,20 +606,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:15 GMT
+                - Wed, 18 Feb 2026 08:28:27 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.967050709s
-    - id: 22
+        duration: 1.073284625s
+    - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -767,7 +635,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -775,20 +643,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:15 GMT
+                - Wed, 18 Feb 2026 08:28:27 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.990229875s
-    - id: 23
+        duration: 1.087968209s
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -804,7 +672,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -812,19 +680,151 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:08.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:21.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:15 GMT
+                - Wed, 18 Feb 2026 08:28:27 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.001319292s
+        duration: 1.09503525s
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.062491959s
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.065284292s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.07423625s
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.118670125s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -837,27 +837,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate
-        method: POST
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:15.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:15 GMT
+                - Wed, 18 Feb 2026 08:28:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.086420208s
+        duration: 1.113984084s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -870,27 +870,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate
-        method: POST
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:16 GMT
+                - Wed, 18 Feb 2026 08:28:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.086037167s
+        duration: 1.115405584s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -903,27 +903,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/activate
-        method: POST
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:16 GMT
+                - Wed, 18 Feb 2026 08:28:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.076314208s
+        duration: 1.116084625s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -936,27 +936,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate
-        method: POST
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:28.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:16 GMT
+                - Wed, 18 Feb 2026 08:28:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.080141292s
+        duration: 2.011246541s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -969,27 +969,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:15.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z1ex9Ap18QPG1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:32.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:16 GMT
+                - Wed, 18 Feb 2026 08:28:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.067100625s
+        duration: 1.206894166s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1002,27 +1002,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4z18si6CnXHNo1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:17 GMT
+                - Wed, 18 Feb 2026 08:28:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.078462125s
+        duration: 1.225549208s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1035,27 +1035,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z0zsySxnBnFw1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:32.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:17 GMT
+                - Wed, 18 Feb 2026 08:28:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071566416s
+        duration: 2.052843417s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1068,27 +1068,24 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z18si6CnXHNo1d7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        content_length: 0
+        body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:17 GMT
+                - Wed, 18 Feb 2026 08:28:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.089809334s
+        status: 204 No Content
+        code: 204
+        duration: 1.065290208s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1101,27 +1098,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:15.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z0y5vj1IlGGo1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:20.000Z","lastUpdated":"2026-02-18T08:28:33.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:18 GMT
+                - Wed, 18 Feb 2026 08:28:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.153936834s
+        duration: 2.810515291s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1134,27 +1131,24 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0zsySxnBnFw1d7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        content_length: 0
+        body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:18 GMT
+                - Wed, 18 Feb 2026 08:28:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.156000667s
+        status: 204 No Content
+        code: 204
+        duration: 1.068003375s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1167,27 +1161,24 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z1ex9Ap18QPG1d7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        content_length: 0
+        body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
             Date:
-                - Wed, 18 Feb 2026 06:26:18 GMT
+                - Wed, 18 Feb 2026 08:28:34 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.160407833s
+        status: 204 No Content
+        code: 204
+        duration: 2.083939125s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1200,172 +1191,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:18 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.160742917s
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ubcrh6a3TApd1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:20 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.1777795s
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4ubjwngwtxTAr1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:20 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.31863125s
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uae7y7nOzmM21d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:20 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.365845708s
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4udk00e8TmMA51d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:26:06.000Z","lastUpdated":"2026-02-18T06:26:20.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:26:20 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.371952958s
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubcrh6a3TApd1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4z0y5vj1IlGGo1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1377,99 +1203,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Wed, 18 Feb 2026 06:26:21 GMT
+                - Wed, 18 Feb 2026 08:28:34 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.186259042s
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4ubjwngwtxTAr1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Wed, 18 Feb 2026 06:26:21 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.119520208s
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uae7y7nOzmM21d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Wed, 18 Feb 2026 06:26:21 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.096611334s
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4udk00e8TmMA51d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Wed, 18 Feb 2026 06:26:21 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.103696459s
+        duration: 1.086035375s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/oie-00.yaml
@@ -25,57 +25,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:14.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:14 GMT
+                - Wed, 18 Feb 2026 06:25:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.29206525s
+        duration: 1.154867584s
     - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 266
-        host: oie-00.dne-okta.com
-        body: |
-            {"asns":{},"ipServiceCategories":{"exclude":["SURFSHARK_VPN"],"include":["ALL_IP_SERVICES"]},"locations":{"include":[{"country":"US"},{"country":"AF","region":"AF-BGL"}]},"name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:14.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 07:16:14 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.347294541s
-    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -99,19 +62,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:14.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:14 GMT
+                - Wed, 18 Feb 2026 06:25:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.35825675s
+        duration: 1.186464167s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 266
+        host: oie-00.dne-okta.com
+        body: |
+            {"asns":{},"ipServiceCategories":{"exclude":["SURFSHARK_VPN"],"include":["ALL_IP_SERVICES"]},"locations":{"include":[{"country":"US"},{"country":"AF","region":"AF-BGL"}]},"name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:25:31 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.186668792s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -136,19 +136,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:14.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:14 GMT
+                - Wed, 18 Feb 2026 06:25:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.93927675s
+        duration: 1.36611275s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -169,19 +169,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:15 GMT
+                - Wed, 18 Feb 2026 06:25:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.091291625s
+        duration: 1.176916333s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,7 +194,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -202,19 +202,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:15 GMT
+                - Wed, 18 Feb 2026 06:25:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.07605575s
+        duration: 1.158244917s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -227,7 +227,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -235,19 +235,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:15 GMT
+                - Wed, 18 Feb 2026 06:25:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071904792s
+        duration: 1.076841708s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -260,7 +260,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -268,19 +268,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:16.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:16 GMT
+                - Wed, 18 Feb 2026 06:25:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.865748292s
+        duration: 1.271620125s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -293,7 +293,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -301,19 +301,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:16 GMT
+                - Wed, 18 Feb 2026 06:25:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.077954125s
+        duration: 1.116382625s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -326,7 +326,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:16 GMT
+                - Wed, 18 Feb 2026 06:25:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079628792s
+        duration: 1.106894625s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:16.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:17 GMT
+                - Wed, 18 Feb 2026 06:25:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.065573542s
+        duration: 1.059350541s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,19 +400,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:17 GMT
+                - Wed, 18 Feb 2026 06:25:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.476994s
+        duration: 1.061988541s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,19 +433,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:19 GMT
+                - Wed, 18 Feb 2026 06:25:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.923993667s
+        duration: 1.058575958s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -458,7 +458,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -466,19 +466,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:19 GMT
+                - Wed, 18 Feb 2026 06:25:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.930688791s
+        duration: 1.069198667s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -491,7 +491,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -499,19 +499,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:16.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:19 GMT
+                - Wed, 18 Feb 2026 06:25:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.93139325s
+        duration: 1.069426208s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -524,7 +524,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -532,19 +532,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:19 GMT
+                - Wed, 18 Feb 2026 06:25:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.935972792s
+        duration: 1.075260666s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -557,7 +557,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -565,19 +565,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:20 GMT
+                - Wed, 18 Feb 2026 06:25:36 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.621487666s
+        duration: 1.198810708s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -590,7 +590,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -598,19 +598,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:20 GMT
+                - Wed, 18 Feb 2026 06:25:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.621903333s
+        duration: 1.975838s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -623,7 +623,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -631,19 +631,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:16.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:20 GMT
+                - Wed, 18 Feb 2026 06:25:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.62207525s
+        duration: 1.98048725s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -656,7 +656,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -664,20 +664,57 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:21 GMT
+                - Wed, 18 Feb 2026 06:25:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.477076542s
+        duration: 1.988960417s
     - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 231
+        host: oie-00.dne-okta.com
+        body: |
+            {"asns":["2232"],"locations":[{"country":"US"},{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic Updated","proxyType":"","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:25:38 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.086465208s
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -693,7 +730,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -701,56 +738,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:23 GMT
+                - Wed, 18 Feb 2026 06:25:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.113266334s
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 137
-        host: oie-00.dne-okta.com
-        body: |
-            {"name":"testAcc_2777345018 Dynamic Proxy Updated","proxyType":"NotTorAnonymizer","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:16.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 07:16:23 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.361705916s
+        duration: 1.087400042s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -767,7 +767,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -775,28 +775,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:23 GMT
+                - Wed, 18 Feb 2026 06:25:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.382206041s
+        duration: 1.098897584s
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 231
+        content_length: 137
         host: oie-00.dne-okta.com
         body: |
-            {"asns":["2232"],"locations":[{"country":"US"},{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic Updated","proxyType":"","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
+            {"name":"testAcc_2777345018 Dynamic Proxy Updated","proxyType":"NotTorAnonymizer","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
         headers:
             Accept:
                 - application/json
@@ -804,7 +804,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -812,19 +812,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:15.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:24 GMT
+                - Wed, 18 Feb 2026 06:25:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.159873083s
+        duration: 1.101727666s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -837,7 +837,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -845,19 +845,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:24 GMT
+                - Wed, 18 Feb 2026 06:25:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.073196708s
+        duration: 1.089404917s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -870,7 +870,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -878,19 +878,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:24 GMT
+                - Wed, 18 Feb 2026 06:25:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081418208s
+        duration: 1.096248125s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -903,7 +903,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -911,19 +911,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:24 GMT
+                - Wed, 18 Feb 2026 06:25:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.080678958s
+        duration: 1.086844583s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -936,27 +936,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:25 GMT
+                - Wed, 18 Feb 2026 06:25:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.062502709s
+        duration: 1.119047791s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -969,27 +969,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/deactivate
-        method: POST
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:25.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:25 GMT
+                - Wed, 18 Feb 2026 06:25:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.131337125s
+        duration: 1.072289458s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1002,7 +1002,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1010,19 +1010,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:25 GMT
+                - Wed, 18 Feb 2026 06:25:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.080215333s
+        duration: 1.06732725s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1035,7 +1035,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1043,19 +1043,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:25 GMT
+                - Wed, 18 Feb 2026 06:25:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.075760833s
+        duration: 1.064716417s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1068,7 +1068,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1076,19 +1076,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:25.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:26 GMT
+                - Wed, 18 Feb 2026 06:25:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.347021041s
+        duration: 1.071654958s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1101,7 +1101,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,19 +1109,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:25.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:28 GMT
+                - Wed, 18 Feb 2026 06:25:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.059891542s
+        duration: 1.125330041s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1134,7 +1134,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1142,19 +1142,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:28 GMT
+                - Wed, 18 Feb 2026 06:25:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071263834s
+        duration: 1.128481208s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1167,7 +1167,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1175,19 +1175,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:28 GMT
+                - Wed, 18 Feb 2026 06:25:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071693583s
+        duration: 1.13064s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1200,7 +1200,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1208,19 +1208,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:24.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:28 GMT
+                - Wed, 18 Feb 2026 06:25:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079715791s
+        duration: 1.932434292s
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1233,7 +1233,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1241,19 +1241,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zadgkgsEYJcQ1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:29.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:29 GMT
+                - Wed, 18 Feb 2026 06:25:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.1369105s
+        duration: 1.09134575s
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1266,7 +1266,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1274,19 +1274,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z61cvuYGxorK1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:29.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:29 GMT
+                - Wed, 18 Feb 2026 06:25:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.143028s
+        duration: 1.105102041s
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1299,7 +1299,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1307,19 +1307,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzou4za4yb3PVClEE1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:29.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:29 GMT
+                - Wed, 18 Feb 2026 06:25:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.145028833s
+        duration: 1.105336167s
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1332,7 +1332,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1340,19 +1340,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzou4z7sj0ZkZxrym1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:16:14.000Z","lastUpdated":"2026-01-23T07:16:29.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:16:29 GMT
+                - Wed, 18 Feb 2026 06:25:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.154535917s
+        duration: 1.868848959s
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1365,7 +1365,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4za4yb3PVClEE1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1377,12 +1377,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:31 GMT
+                - Wed, 18 Feb 2026 06:25:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 2.276153084s
+        duration: 1.104868625s
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1395,7 +1395,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z7sj0ZkZxrym1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1407,12 +1407,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:31 GMT
+                - Wed, 18 Feb 2026 06:25:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 2.26763s
+        duration: 1.107633875s
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1425,7 +1425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zadgkgsEYJcQ1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1437,12 +1437,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:31 GMT
+                - Wed, 18 Feb 2026 06:25:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 2.287220584s
+        duration: 1.184512042s
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1455,7 +1455,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4z61cvuYGxorK1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1467,9 +1467,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:16:31 GMT
+                - Wed, 18 Feb 2026 06:25:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 2.284632791s
+        duration: 1.098206375s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_crud/oie-00.yaml
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:53.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:31 GMT
+                - Wed, 18 Feb 2026 08:28:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.154867584s
+        duration: 1.071865542s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -62,57 +62,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:53.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:31 GMT
+                - Wed, 18 Feb 2026 08:28:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.186464167s
+        duration: 1.081573167s
     - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 266
-        host: oie-00.dne-okta.com
-        body: |
-            {"asns":{},"ipServiceCategories":{"exclude":["SURFSHARK_VPN"],"include":["ALL_IP_SERVICES"]},"locations":{"include":[{"country":"US"},{"country":"AF","region":"AF-BGL"}]},"name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:31 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.186668792s
-    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -136,19 +99,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:31.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:53.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:31 GMT
+                - Wed, 18 Feb 2026 08:28:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.36611275s
+        duration: 1.082030916s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 266
+        host: oie-00.dne-okta.com
+        body: |
+            {"asns":{},"ipServiceCategories":{"exclude":["SURFSHARK_VPN"],"include":["ALL_IP_SERVICES"]},"locations":{"include":[{"country":"US"},{"country":"AF","region":"AF-BGL"}]},"name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:53.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:53 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.085688792s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -169,19 +169,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:32 GMT
+                - Wed, 18 Feb 2026 08:28:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.176916333s
+        duration: 1.049321708s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,7 +194,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -202,19 +202,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:32 GMT
+                - Wed, 18 Feb 2026 08:28:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.158244917s
+        duration: 1.041637875s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -227,7 +227,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -235,19 +235,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:32 GMT
+                - Wed, 18 Feb 2026 08:28:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.076841708s
+        duration: 1.064490916s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -260,7 +260,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -268,19 +268,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:32 GMT
+                - Wed, 18 Feb 2026 08:28:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.271620125s
+        duration: 1.069272875s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -293,7 +293,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -301,19 +301,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:33 GMT
+                - Wed, 18 Feb 2026 08:28:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.116382625s
+        duration: 1.063472958s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -326,7 +326,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:33 GMT
+                - Wed, 18 Feb 2026 08:28:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.106894625s
+        duration: 1.063915583s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:33 GMT
+                - Wed, 18 Feb 2026 08:28:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.059350541s
+        duration: 1.070240083s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,19 +400,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:33 GMT
+                - Wed, 18 Feb 2026 08:28:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.061988541s
+        duration: 1.070428833s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,19 +433,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:35 GMT
+                - Wed, 18 Feb 2026 08:28:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.058575958s
+        duration: 1.05459525s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -458,7 +458,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -466,19 +466,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:35 GMT
+                - Wed, 18 Feb 2026 08:28:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.069198667s
+        duration: 1.055827625s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -491,7 +491,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -499,19 +499,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:35 GMT
+                - Wed, 18 Feb 2026 08:28:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.069426208s
+        duration: 1.06138625s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -524,7 +524,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -532,189 +532,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:35 GMT
+                - Wed, 18 Feb 2026 08:28:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.075260666s
+        duration: 1.06324525s
     - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:36 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.198810708s
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"exclude":[]},"ipServiceCategories":{"include":["ALL_IP_SERVICES"],"exclude":["SURFSHARK_VPN"]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:37 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.975838s
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:37 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.98048725s
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy","status":"ACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"TorAnonymizer","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:37 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.988960417s
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 231
-        host: oie-00.dne-okta.com
-        body: |
-            {"asns":["2232"],"locations":[{"country":"US"},{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic Updated","proxyType":"","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:38 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.086465208s
-    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -730,7 +561,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -738,57 +569,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:38 GMT
+                - Wed, 18 Feb 2026 08:28:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.087400042s
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 290
-        host: oie-00.dne-okta.com
-        body: |
-            {"asns":{},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"]},"locations":{"exclude":[{"country":"CN","region":"CN-BJ"},{"country":"BE","region":"BE-VAN"}]},"name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:38 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.098897584s
-    - id: 23
+        duration: 1.070193375s
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -804,7 +598,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -812,19 +606,225 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:32.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:38 GMT
+                - Wed, 18 Feb 2026 08:28:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.101727666s
+        duration: 1.075882459s
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 290
+        host: oie-00.dne-okta.com
+        body: |
+            {"asns":{},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"]},"locations":{"exclude":[{"country":"CN","region":"CN-BJ"},{"country":"BE","region":"BE-VAN"}]},"name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","type":"DYNAMIC_V2","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:58 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.086768875s
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 231
+        host: oie-00.dne-okta.com
+        body: |
+            {"asns":["2232"],"locations":[{"country":"US"},{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"}],"name":"testAcc_2777345018 Dynamic Updated","proxyType":"","status":"INACTIVE","type":"DYNAMIC","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:54.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:58 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.272612208s
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:59 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.084185917s
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:59 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.097444917s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:28:59 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.141688792s
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:29:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.254807875s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -837,27 +837,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate
-        method: POST
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:39 GMT
+                - Wed, 18 Feb 2026 08:29:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.089404917s
+        duration: 1.051937958s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -870,27 +870,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate
-        method: POST
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:39 GMT
+                - Wed, 18 Feb 2026 08:29:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.096248125s
+        duration: 1.055551084s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -903,27 +903,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/activate
-        method: POST
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:39 GMT
+                - Wed, 18 Feb 2026 08:29:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.086844583s
+        duration: 1.056608625s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -936,27 +936,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate
-        method: POST
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:28:59.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:39 GMT
+                - Wed, 18 Feb 2026 08:29:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.119047791s
+        duration: 1.062086917s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -969,27 +969,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z2am0crDqZpF1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:29:02.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:40 GMT
+                - Wed, 18 Feb 2026 08:29:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.072289458s
+        duration: 1.070633s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1002,27 +1002,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4yzs3p3zCKUkm1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:29:02.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:40 GMT
+                - Wed, 18 Feb 2026 08:29:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.06732725s
+        duration: 1.073087916s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1035,27 +1035,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"DYNAMIC_V2","id":"nzov4z1j4k1LhMoJX1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:29:02.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:40 GMT
+                - Wed, 18 Feb 2026 08:29:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.064716417s
+        duration: 1.074543541s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1068,27 +1068,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"DYNAMIC","id":"nzov4z21g5y7e1hMT1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:28:53.000Z","lastUpdated":"2026-02-18T08:29:02.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:40 GMT
+                - Wed, 18 Feb 2026 08:29:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071654958s
+        duration: 1.098775875s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1101,27 +1101,24 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z2am0crDqZpF1d7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        content_length: 0
+        body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:42 GMT
+                - Wed, 18 Feb 2026 08:29:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.125330041s
+        status: 204 No Content
+        code: 204
+        duration: 1.084810125s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1134,27 +1131,24 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z1j4k1LhMoJX1d7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        content_length: 0
+        body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:42 GMT
+                - Wed, 18 Feb 2026 08:29:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.128481208s
+        status: 204 No Content
+        code: 204
+        duration: 1.087737375s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1167,27 +1161,24 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4yzs3p3zCKUkm1d7
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        content_length: 0
+        body: ""
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
             Date:
-                - Wed, 18 Feb 2026 06:25:42 GMT
+                - Wed, 18 Feb 2026 08:29:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.13064s
+        status: 204 No Content
+        code: 204
+        duration: 1.091713708s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1200,172 +1191,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:39.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:42 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.932434292s
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC_V2","id":"nzov4uc4e2yyXmCOt1d7","name":"testAcc_2777345018 Dynamic V2 Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"locations":{"include":[],"exclude":[{"country":"BE","region":"BE-VAN"},{"country":"CN","region":"CN-BJ"}]},"ipServiceCategories":{"include":["SYMANTEC_VPN","GOOGLE_VPN","TRENDMICRO_VPN"],"exclude":[]},"asns":{"include":[],"exclude":[]},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:44 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.09134575s
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4ub7hiW8PTtIM1d7","name":"testAcc_2777345018 Updated","status":"INACTIVE","usage":"BLOCKLIST","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.10"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":null,"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:44 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.105102041s
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4u9yx4a6VI17J1d7","name":"testAcc_2777345018 Dynamic Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"locations":[{"country":"UA","region":"UA-26"},{"country":"AF","region":"AF-BGL"},{"country":"US","region":null}],"proxyType":"","asns":["2232"],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:44 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.105336167s
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"DYNAMIC","id":"nzov4ud290TJ4xFtP1d7","name":"testAcc_2777345018 Dynamic Proxy Updated","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:25:31.000Z","lastUpdated":"2026-02-18T06:25:44.000Z","system":false,"locations":null,"proxyType":"NotTorAnonymizer","_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:25:44 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.868848959s
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uc4e2yyXmCOt1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z21g5y7e1hMT1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1377,99 +1203,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Wed, 18 Feb 2026 06:25:45 GMT
+                - Wed, 18 Feb 2026 08:29:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.104868625s
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ub7hiW8PTtIM1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Wed, 18 Feb 2026 06:25:45 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.107633875s
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4u9yx4a6VI17J1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Wed, 18 Feb 2026 06:25:45 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.184512042s
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ud290TJ4xFtP1d7
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Date:
-                - Wed, 18 Feb 2026 06:25:45 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.098206375s
+        duration: 1.0720215s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/classic-00.yaml
@@ -13,7 +13,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -21,19 +21,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:12 GMT
+                - Wed, 18 Feb 2026 20:00:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.202050875s
+        duration: 1.244849833s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,7 +46,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -54,19 +54,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:14 GMT
+                - Wed, 18 Feb 2026 20:00:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.212556s
+        duration: 1.246446292s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"useAsBlackList":false,"useAsExemptList":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"useAsBlackList":false,"useAsExemptList":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:15 GMT
+                - Wed, 18 Feb 2026 20:00:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.063226416s
+        duration: 1.239646334s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -124,16 +124,16 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:16 GMT
+                - Wed, 18 Feb 2026 20:00:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.063470792s
+        duration: 1.275033959s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/classic-00.yaml
@@ -1,0 +1,139 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:12 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.202050875s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.212556s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        host: classic-00.dne-okta.com
+        body: |
+            {"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"name":"DefaultExemptIpZone","status":"ACTIVE","type":"IP","usage":"POLICY","useAsExemptList":true}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"useAsBlackList":false,"useAsExemptList":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.063226416s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.063470792s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/oie-00.yaml
@@ -13,7 +13,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -21,19 +21,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:30 GMT
+                - Wed, 18 Feb 2026 20:00:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079515625s
+        duration: 1.320427083s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,7 +46,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -54,19 +54,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:31 GMT
+                - Wed, 18 Feb 2026 20:00:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.102698583s
+        duration: 1.241080042s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"useAsBlackList":false,"useAsExemptList":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"useAsBlackList":false,"useAsExemptList":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:33 GMT
+                - Wed, 18 Feb 2026 20:00:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.076978459s
+        duration: 1.242385333s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -124,16 +124,16 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzotivlj3iItmtmnC1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2026-01-06T09:20:55.000Z","lastUpdated":"2026-02-17T14:15:10.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzotivlj3iItmtmnC1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 08:43:34 GMT
+                - Wed, 18 Feb 2026 20:00:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.090254166s
+        duration: 1.234475583s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2271/oie-00.yaml
@@ -1,0 +1,139 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:30 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.079515625s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:31 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.102698583s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        host: oie-00.dne-okta.com
+        body: |
+            {"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"name":"DefaultExemptIpZone","status":"ACTIVE","type":"IP","usage":"POLICY","useAsExemptList":true}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"useAsBlackList":false,"useAsExemptList":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.076978459s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzor6xnr37MfQVHrs1d7","name":"DefaultExemptIpZone","status":"ACTIVE","usage":"POLICY","created":"2025-10-22T08:59:41.000Z","lastUpdated":"2026-02-18T07:47:33.000Z","system":true,"gateways":[{"type":"CIDR","value":"1.2.3.4/32"},{"type":"CIDR","value":"4.5.6.7/32"}],"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzor6xnr37MfQVHrs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:43:34 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.090254166s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/classic-00.yaml
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:04.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:36.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:33:04 GMT
+                - Wed, 18 Feb 2026 08:35:36 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079510416s
+        duration: 1.071193292s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:33:05 GMT
+                - Wed, 18 Feb 2026 08:35:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.129775375s
+        duration: 1.06220975s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:33:06 GMT
+                - Wed, 18 Feb 2026 08:35:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.175696667s
+        duration: 1.0512785s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -124,53 +124,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:33:08 GMT
+                - Wed, 18 Feb 2026 08:35:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.075592333s
+        duration: 1.050287292s
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:33:09 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.064670125s
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -186,7 +153,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -194,19 +161,52 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:33:10 GMT
+                - Wed, 18 Feb 2026 08:35:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.163213375s
+        duration: 1.073508708s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:42.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:35:42 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.142640291s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -219,27 +219,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate
-        method: POST
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:11.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:42.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:33:11 GMT
+                - Wed, 18 Feb 2026 08:35:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.226328375s
+        duration: 1.058267875s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -252,27 +252,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
-        method: GET
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:11.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4zap3fioHoZDj1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:36.000Z","lastUpdated":"2026-02-18T08:35:44.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:33:12 GMT
+                - Wed, 18 Feb 2026 08:35:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.127879042s
+        duration: 1.137299417s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,73 +285,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:11.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:33:14 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.073536042s
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:33:15 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.100977291s
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4zap3fioHoZDj1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -363,9 +297,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Wed, 18 Feb 2026 06:33:16 GMT
+                - Wed, 18 Feb 2026 08:35:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.114106875s
+        duration: 1.141496333s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/classic-00.yaml
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:43:53.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:04.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:53 GMT
+                - Wed, 18 Feb 2026 06:33:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.047008458s
+        duration: 1.079510416s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:43:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:54 GMT
+                - Wed, 18 Feb 2026 06:33:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.042253458s
+        duration: 1.129775375s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:43:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:56 GMT
+                - Wed, 18 Feb 2026 06:33:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.165847208s
+        duration: 1.175696667s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -124,19 +124,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:43:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:57 GMT
+                - Wed, 18 Feb 2026 06:33:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.039086541s
+        duration: 1.075592333s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -149,7 +149,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -157,19 +157,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:43:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:58 GMT
+                - Wed, 18 Feb 2026 06:33:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.077087917s
+        duration: 1.064670125s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -186,7 +186,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -194,19 +194,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:43:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:05.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:59 GMT
+                - Wed, 18 Feb 2026 06:33:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.12950275s
+        duration: 1.163213375s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -227,19 +227,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:44:00.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:11.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:44:00 GMT
+                - Wed, 18 Feb 2026 06:33:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0644845s
+        duration: 1.226328375s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -252,7 +252,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -260,19 +260,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:44:00.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:11.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:44:01 GMT
+                - Wed, 18 Feb 2026 06:33:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.045856458s
+        duration: 1.127879042s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,7 +285,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -293,19 +293,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:44:00.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:11.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:44:03 GMT
+                - Wed, 18 Feb 2026 06:33:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.128249542s
+        duration: 1.073536042s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -318,7 +318,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -326,19 +326,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yrljwtZOKUUs1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:53.000Z","lastUpdated":"2026-01-22T14:44:04.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uraw8U5YUL2z1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:33:04.000Z","lastUpdated":"2026-02-18T06:33:15.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:44:04 GMT
+                - Wed, 18 Feb 2026 06:33:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.054004208s
+        duration: 1.100977291s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -351,7 +351,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou3yrljwtZOKUUs1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uraw8U5YUL2z1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -363,9 +363,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Thu, 22 Jan 2026 14:44:05 GMT
+                - Wed, 18 Feb 2026 06:33:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.192322041s
+        duration: 1.114106875s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/oie-00.yaml
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:30.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:38.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:30 GMT
+                - Wed, 18 Feb 2026 06:32:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.104593917s
+        duration: 1.250253167s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:31.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:31 GMT
+                - Wed, 18 Feb 2026 06:32:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.187008708s
+        duration: 1.104060459s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:31.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:32 GMT
+                - Wed, 18 Feb 2026 06:32:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.057238666s
+        duration: 1.083461042s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -124,19 +124,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:31.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:33 GMT
+                - Wed, 18 Feb 2026 06:32:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.04673025s
+        duration: 1.096256209s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -149,7 +149,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -157,19 +157,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:31.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:35 GMT
+                - Wed, 18 Feb 2026 06:32:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.045730167s
+        duration: 1.071297416s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -186,7 +186,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -194,19 +194,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:31.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:36 GMT
+                - Wed, 18 Feb 2026 06:32:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.128830333s
+        duration: 1.074300917s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -227,19 +227,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:37 GMT
+                - Wed, 18 Feb 2026 06:32:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.05681125s
+        duration: 1.124617083s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -252,7 +252,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -260,19 +260,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:38 GMT
+                - Wed, 18 Feb 2026 06:32:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.127861625s
+        duration: 1.085950042s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,7 +285,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -293,19 +293,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:37.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:39 GMT
+                - Wed, 18 Feb 2026 06:32:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.098835s
+        duration: 1.130340875s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -318,7 +318,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -326,19 +326,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou3yttrupHejEyi1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-01-22T14:43:30.000Z","lastUpdated":"2026-01-22T14:43:41.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:48.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Thu, 22 Jan 2026 14:43:41 GMT
+                - Wed, 18 Feb 2026 06:32:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.050819375s
+        duration: 1.080118625s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -351,7 +351,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou3yttrupHejEyi1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -363,9 +363,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Thu, 22 Jan 2026 14:43:42 GMT
+                - Wed, 18 Feb 2026 06:32:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.191993083s
+        duration: 1.105506792s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2578/oie-00.yaml
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:38.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:09.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:32:38 GMT
+                - Wed, 18 Feb 2026 08:35:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.250253167s
+        duration: 1.179822292s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:10.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:32:39 GMT
+                - Wed, 18 Feb 2026 08:35:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.104060459s
+        duration: 1.187869875s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:10.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:32:40 GMT
+                - Wed, 18 Feb 2026 08:35:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.083461042s
+        duration: 1.115555333s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -116,7 +116,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -124,53 +124,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:10.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:32:41 GMT
+                - Wed, 18 Feb 2026 08:35:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.096256209s
+        duration: 1.183725167s
     - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:32:42 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.071297416s
-    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -186,7 +153,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -194,19 +161,52 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:10.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:32:44 GMT
+                - Wed, 18 Feb 2026 08:35:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.074300917s
+        duration: 1.134384459s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 08:35:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.227339875s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -219,27 +219,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate
-        method: POST
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:16.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:32:45 GMT
+                - Wed, 18 Feb 2026 08:35:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.124617083s
+        duration: 1.128674375s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -252,27 +252,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
-        method: GET
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/deactivate
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4z94vrw157gPb1d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T08:35:09.000Z","lastUpdated":"2026-02-18T08:35:18.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Wed, 18 Feb 2026 06:32:46 GMT
+                - Wed, 18 Feb 2026 08:35:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.085950042s
+        duration: 1.066829042s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -285,73 +285,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:32:47 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.130340875s
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/deactivate
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzov4uqygjaQgEf701d7","name":"testAcc_3551008736","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:32:38.000Z","lastUpdated":"2026-02-18T06:32:48.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Wed, 18 Feb 2026 06:32:48 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.080118625s
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uqygjaQgEf701d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4z94vrw157gPb1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -363,9 +297,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Wed, 18 Feb 2026 06:32:49 GMT
+                - Wed, 18 Feb 2026 08:35:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.105506792s
+        duration: 1.082176209s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_crud/classic-00.yaml
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:09.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:34:34.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:09 GMT
+                - Wed, 18 Feb 2026 06:34:34 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.149809042s
+        duration: 1.132699542s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:09.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:34:34.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:10 GMT
+                - Wed, 18 Feb 2026 06:34:36 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.819738208s
+        duration: 1.387389292s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:09.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:34:34.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:12 GMT
+                - Wed, 18 Feb 2026 06:34:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.06883075s
+        duration: 1.057357458s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -128,19 +128,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrkx6q8MEKrP1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:13.000Z","lastUpdated":"2026-01-23T07:38:13.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uue5maVCwJLD1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:34:38.000Z","lastUpdated":"2026-02-18T06:34:38.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:13 GMT
+                - Wed, 18 Feb 2026 06:34:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.083021959s
+        duration: 1.200089458s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrkx6q8MEKrP1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:13.000Z","lastUpdated":"2026-01-23T07:38:14.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uue5maVCwJLD1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:34:38.000Z","lastUpdated":"2026-02-18T06:34:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:14 GMT
+                - Wed, 18 Feb 2026 06:34:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0853215s
+        duration: 1.186494291s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -186,7 +186,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,19 +194,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrkx6q8MEKrP1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:13.000Z","lastUpdated":"2026-01-23T07:38:14.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uue5maVCwJLD1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:34:38.000Z","lastUpdated":"2026-02-18T06:34:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:16 GMT
+                - Wed, 18 Feb 2026 06:34:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.998772583s
+        duration: 1.161074042s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -215,7 +215,7 @@ interactions:
         content_length: 59
         host: classic-00.dne-okta.com
         body: |
-            {"action":"block","excludeZones":["nzou4zrkx6q8MEKrP1d7"]}
+            {"action":"block","excludeZones":["nzov4uue5maVCwJLD1d7"]}
         headers:
             Accept:
                 - application/json
@@ -231,19 +231,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou4zrkx6q8MEKrP1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:18.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4uue5maVCwJLD1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:34:42.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:18 GMT
+                - Wed, 18 Feb 2026 06:34:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.432268333s
+        duration: 1.347533791s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -256,7 +256,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,19 +264,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrkx6q8MEKrP1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:13.000Z","lastUpdated":"2026-01-23T07:38:14.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uue5maVCwJLD1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:34:38.000Z","lastUpdated":"2026-02-18T06:34:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:19 GMT
+                - Wed, 18 Feb 2026 06:34:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.073978333s
+        duration: 1.060302875s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -297,19 +297,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou4zrkx6q8MEKrP1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:18.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4uue5maVCwJLD1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:34:42.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:20 GMT
+                - Wed, 18 Feb 2026 06:34:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.231314042s
+        duration: 1.220829291s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:22.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:34:46.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:22 GMT
+                - Wed, 18 Feb 2026 06:34:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.240917208s
+        duration: 1.287619625s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrkx6q8MEKrP1d7","name":"testAcc_856055093","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:38:13.000Z","lastUpdated":"2026-01-23T07:38:23.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uue5maVCwJLD1d7","name":"testAcc_856055093","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:34:38.000Z","lastUpdated":"2026-02-18T06:34:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:23 GMT
+                - Wed, 18 Feb 2026 06:34:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.072299625s
+        duration: 1.165072458s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrkx6q8MEKrP1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uue5maVCwJLD1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -404,9 +404,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:38:24 GMT
+                - Wed, 18 Feb 2026 06:34:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.297746125s
+        duration: 1.357409792s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_crud/oie-00.yaml
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:53.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:01.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:53 GMT
+                - Wed, 18 Feb 2026 06:35:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.129549584s
+        duration: 1.113029459s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:53.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:01.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:54 GMT
+                - Wed, 18 Feb 2026 06:35:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.055773542s
+        duration: 1.093751041s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -91,19 +91,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:38:53.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:01.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:56 GMT
+                - Wed, 18 Feb 2026 06:35:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.137494s
+        duration: 1.075530042s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -128,19 +128,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou5016r5G2l06QX1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:57.000Z","lastUpdated":"2026-01-23T07:38:57.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ute1uGu7m7ei1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:04.000Z","lastUpdated":"2026-02-18T06:35:04.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:57 GMT
+                - Wed, 18 Feb 2026 06:35:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.083872708s
+        duration: 1.082901875s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou5016r5G2l06QX1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:57.000Z","lastUpdated":"2026-01-23T07:38:58.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ute1uGu7m7ei1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:04.000Z","lastUpdated":"2026-02-18T06:35:06.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:38:58 GMT
+                - Wed, 18 Feb 2026 06:35:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.664038167s
+        duration: 1.263181541s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -186,7 +186,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -194,19 +194,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou5016r5G2l06QX1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:57.000Z","lastUpdated":"2026-01-23T07:38:58.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ute1uGu7m7ei1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:04.000Z","lastUpdated":"2026-02-18T06:35:06.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:39:00 GMT
+                - Wed, 18 Feb 2026 06:35:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.088003958s
+        duration: 1.127606666s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -215,7 +215,7 @@ interactions:
         content_length: 59
         host: oie-00.dne-okta.com
         body: |
-            {"action":"block","excludeZones":["nzou5016r5G2l06QX1d7"]}
+            {"action":"block","excludeZones":["nzov4ute1uGu7m7ei1d7"]}
         headers:
             Accept:
                 - application/json
@@ -231,19 +231,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou5016r5G2l06QX1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:39:02.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4ute1uGu7m7ei1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:08.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:39:02 GMT
+                - Wed, 18 Feb 2026 06:35:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.6622305s
+        duration: 1.227329208s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -256,7 +256,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,19 +264,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou5016r5G2l06QX1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:38:57.000Z","lastUpdated":"2026-01-23T07:38:58.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4ute1uGu7m7ei1d7","name":"testAcc_856055093","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:04.000Z","lastUpdated":"2026-02-18T06:35:06.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:39:04 GMT
+                - Wed, 18 Feb 2026 06:35:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.80849325s
+        duration: 1.166995709s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -297,19 +297,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou5016r5G2l06QX1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:39:02.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4ute1uGu7m7ei1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:08.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:39:05 GMT
+                - Wed, 18 Feb 2026 06:35:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.057196125s
+        duration: 1.1778085s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:39:07.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:12.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:39:07 GMT
+                - Wed, 18 Feb 2026 06:35:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.855701417s
+        duration: 1.245902875s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou5016r5G2l06QX1d7","name":"testAcc_856055093","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:38:57.000Z","lastUpdated":"2026-01-23T07:39:10.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4ute1uGu7m7ei1d7","name":"testAcc_856055093","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:35:04.000Z","lastUpdated":"2026-02-18T06:35:13.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:39:10 GMT
+                - Wed, 18 Feb 2026 06:35:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.425549s
+        duration: 1.093186791s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou5016r5G2l06QX1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4ute1uGu7m7ei1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -404,9 +404,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:39:13 GMT
+                - Wed, 18 Feb 2026 06:35:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 3.422763583s
+        duration: 1.259056208s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_issue_1221_NetworkZoneOrdering/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_issue_1221_NetworkZoneOrdering/classic-00.yaml
@@ -9,43 +9,6 @@ interactions:
         content_length: 266
         host: classic-00.dne-okta.com
         body: |
-            {"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"name":"testAcc_1303341752-3","proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-            Content-Type:
-                - application/json
-        url: https://classic-00.dne-okta.com/api/v1/zones
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrep6hImk3cy1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:26.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Fri, 23 Jan 2026 07:37:26 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.131163125s
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 266
-        host: classic-00.dne-okta.com
-        body: |
             {"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"name":"testAcc_1303341752-1","proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
         headers:
             Accept:
@@ -62,20 +25,20 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxsbhlFpU6tF1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:26.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4usy5r3td4wWz1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:26 GMT
+                - Wed, 18 Feb 2026 06:36:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.134455708s
-    - id: 2
+        duration: 1.116721709s
+    - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -99,19 +62,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zqlvoB9tRRmx1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:27.000Z","lastUpdated":"2026-01-23T07:37:27.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvyncwnMmAPf1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:27 GMT
+                - Wed, 18 Feb 2026 06:36:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.920165625s
+        duration: 1.117525375s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 266
+        host: classic-00.dne-okta.com
+        body: |
+            {"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"name":"testAcc_1303341752-3","proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/zones
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzov4uwpg1uusXo6M1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:39.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 18 Feb 2026 06:36:39 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.147062791s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -124,7 +124,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -132,19 +132,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrep6hImk3cy1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:27.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvyncwnMmAPf1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:27 GMT
+                - Wed, 18 Feb 2026 06:36:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.074415084s
+        duration: 1.169193166s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -157,7 +157,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -165,19 +165,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxsbhlFpU6tF1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:27.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4usy5r3td4wWz1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:27 GMT
+                - Wed, 18 Feb 2026 06:36:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.073807833s
+        duration: 1.185549584s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -190,7 +190,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7/lifecycle/activate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -198,19 +198,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zqlvoB9tRRmx1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:27.000Z","lastUpdated":"2026-01-23T07:37:28.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwpg1uusXo6M1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:28 GMT
+                - Wed, 18 Feb 2026 06:36:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079688917s
+        duration: 1.254303958s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -223,7 +223,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,19 +231,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxsbhlFpU6tF1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:27.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4usy5r3td4wWz1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:29 GMT
+                - Wed, 18 Feb 2026 06:36:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.084510958s
+        duration: 1.073552292s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -256,7 +256,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,19 +264,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrep6hImk3cy1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:27.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvyncwnMmAPf1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:29 GMT
+                - Wed, 18 Feb 2026 06:36:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.087198916s
+        duration: 1.10654625s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -289,7 +289,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -297,19 +297,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zqlvoB9tRRmx1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:27.000Z","lastUpdated":"2026-01-23T07:37:28.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwpg1uusXo6M1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:29 GMT
+                - Wed, 18 Feb 2026 06:36:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.076596459s
+        duration: 1.063418s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -318,7 +318,7 @@ interactions:
         content_length: 105
         host: classic-00.dne-okta.com
         body: |
-            {"action":"block","excludeZones":["nzou4zxsbhlFpU6tF1d7","nzou4zqlvoB9tRRmx1d7","nzou4zrep6hImk3cy1d7"]}
+            {"action":"block","excludeZones":["nzov4usy5r3td4wWz1d7","nzov4uvyncwnMmAPf1d7","nzov4uwpg1uusXo6M1d7"]}
         headers:
             Accept:
                 - application/json
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou4zrep6hImk3cy1d7","nzou4zxsbhlFpU6tF1d7","nzou4zqlvoB9tRRmx1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:37:30.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4uvyncwnMmAPf1d7","nzov4usy5r3td4wWz1d7","nzov4uwpg1uusXo6M1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:36:42.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:30 GMT
+                - Wed, 18 Feb 2026 06:36:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081311583s
+        duration: 1.07601175s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrep6hImk3cy1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:27.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvyncwnMmAPf1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:32 GMT
+                - Wed, 18 Feb 2026 06:36:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.080820625s
+        duration: 1.057135584s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,19 +400,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zqlvoB9tRRmx1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:27.000Z","lastUpdated":"2026-01-23T07:37:28.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwpg1uusXo6M1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:32 GMT
+                - Wed, 18 Feb 2026 06:36:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.085280375s
+        duration: 1.0625365s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,19 +433,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxsbhlFpU6tF1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:27.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4usy5r3td4wWz1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:32 GMT
+                - Wed, 18 Feb 2026 06:36:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.086902458s
+        duration: 1.069522334s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -466,19 +466,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou4zrep6hImk3cy1d7","nzou4zxsbhlFpU6tF1d7","nzou4zqlvoB9tRRmx1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:37:30.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4uvyncwnMmAPf1d7","nzov4usy5r3td4wWz1d7","nzov4uwpg1uusXo6M1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:36:42.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:33 GMT
+                - Wed, 18 Feb 2026 06:36:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071681125s
+        duration: 1.107530917s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -503,19 +503,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:37:34.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:36:46.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:34 GMT
+                - Wed, 18 Feb 2026 06:36:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.075238125s
+        duration: 1.25263125s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -528,7 +528,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -536,19 +536,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxsbhlFpU6tF1d7","name":"testAcc_1303341752-1","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:35.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwpg1uusXo6M1d7","name":"testAcc_1303341752-3","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:47.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:35 GMT
+                - Wed, 18 Feb 2026 06:36:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.080091125s
+        duration: 1.096413875s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -561,7 +561,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -569,19 +569,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zrep6hImk3cy1d7","name":"testAcc_1303341752-3","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:37:26.000Z","lastUpdated":"2026-01-23T07:37:35.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4usy5r3td4wWz1d7","name":"testAcc_1303341752-1","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:35 GMT
+                - Wed, 18 Feb 2026 06:36:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.087159042s
+        duration: 1.117281s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -594,7 +594,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -602,19 +602,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zqlvoB9tRRmx1d7","name":"testAcc_1303341752-2","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:37:27.000Z","lastUpdated":"2026-01-23T07:37:35.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvyncwnMmAPf1d7","name":"testAcc_1303341752-2","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:36:39.000Z","lastUpdated":"2026-02-18T06:36:48.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:37:35 GMT
+                - Wed, 18 Feb 2026 06:36:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.1049915s
+        duration: 2.116206916s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -627,7 +627,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zrep6hImk3cy1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uwpg1uusXo6M1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -639,12 +639,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:37:36 GMT
+                - Wed, 18 Feb 2026 06:36:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.07754725s
+        duration: 1.080635542s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -657,7 +657,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zxsbhlFpU6tF1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4usy5r3td4wWz1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -669,12 +669,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:37:36 GMT
+                - Wed, 18 Feb 2026 06:36:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.11758675s
+        duration: 1.105350958s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -687,7 +687,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/zones/nzou4zqlvoB9tRRmx1d7
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzov4uvyncwnMmAPf1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -699,9 +699,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:37:36 GMT
+                - Wed, 18 Feb 2026 06:36:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.121075792s
+        duration: 1.167372375s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_issue_1221_NetworkZoneOrdering/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaThreatInsightSettings_issue_1221_NetworkZoneOrdering/oie-00.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 266
         host: oie-00.dne-okta.com
         body: |
-            {"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"name":"testAcc_1303341752-3","proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
+            {"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"name":"testAcc_1303341752-1","proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
         headers:
             Accept:
                 - application/json
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou502r4auG8A2KB1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:39.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uu0bx7IV50Vb1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:39 GMT
+                - Wed, 18 Feb 2026 06:35:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.31995s
+        duration: 1.075857708s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -62,19 +62,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4znxmc8kfnNnM1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvdpfNgnj2US1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:45.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:39 GMT
+                - Wed, 18 Feb 2026 06:35:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.320865083s
+        duration: 1.092477292s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
         content_length: 266
         host: oie-00.dne-okta.com
         body: |
-            {"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"name":"testAcc_1303341752-1","proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
+            {"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"name":"testAcc_1303341752-3","proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"status":"ACTIVE","type":"IP","usage":"POLICY"}
         headers:
             Accept:
                 - application/json
@@ -99,19 +99,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxm1rRoNhoPf1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:39.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwaseyYnRaWr1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:46.000Z","lastUpdated":"2026-02-18T06:35:46.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:39 GMT
+                - Wed, 18 Feb 2026 06:35:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.358079958s
+        duration: 1.870796833s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -124,7 +124,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -132,19 +132,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou502r4auG8A2KB1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uu0bx7IV50Vb1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:46.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:40 GMT
+                - Wed, 18 Feb 2026 06:35:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.412405s
+        duration: 1.069036458s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -157,7 +157,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -165,19 +165,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxm1rRoNhoPf1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvdpfNgnj2US1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:46.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:40 GMT
+                - Wed, 18 Feb 2026 06:35:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.376962959s
+        duration: 1.074718083s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -190,7 +190,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7/lifecycle/activate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7/lifecycle/activate
         method: POST
       response:
         proto: HTTP/2.0
@@ -198,19 +198,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4znxmc8kfnNnM1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwaseyYnRaWr1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:46.000Z","lastUpdated":"2026-02-18T06:35:47.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:40 GMT
+                - Wed, 18 Feb 2026 06:35:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.416062458s
+        duration: 1.076846417s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -223,7 +223,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,19 +231,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou502r4auG8A2KB1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uu0bx7IV50Vb1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:46.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:41 GMT
+                - Wed, 18 Feb 2026 06:35:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.076974458s
+        duration: 1.067911708s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -256,7 +256,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,19 +264,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxm1rRoNhoPf1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvdpfNgnj2US1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:46.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:41 GMT
+                - Wed, 18 Feb 2026 06:35:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.08470425s
+        duration: 1.069029292s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -289,7 +289,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -297,19 +297,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4znxmc8kfnNnM1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwaseyYnRaWr1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:46.000Z","lastUpdated":"2026-02-18T06:35:47.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:41 GMT
+                - Wed, 18 Feb 2026 06:35:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.083259375s
+        duration: 1.115718166s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -318,7 +318,7 @@ interactions:
         content_length: 105
         host: oie-00.dne-okta.com
         body: |
-            {"action":"block","excludeZones":["nzou4zxm1rRoNhoPf1d7","nzou4znxmc8kfnNnM1d7","nzou502r4auG8A2KB1d7"]}
+            {"action":"block","excludeZones":["nzov4uu0bx7IV50Vb1d7","nzov4uvdpfNgnj2US1d7","nzov4uwaseyYnRaWr1d7"]}
         headers:
             Accept:
                 - application/json
@@ -334,19 +334,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou4znxmc8kfnNnM1d7","nzou502r4auG8A2KB1d7","nzou4zxm1rRoNhoPf1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:36:42.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4uwaseyYnRaWr1d7","nzov4uvdpfNgnj2US1d7","nzov4uu0bx7IV50Vb1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:50.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:42 GMT
+                - Wed, 18 Feb 2026 06:35:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0825665s
+        duration: 1.137838458s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -359,7 +359,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -367,19 +367,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou502r4auG8A2KB1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvdpfNgnj2US1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:46.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:44 GMT
+                - Wed, 18 Feb 2026 06:35:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.395832334s
+        duration: 1.06550225s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -392,7 +392,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -400,19 +400,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxm1rRoNhoPf1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwaseyYnRaWr1d7","name":"testAcc_1303341752-3","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:46.000Z","lastUpdated":"2026-02-18T06:35:47.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:44 GMT
+                - Wed, 18 Feb 2026 06:35:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.396747625s
+        duration: 1.068567958s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -425,7 +425,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -433,19 +433,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4znxmc8kfnNnM1d7","name":"testAcc_1303341752-2","status":"ACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:40.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"type":"IP","id":"nzov4uu0bx7IV50Vb1d7","name":"testAcc_1303341752-1","status":"ACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:46.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:44 GMT
+                - Wed, 18 Feb 2026 06:35:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.397330916s
+        duration: 1.071009417s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -466,19 +466,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"block","excludeZones":["nzou4znxmc8kfnNnM1d7","nzou502r4auG8A2KB1d7","nzou4zxm1rRoNhoPf1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:36:42.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"block","excludeZones":["nzov4uwaseyYnRaWr1d7","nzov4uvdpfNgnj2US1d7","nzov4uu0bx7IV50Vb1d7"],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:50.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:45 GMT
+                - Wed, 18 Feb 2026 06:35:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.06567825s
+        duration: 1.063509209s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -503,19 +503,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-01-23T07:36:46.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
+        body: '{"action":"none","excludeZones":[],"created":"2025-10-07T06:36:55.000Z","lastUpdated":"2026-02-18T06:35:53.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/threats/configuration","hints":{"allow":["GET","POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:46 GMT
+                - Wed, 18 Feb 2026 06:35:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.08572925s
+        duration: 1.126339375s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -528,7 +528,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -536,19 +536,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4zxm1rRoNhoPf1d7","name":"testAcc_1303341752-1","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uvdpfNgnj2US1d7","name":"testAcc_1303341752-2","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:54.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:47 GMT
+                - Wed, 18 Feb 2026 06:35:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.238812667s
+        duration: 1.206250166s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -561,7 +561,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -569,19 +569,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou502r4auG8A2KB1d7","name":"testAcc_1303341752-3","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:47.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uu0bx7IV50Vb1d7","name":"testAcc_1303341752-1","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:35:45.000Z","lastUpdated":"2026-02-18T06:35:55.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"1.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"2.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:47 GMT
+                - Wed, 18 Feb 2026 06:35:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.241752083s
+        duration: 1.97711375s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -594,7 +594,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -602,19 +602,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"type":"IP","id":"nzou4znxmc8kfnNnM1d7","name":"testAcc_1303341752-2","status":"INACTIVE","usage":"POLICY","created":"2026-01-23T07:36:39.000Z","lastUpdated":"2026-01-23T07:36:47.000Z","system":false,"gateways":[{"type":"RANGE","value":"2.3.4.5-2.3.4.15"},{"type":"CIDR","value":"2.2.3.4/24"}],"proxies":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        body: '{"type":"IP","id":"nzov4uwaseyYnRaWr1d7","name":"testAcc_1303341752-3","status":"INACTIVE","usage":"POLICY","created":"2026-02-18T06:35:46.000Z","lastUpdated":"2026-02-18T06:35:55.000Z","system":false,"gateways":[{"type":"CIDR","value":"3.2.3.4/24"},{"type":"RANGE","value":"2.3.4.5-2.3.4.15"}],"proxies":[{"type":"CIDR","value":"4.2.3.4/24"},{"type":"RANGE","value":"3.3.4.5-3.3.4.15"}],"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7","hints":{"allow":["GET","PUT","DELETE"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 23 Jan 2026 07:36:47 GMT
+                - Wed, 18 Feb 2026 06:35:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.475505708s
+        duration: 1.994918625s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -627,7 +627,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou502r4auG8A2KB1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uvdpfNgnj2US1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -639,12 +639,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:36:48 GMT
+                - Wed, 18 Feb 2026 06:35:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.089055083s
+        duration: 1.0813925s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -657,7 +657,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4zxm1rRoNhoPf1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uu0bx7IV50Vb1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -669,12 +669,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:36:48 GMT
+                - Wed, 18 Feb 2026 06:35:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.092927875s
+        duration: 1.11485925s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -687,7 +687,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/zones/nzou4znxmc8kfnNnM1d7
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzov4uwaseyYnRaWr1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -699,9 +699,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 23 Jan 2026 07:36:49 GMT
+                - Wed, 18 Feb 2026 06:35:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.086419833s
+        duration: 1.865765917s


### PR DESCRIPTION
Fixes #2271
### Changes
New schema attribute `set_usage_as_exempt_list` (optional bool) — maps to the API's useAsExemptList field. When set to true, the provider includes it in the request payload, allowing updates to the DefaultExemptIpZone.

Create guard — prevents terraform apply from attempting to create a DefaultExemptIpZone (it's built-in). Returns a helpful error directing users to terraform import.

Update logic — skips activate/deactivate lifecycle calls for DefaultExemptIpZone (the API doesn't allow status changes on it). Sets useAsExemptList on the IP zone payload via ipnz.SetUseAsExemptList().

Delete guard — DefaultExemptIpZone cannot be deleted from Okta, so the provider just removes it from state instead of calling the delete API.

State mapping — create and update now directly map the API response to state (instead of re-reading), since the GET API does not return useAsExemptList and it needs to be persisted from config.

Documentation — adds set_usage_as_exempt_list to `network_zone.md`.