### PR TITLE
improves documentation for usage of for_Each for app_group_assignments resource

### DIFF
--- a/docs/resources/app_group_assignments.md
+++ b/docs/resources/app_group_assignments.md
@@ -2,14 +2,42 @@
 page_title: "Resource: okta_app_group_assignments"
 description: |-
   Assigns groups to an application. This resource allows you to create multiple App Group assignments.
-  Important: Do not use in conjunction with for_each
+  Important: Do not use `for_each` on this resource to iterate over groups for the same `app_id`. Use `dynamic` blocks inside a single resource instance instead.
 ---
 
 # Resource: okta_app_group_assignments
 
 Assigns groups to an application. This resource allows you to create multiple App Group assignments.
 
-**Important**: Do not use in conjunction with for_each
+**Important**: Do not use `for_each` on this resource to iterate over groups for the same `app_id`. This resource's Read implementation fetches **all** groups currently assigned to the app from the Okta API — not just the ones declared in config. When multiple instances share the same `app_id`, the following infinite loop occurs on every apply:
+
+1. Each instance's update deletes the groups it does not own from Okta.
+2. Each instance's Read (called at the end of update) re-fetches all groups from the API and absorbs the other instance's groups back into state as drift.
+3. State after apply is identical to state before apply — the plan never converges and the same diff reappears on every `terraform plan`.
+
+Since this resource natively supports multiple `group` blocks, use a [`dynamic` block](https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks) instead:
+
+**Bad** — creates two conflicting resource instances for the same app:
+```terraform
+resource "okta_app_group_assignments" "this" {
+  for_each = toset(["group-a", "group-b"])
+  app_id   = okta_app_bookmark.this.id
+  group { id = each.value }
+}
+```
+
+**Good** — a single resource instance manages all groups for the app:
+```terraform
+resource "okta_app_group_assignments" "this" {
+  app_id = okta_app_bookmark.this.id
+  dynamic "group" {
+    for_each = toset(["group-a", "group-b"])
+    content { id = group.value }
+  }
+}
+```
+
+> **Note:** Using `for_each` on this resource is safe when each instance targets a **different** `app_id`, for example when assigning the same group to multiple applications.
 
 ## Example Usage
 


### PR DESCRIPTION
fixes #2209
The existing documentation for okta_app_group_assignments only stated "Do not use in conjunction with for_each" without explaining why, leaving users confused about which for_each patterns are actually problematic.

### What changed
resource_okta_app_group_assignments.go — Updated the resource description with a precise explanation of the failure mode, and bad/good code examples.
app_group_assignments.md — Updated the docs page to match, with the same explanation and examples surfaced for end users.

Why for_each on the resource is dangerous for the same app_id
okta_app_group_assignments uses app_id as its Terraform resource ID. Its Read implementation calls `listApplicationGroupAssignments` which fetches all groups assigned to that app from the Okta API — not just the ones declared in config. `syncGroups` then absorbs any API group not present in config into local state as "external drift".

When `for_each` is used to iterate over groups for the same `app_id`, this creates multiple Terraform instances all pointing at the same app. The following infinite loop occurs on every apply:

Each instance's Update deletes the groups it doesn't own from Okta.
Each instance's Read (called at the end of Update) re-fetches all groups from the API. Since the sibling instance just re-added its group, `syncGroups` absorbs it back into state as drift.
State after apply is identical to state before apply — the plan never converges and the same diff reappears on every terraform plan.
### What is actually safe
Using for_each on this resource is safe when each instance targets a different app_id — e.g. assigning the same group to multiple apps. Each instance then operates on a completely independent app, with no shared API state to bleed across instances.

### Migration guidance
Instead of:
`resource "okta_app_group_assignments" "this" {
  for_each = toset(["group-a", "group-b"])
  app_id   = okta_app_bookmark.this.id
  group { id = each.value }
}`

Use a dynamic block inside a single resource instance:
`resource "okta_app_group_assignments" "this" {
  app_id = okta_app_bookmark.this.id
  dynamic "group" {
    for_each = toset(["group-a", "group-b"])
    content { id = group.value }
  }
}`