### PR TITLE
Allowing changes to default blocklist called BlockedIpZone

### DIFF
--- a/examples/resources/okta_network_zone/basic_issue_2689.tf
+++ b/examples/resources/okta_network_zone/basic_issue_2689.tf
@@ -1,0 +1,6 @@
+resource "okta_network_zone" "default_blocklist" {
+  name     = "BlockedIpZone"
+  type     = "IP"
+  status   = "ACTIVE"
+  gateways = []
+}

--- a/examples/resources/okta_network_zone/basic_issue_2689.tf
+++ b/examples/resources/okta_network_zone/basic_issue_2689.tf
@@ -2,5 +2,6 @@ resource "okta_network_zone" "default_blocklist" {
   name     = "BlockedIpZone"
   type     = "IP"
   status   = "ACTIVE"
+  usage    = "BLOCKLIST"
   gateways = []
 }

--- a/okta/services/idaas/data_source_okta_network_zone.go
+++ b/okta/services/idaas/data_source_okta_network_zone.go
@@ -92,7 +92,6 @@ func dataSourceNetworkZone() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Indicates a system Network Zone",
-				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
 		},
 		Description: "Gets Okta Network Zone.",

--- a/okta/services/idaas/data_source_okta_network_zone.go
+++ b/okta/services/idaas/data_source_okta_network_zone.go
@@ -91,6 +91,7 @@ func dataSourceNetworkZone() *schema.Resource {
 			"system": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Indicates a system Network Zone",
 			},
 		},

--- a/okta/services/idaas/data_source_okta_network_zone.go
+++ b/okta/services/idaas/data_source_okta_network_zone.go
@@ -88,6 +88,12 @@ func dataSourceNetworkZone() *schema.Resource {
 				Description: "List of ip service excluded. Use with type `DYNAMIC_V2`",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"system": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates a system Network Zone",
+				Elem:        &schema.Schema{Type: schema.TypeBool},
+			},
 		},
 		Description: "Gets Okta Network Zone.",
 	}

--- a/okta/services/idaas/data_source_okta_network_zone.go
+++ b/okta/services/idaas/data_source_okta_network_zone.go
@@ -90,7 +90,6 @@ func dataSourceNetworkZone() *schema.Resource {
 			},
 			"system": {
 				Type:        schema.TypeBool,
-				Optional:    true,
 				Computed:    true,
 				Description: "Indicates a system Network Zone",
 			},

--- a/okta/services/idaas/resource_okta_network_zone.go
+++ b/okta/services/idaas/resource_okta_network_zone.go
@@ -105,7 +105,6 @@ func resourceNetworkZone() *schema.Resource {
 			"system": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Optional:    true,
 				Description: "Indicates a system Network Zone",
 			},
 		},

--- a/okta/services/idaas/resource_okta_network_zone.go
+++ b/okta/services/idaas/resource_okta_network_zone.go
@@ -104,6 +104,7 @@ func resourceNetworkZone() *schema.Resource {
 			},
 			"system": {
 				Type:        schema.TypeBool,
+				Computed:    true,
 				Optional:    true,
 				Description: "Indicates a system Network Zone",
 			},
@@ -122,6 +123,10 @@ func resourceNetworkZoneCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 	if d.Get("name").(string) == "DefaultExemptIpZone" {
 		return diag.Errorf("the DefaultExemptIpZone is a built-in Okta network zone and cannot be created. " +
+			"Please use 'terraform import okta_network_zone.<resource_name> <zone_id>' to manage it")
+	}
+	if d.Get("name").(string) == "BlockedIpZone" {
+		return diag.Errorf("the BlockedIpZone is a built-in Okta network zone and cannot be created. " +
 			"Please use 'terraform import okta_network_zone.<resource_name> <zone_id>' to manage it")
 	}
 	zone, _, err := getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.CreateNetworkZone(ctx).Zone(payload).Execute()
@@ -186,7 +191,10 @@ func resourceNetworkZoneUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.Errorf("failed to update network zone: %v", err)
 	}
-	if d.Get("name").(string) != "DefaultExemptIpZone" {
+
+	name := d.Get("name").(string)
+
+	if name != "DefaultExemptIpZone" && name != "BlockedIpZone" {
 		if d.Get("status").(string) == "ACTIVE" {
 			zone, _, err = getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.ActivateNetworkZone(ctx, d.Id()).Execute()
 			if err != nil {
@@ -209,9 +217,9 @@ func resourceNetworkZoneUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceNetworkZoneDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Built-in zones like DefaultExemptIpZone cannot be deleted from Okta,
-	// so just remove them from state.
-	if d.Get("name").(string) == "DefaultExemptIpZone" {
+	// System zones (e.g. DefaultExemptIpZone, BlockedIpZone) cannot be deleted
+	// from Okta, so just remove them from state.
+	if d.Get("system").(bool) || d.Get("name").(string) == "DefaultExemptIpZone" {
 		return nil
 	}
 	_, resp, err := getOktaV6ClientFromMetadata(meta).NetworkZoneAPI.DeactivateNetworkZone(ctx, d.Id()).Execute()
@@ -234,6 +242,10 @@ func buildNetworkZone(d *schema.ResourceData) (v6okta.ListNetworkZones200Respons
 		ipnz.SetName(d.Get("name").(string))
 		ipnz.SetType(zoneType)
 		ipnz.SetUsage(d.Get("usage").(string))
+		if d.Get("name").(string) == "BlockedIpZone" {
+			ipnz.SetSystem(d.Get("system").(bool))
+		}
+
 		if values, ok := d.GetOk("gateways"); ok {
 			ipnz.SetGateways(buildAddressObjList(values.(*schema.Set)))
 		}

--- a/okta/services/idaas/resource_okta_network_zone.go
+++ b/okta/services/idaas/resource_okta_network_zone.go
@@ -106,7 +106,6 @@ func resourceNetworkZone() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Indicates a system Network Zone",
-				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
 		},
 	}

--- a/okta/services/idaas/resource_okta_network_zone.go
+++ b/okta/services/idaas/resource_okta_network_zone.go
@@ -102,6 +102,12 @@ func resourceNetworkZone() *schema.Resource {
 				Optional:    true,
 				Description: "Set this parameter to true in your request when you update the DefaultExemptIpZone to allow IPs through the blocklist.",
 			},
+			"system": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates a system Network Zone",
+				Elem:        &schema.Schema{Type: schema.TypeBool},
+			},
 		},
 	}
 }
@@ -442,6 +448,7 @@ func mapNetworkZoneToState(d *schema.ResourceData, data *v6okta.ListNetworkZones
 		_ = d.Set("type", v.GetType())
 		_ = d.Set("status", v.GetStatus())
 		_ = d.Set("usage", v.GetUsage())
+		_ = d.Set("system", v.GetSystem())
 		err = utils.SetNonPrimitives(d, map[string]interface{}{
 			"gateways": flattenAddresses(v.GetGateways()),
 			"proxies":  flattenAddresses(v.GetProxies()),

--- a/okta/services/idaas/resource_okta_network_zone_test.go
+++ b/okta/services/idaas/resource_okta_network_zone_test.go
@@ -144,12 +144,6 @@ func TestAccResourceOktaNetworkZone_issue_2271(t *testing.T) {
 	})
 }
 
-func doesNetworkZoneExist(id string) (bool, error) {
-	client := iDaaSAPIClientForTestUtil.OktaSDKClientV2()
-	_, response, err := client.NetworkZone.GetNetworkZone(context.Background(), id)
-	return utils.DoesResourceExist(response, err)
-}
-
 func TestAccResourceOktaNetworkZone_issue_2689(t *testing.T) {
 	mgr := newFixtureManager("resources", resources.OktaIDaaSNetworkZone, t.Name())
 	config := mgr.GetFixtures("basic_issue_2689.tf", t)
@@ -164,21 +158,27 @@ func TestAccResourceOktaNetworkZone_issue_2689(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ImportState:        true,
-				ResourceName:       "okta_network_zone.default",
-				ImportStateId:      "nzotivlj3iItmtmnC1d7",
+				ResourceName:       "okta_network_zone.default_blocklist",
+				ImportStateId:      "nzo1x48tm4y10Y5h01d8",
 				ImportStatePersist: true,
 				Config:             config,
 			},
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("okta_network_zone.default", "name", "BlockedIpZone"),
-					resource.TestCheckResourceAttr("okta_network_zone.default", "type", "IP"),
-					resource.TestCheckResourceAttr("okta_network_zone.default", "status", "ACTIVE"),
-					resource.TestCheckResourceAttr("okta_network_zone.default", "usage", "BLOCKLIST"),
-					resource.TestCheckResourceAttr("okta_network_zone.default", "gateways.#", "0"),
+					resource.TestCheckResourceAttr("okta_network_zone.default_blocklist", "name", "BlockedIpZone"),
+					resource.TestCheckResourceAttr("okta_network_zone.default_blocklist", "type", "IP"),
+					resource.TestCheckResourceAttr("okta_network_zone.default_blocklist", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("okta_network_zone.default_blocklist", "usage", "BLOCKLIST"),
+					resource.TestCheckResourceAttr("okta_network_zone.default_blocklist", "gateways.#", "0"),
 				),
 			},
 		},
 	})
+}
+
+func doesNetworkZoneExist(id string) (bool, error) {
+	client := iDaaSAPIClientForTestUtil.OktaSDKClientV2()
+	_, response, err := client.NetworkZone.GetNetworkZone(context.Background(), id)
+	return utils.DoesResourceExist(response, err)
 }

--- a/okta/services/idaas/resource_okta_network_zone_test.go
+++ b/okta/services/idaas/resource_okta_network_zone_test.go
@@ -149,3 +149,36 @@ func doesNetworkZoneExist(id string) (bool, error) {
 	_, response, err := client.NetworkZone.GetNetworkZone(context.Background(), id)
 	return utils.DoesResourceExist(response, err)
 }
+
+func TestAccResourceOktaNetworkZone_issue_2689(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSNetworkZone, t.Name())
+	config := mgr.GetFixtures("basic_issue_2689.tf", t)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy: func(state *terraform.State) error {
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				ImportState:        true,
+				ResourceName:       "okta_network_zone.default",
+				ImportStateId:      "nzotivlj3iItmtmnC1d7",
+				ImportStatePersist: true,
+				Config:             config,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("okta_network_zone.default", "name", "BlockedIpZone"),
+					resource.TestCheckResourceAttr("okta_network_zone.default", "type", "IP"),
+					resource.TestCheckResourceAttr("okta_network_zone.default", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("okta_network_zone.default", "usage", "BLOCKLIST"),
+					resource.TestCheckResourceAttr("okta_network_zone.default", "gateways.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2689/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2689/classic-00.yaml
@@ -1,0 +1,102 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzo1x48tm4y10Y5h01d8","name":"BlockedIpZone","status":"ACTIVE","usage":"BLOCKLIST","created":"2025-07-23T15:09:39.000Z","lastUpdated":"2026-03-05T07:18:18.000Z","system":true,"gateways":null,"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 05 Mar 2026 07:22:25 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.118145375s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzo1x48tm4y10Y5h01d8","name":"BlockedIpZone","status":"ACTIVE","usage":"BLOCKLIST","created":"2025-07-23T15:09:39.000Z","lastUpdated":"2026-03-05T07:18:18.000Z","system":true,"gateways":null,"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 05 Mar 2026 07:22:26 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.209628042s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzo1x48tm4y10Y5h01d8","name":"BlockedIpZone","status":"ACTIVE","usage":"BLOCKLIST","created":"2025-07-23T15:09:39.000Z","lastUpdated":"2026-03-05T07:18:18.000Z","system":true,"gateways":null,"proxies":null,"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 05 Mar 2026 07:22:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 940.789875ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2689/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaNetworkZone_issue_2689/oie-00.yaml
@@ -1,0 +1,102 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzo1x48tm4y10Y5h01d8","name":"BlockedIpZone","status":"ACTIVE","usage":"BLOCKLIST","created":"2025-07-23T15:09:39.000Z","lastUpdated":"2026-03-05T07:18:18.000Z","system":true,"gateways":null,"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 05 Mar 2026 07:21:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.216127333s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzo1x48tm4y10Y5h01d8","name":"BlockedIpZone","status":"ACTIVE","usage":"BLOCKLIST","created":"2025-07-23T15:09:39.000Z","lastUpdated":"2026-03-05T07:18:18.000Z","system":true,"gateways":null,"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 05 Mar 2026 07:21:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.156104084s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"type":"IP","id":"nzo1x48tm4y10Y5h01d8","name":"BlockedIpZone","status":"ACTIVE","usage":"BLOCKLIST","created":"2025-07-23T15:09:39.000Z","lastUpdated":"2026-03-05T07:18:18.000Z","system":true,"gateways":null,"proxies":null,"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8","hints":{"allow":["GET","PUT","DELETE"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/zones/nzo1x48tm4y10Y5h01d8/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 05 Mar 2026 07:21:46 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.245748s


### PR DESCRIPTION
Fixes #2689 
When we try and update the default ip blocklist called BlockedIpZone, the API would reject the request because the provider is not passing the system object for system created configurations. 

This change adds the system object to the provider allowing the provider to make changes to default IP blocklist and resolves the issue #2689
