### PR TITLE
resolves issue and re-records vcr

### DIFF
--- a/examples/resources/okta_entitlement/basic.tf
+++ b/examples/resources/okta_entitlement/basic.tf
@@ -6,7 +6,7 @@ resource "okta_entitlement" "test" {
   data_type      = "array"
 
   parent {
-    external_id = "0oao01ardu8r8qUP91d7"
+    external_id = "0oatu8k9anRWwR1oq1d7"
     type        = "APPLICATION"
   }
 

--- a/okta/services/governance/resource_entitlement_test.go
+++ b/okta/services/governance/resource_entitlement_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAccEntitlement_basic(t *testing.T) {
-	t.Skip("Skipping Entitlement tests")
 	mgr := newFixtureManager("resources", resources.OktaGovernanceEntitlement, t.Name())
 	config := mgr.GetFixtures("basic.tf", t)
 	resourceName := fmt.Sprintf("%s.test", resources.OktaGovernanceEntitlement)

--- a/test/fixtures/vcr/governance/TestAccEntitlement_basic/classic-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccEntitlement_basic/classic-00.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 390
         host: classic-00.dne-okta.com
         body: |
-            {"dataType":"array","description":"Some license entitlement","externalValue":"Entitlement Bundle","multiValue":true,"name":"Entitlement Bundle","parent":{"externalId":"0oao01ardu8r8qUP91d7","type":"APPLICATION"},"values":[{"description":"description for value1","externalValue":"value_1","name":"value1"},{"description":"description for value2","externalValue":"value_2","name":"value2"}]}
+            {"dataType":"array","description":"Some license entitlement","externalValue":"Entitlement Bundle","multiValue":true,"name":"Entitlement Bundle","parent":{"externalId":"0oatu8k9anRWwR1oq1d7","type":"APPLICATION"},"values":[{"description":"description for value1","externalValue":"value_1","name":"value1"},{"description":"description for value2","externalValue":"value_2","name":"value2"}]}
         headers:
             Accept:
                 - application/json
@@ -23,26 +23,26 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 763
-        body: '{"parentResourceOrn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oao01ardu8r8qUP91d7","parent":{"externalId":"0oao01ardu8r8qUP91d7","type":"APPLICATION"},"values":[{"id":"ent10fuc75rIw9imq1d7","name":"value1","externalValue":"value_1","description":"description for value1"},{"id":"ent10fuc76dUXHZcY1d7","name":"value2","externalValue":"value_2","description":"description for value2"}],"_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp10fuc74ffLTNHZ1d7","hints":{}}},"metadata":{"total":2},"id":"esp10fuc74ffLTNHZ1d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array"}'
+        content_length: 1380
+        body: '{"parentResourceOrn":"orn:oktapreview:idp:00otivnuq1X5554yc1d7:apps:oidc_client:0oatu8k9anRWwR1oq1d7","parent":{"externalId":"0oatu8k9anRWwR1oq1d7","type":"APPLICATION"},"values":[{"id":"ent18b2ocgk6uSI331d7","name":"value1","externalValue":"value_1","description":"description for value1","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b2ocgk6uSI331d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:49:52Z","lastUpdated":"2026-02-26T20:49:52Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"},{"id":"ent18b2ochkLPK8Tz1d7","name":"value2","externalValue":"value_2","description":"description for value2","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b2ochkLPK8Tz1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:49:52Z","lastUpdated":"2026-02-26T20:49:52Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}],"_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b2ocfTvRyni71d7","hints":{}}},"metadata":{"total":2},"id":"esp18b2ocfTvRyni71d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:49:52.434Z","lastUpdated":"2026-02-26T20:49:52.434Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Length:
-                - "763"
+                - "1380"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 15 Aug 2025 19:23:42 GMT
+                - Thu, 26 Feb 2026 20:49:52 GMT
             Link:
-                - <https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp10fuc74ffLTNHZ1d7>; rel="self"
+                - <https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b2ocfTvRyni71d7>; rel="self"
             Location:
-                - https://dcp-testing-oig-2025-06-26-admin.oktapreview.com/governance/api/v1/entitlements/esp10fuc74ffLTNHZ1d7
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v1/entitlements/esp18b2ocfTvRyni71d7
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 201 Created
         code: 201
-        duration: 1.154181042s
+        duration: 1.196760958s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/governance/api/v1/entitlements/esp10fuc74ffLTNHZ1d7
+        url: https://classic-00.dne-okta.com/governance/api/v1/entitlements/esp18b2ocfTvRyni71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,21 +63,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"parentResourceOrn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oao01ardu8r8qUP91d7","parent":{"externalId":"0oao01ardu8r8qUP91d7","type":"APPLICATION"},"values":[{"id":"ent10fuc75rIw9imq1d7","name":"value1","externalValue":"value_1","description":"description for value1"},{"id":"ent10fuc76dUXHZcY1d7","name":"value2","externalValue":"value_2","description":"description for value2"}],"_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp10fuc74ffLTNHZ1d7","hints":{}}},"metadata":{"total":2},"id":"esp10fuc74ffLTNHZ1d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array"}'
+        body: '{"parentResourceOrn":"orn:oktapreview:idp:00otivnuq1X5554yc1d7:apps:oidc_client:0oatu8k9anRWwR1oq1d7","parent":{"externalId":"0oatu8k9anRWwR1oq1d7","type":"APPLICATION"},"values":[{"id":"ent18b2ocgk6uSI331d7","name":"value1","externalValue":"value_1","description":"description for value1","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b2ocgk6uSI331d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:49:52Z","lastUpdated":"2026-02-26T20:49:52Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"},{"id":"ent18b2ochkLPK8Tz1d7","name":"value2","externalValue":"value_2","description":"description for value2","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b2ochkLPK8Tz1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:49:52Z","lastUpdated":"2026-02-26T20:49:52Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}],"_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b2ocfTvRyni71d7","hints":{}}},"metadata":{"total":2},"id":"esp18b2ocfTvRyni71d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:49:52Z","lastUpdated":"2026-02-26T20:49:52Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Fri, 15 Aug 2025 19:23:43 GMT
+                - Thu, 26 Feb 2026 20:49:54 GMT
             Link:
-                - <https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp10fuc74ffLTNHZ1d7>; rel="self"
+                - <https://classic-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b2ocfTvRyni71d7>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.06533925s
+        duration: 1.329314375s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/governance/api/v1/entitlements/esp10fuc74ffLTNHZ1d7
+        url: https://classic-00.dne-okta.com/governance/api/v1/entitlements/esp18b2ocfTvRyni71d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -102,9 +102,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Fri, 15 Aug 2025 19:23:44 GMT
+                - Thu, 26 Feb 2026 20:49:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.19227975s
+        duration: 1.184215625s

--- a/test/fixtures/vcr/governance/TestAccEntitlement_basic/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccEntitlement_basic/oie-00.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 390
         host: oie-00.dne-okta.com
         body: |
-            {"dataType":"array","description":"Some license entitlement","externalValue":"Entitlement Bundle","multiValue":true,"name":"Entitlement Bundle","parent":{"externalId":"0oao01ardu8r8qUP91d7","type":"APPLICATION"},"values":[{"description":"description for value1","externalValue":"value_1","name":"value1"},{"description":"description for value2","externalValue":"value_2","name":"value2"}]}
+            {"dataType":"array","description":"Some license entitlement","externalValue":"Entitlement Bundle","multiValue":true,"name":"Entitlement Bundle","parent":{"externalId":"0oatu8k9anRWwR1oq1d7","type":"APPLICATION"},"values":[{"description":"description for value1","externalValue":"value_1","name":"value1"},{"description":"description for value2","externalValue":"value_2","name":"value2"}]}
         headers:
             Accept:
                 - application/json
@@ -23,26 +23,26 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 763
-        body: '{"parentResourceOrn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oao01ardu8r8qUP91d7","parent":{"externalId":"0oao01ardu8r8qUP91d7","type":"APPLICATION"},"values":[{"id":"ent11avnmkGLG1pYw1d7","name":"value1","externalValue":"value_1","description":"description for value1"},{"id":"ent11avnmlWTbT4JU1d7","name":"value2","externalValue":"value_2","description":"description for value2"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp11avnmjkPpHHPQ1d7","hints":{}}},"metadata":{"total":2},"id":"esp11avnmjkPpHHPQ1d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array"}'
+        content_length: 1380
+        body: '{"parentResourceOrn":"orn:oktapreview:idp:00otivnuq1X5554yc1d7:apps:oidc_client:0oatu8k9anRWwR1oq1d7","parent":{"externalId":"0oatu8k9anRWwR1oq1d7","type":"APPLICATION"},"values":[{"id":"ent18b392ud9eP6Vv1d7","name":"value1","externalValue":"value_1","description":"description for value1","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b392ud9eP6Vv1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:50:04Z","lastUpdated":"2026-02-26T20:50:04Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"},{"id":"ent18b392v6T30aH21d7","name":"value2","externalValue":"value_2","description":"description for value2","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b392v6T30aH21d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:50:04Z","lastUpdated":"2026-02-26T20:50:04Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b392t3dw6eAA1d7","hints":{}}},"metadata":{"total":2},"id":"esp18b392t3dw6eAA1d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:50:04.728Z","lastUpdated":"2026-02-26T20:50:04.728Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Length:
-                - "763"
+                - "1380"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 08 Sep 2025 21:03:27 GMT
+                - Thu, 26 Feb 2026 20:50:04 GMT
             Link:
-                - <https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp11avnmjkPpHHPQ1d7>; rel="self"
+                - <https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b392t3dw6eAA1d7>; rel="self"
             Location:
-                - https://dcp-testing-oig-2025-06-26-admin.oktapreview.com/governance/api/v1/entitlements/esp11avnmjkPpHHPQ1d7
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v1/entitlements/esp18b392t3dw6eAA1d7
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 201 Created
         code: 201
-        duration: 1.31919425s
+        duration: 1.193890208s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/governance/api/v1/entitlements/esp11avnmjkPpHHPQ1d7
+        url: https://oie-00.dne-okta.com/governance/api/v1/entitlements/esp18b392t3dw6eAA1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,21 +63,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"parentResourceOrn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oao01ardu8r8qUP91d7","parent":{"externalId":"0oao01ardu8r8qUP91d7","type":"APPLICATION"},"values":[{"id":"ent11avnmkGLG1pYw1d7","name":"value1","externalValue":"value_1","description":"description for value1"},{"id":"ent11avnmlWTbT4JU1d7","name":"value2","externalValue":"value_2","description":"description for value2"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp11avnmjkPpHHPQ1d7","hints":{}}},"metadata":{"total":2},"id":"esp11avnmjkPpHHPQ1d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array"}'
+        body: '{"parentResourceOrn":"orn:oktapreview:idp:00otivnuq1X5554yc1d7:apps:oidc_client:0oatu8k9anRWwR1oq1d7","parent":{"externalId":"0oatu8k9anRWwR1oq1d7","type":"APPLICATION"},"values":[{"id":"ent18b392ud9eP6Vv1d7","name":"value1","externalValue":"value_1","description":"description for value1","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b392ud9eP6Vv1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:50:04Z","lastUpdated":"2026-02-26T20:50:04Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"},{"id":"ent18b392v6T30aH21d7","name":"value2","externalValue":"value_2","description":"description for value2","orn":"orn:okta:governance:00otivnuq1X5554yc1d7:entitlement-values:ent18b392v6T30aH21d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:50:04Z","lastUpdated":"2026-02-26T20:50:04Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b392t3dw6eAA1d7","hints":{}}},"metadata":{"total":2},"id":"esp18b392t3dw6eAA1d7","name":"Entitlement Bundle","externalValue":"Entitlement Bundle","description":"Some license entitlement","multiValue":true,"required":false,"dataType":"array","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-02-26T20:50:04Z","lastUpdated":"2026-02-26T20:50:04Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Mon, 08 Sep 2025 21:03:29 GMT
+                - Thu, 26 Feb 2026 20:50:06 GMT
             Link:
-                - <https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp11avnmjkPpHHPQ1d7>; rel="self"
+                - <https://oie-00-admin.dne-okta.com/governance/api/v1/entitlements/esp18b392t3dw6eAA1d7>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.078446875s
+        duration: 1.153254s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/governance/api/v1/entitlements/esp11avnmjkPpHHPQ1d7
+        url: https://oie-00.dne-okta.com/governance/api/v1/entitlements/esp18b392t3dw6eAA1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -102,9 +102,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Mon, 08 Sep 2025 21:03:30 GMT
+                - Thu, 26 Feb 2026 20:50:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.188290959s
+        duration: 1.17884425s


### PR DESCRIPTION
Fixes #2687 
applyEntitlementToState: Build a map[external_value] → response_value lookup from the API response, then iterate plan values first to preserve plan order. Any response values not present in the plan are appended at the end.

buildEntitlementValuesForReplace: Build a map[external_value] → ID lookup from prior state, so existing value IDs are correctly associated by their unique external_value key regardless of position.

