### PR TITLE
Adding Support For "Enable Trust Claims For IdP" For okta_idp_saml & okta_idp_oidc

### DIFF
--- a/examples/data-sources/okta_idp_oidc/datasource.tf
+++ b/examples/data-sources/okta_idp_oidc/datasource.tf
@@ -13,6 +13,7 @@ resource "okta_idp_oidc" "test" {
   client_secret         = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   issuer_url            = "https://id.example.com"
   username_template     = "idpuser.email"
+  trust_claims          = true
 }
 
 data "okta_idp_oidc" "test" {

--- a/examples/data-sources/okta_idp_oidc/generic_oidc.tf
+++ b/examples/data-sources/okta_idp_oidc/generic_oidc.tf
@@ -13,4 +13,5 @@ resource "okta_idp_oidc" "test" {
   client_secret         = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   issuer_url            = "https://id.example.com"
   username_template     = "idpuser.email"
+  trust_claims          = true
 }

--- a/examples/data-sources/okta_idp_saml/datasource.tf
+++ b/examples/data-sources/okta_idp_saml/datasource.tf
@@ -28,6 +28,7 @@ resource "okta_idp_saml" "test" {
   issuer                   = "https://idp.example.com"
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"
+  trust_claims             = true
 }
 
 data "okta_idp_saml" "test" {

--- a/examples/data-sources/okta_idp_saml/datasource_id.tf
+++ b/examples/data-sources/okta_idp_saml/datasource_id.tf
@@ -28,6 +28,7 @@ resource "okta_idp_saml" "test" {
   issuer                   = "https://idp.example.com"
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"
+  trust_claims             = false
 }
 
 data "okta_idp_saml" "test" {

--- a/examples/resources/okta_idp_oidc/generic_oidc.tf
+++ b/examples/resources/okta_idp_oidc/generic_oidc.tf
@@ -14,4 +14,5 @@ resource "okta_idp_oidc" "test" {
   issuer_url            = "https://id.example.com"
   username_template     = "idpuser.email"
   filter                = "abc"
+  trust_claims          = true
 }

--- a/examples/resources/okta_idp_oidc/generic_oidc_updated.tf
+++ b/examples/resources/okta_idp_oidc/generic_oidc_updated.tf
@@ -14,4 +14,5 @@ resource "okta_idp_oidc" "test" {
   issuer_url            = "https://id.example.com"
   username_template     = "idpuser.email"
   filter                = "xyz"
+  trust_claims          = false
 }

--- a/examples/resources/okta_idp_saml/basic.tf
+++ b/examples/resources/okta_idp_saml/basic.tf
@@ -29,4 +29,5 @@ resource "okta_idp_saml" "test" {
   request_signature_scope  = "REQUEST"
   response_signature_scope = "ANY"
   honor_persistent_name_id = true
+  trust_claims             = true
 }

--- a/examples/resources/okta_idp_saml/basic_updated.tf
+++ b/examples/resources/okta_idp_saml/basic_updated.tf
@@ -31,4 +31,5 @@ resource "okta_idp_saml" "test" {
   max_clock_skew           = 60
   name_format              = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
   honor_persistent_name_id = false
+  trust_claims             = false
 }

--- a/okta/services/idaas/data_source_okta_idp_oidc.go
+++ b/okta/services/idaas/data_source_okta_idp_oidc.go
@@ -109,6 +109,11 @@ func dataSourceIdpOidc() *schema.Resource {
 				Computed:    true,
 				Description: "Maximum allowable clock-skew when processing messages from the IdP.",
 			},
+			"trust_claims": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether to trust authentication claims from the IdP.",
+			},
 		},
 		Description: "Get a OIDC IdP from Okta.",
 	}
@@ -156,5 +161,6 @@ func dataSourceIdpOidcRead(ctx context.Context, d *schema.ResourceData, meta int
 	if oidc.IssuerMode != "" {
 		_ = d.Set("issuer_mode", oidc.IssuerMode)
 	}
+	d.Set("trust_claims", oidc.Policy.TrustClaims)
 	return nil
 }

--- a/okta/services/idaas/data_source_okta_idp_oidc_test.go
+++ b/okta/services/idaas/data_source_okta_idp_oidc_test.go
@@ -24,6 +24,7 @@ func TestAccDataSourceOktaIdpOidc_read(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_idp_oidc.test", "id"),
+					resource.TestCheckResourceAttrSet("data.okta_idp_oidc.test", "trust_claims"),
 				),
 			},
 		},

--- a/okta/services/idaas/data_source_okta_idp_saml.go
+++ b/okta/services/idaas/data_source_okta_idp_saml.go
@@ -88,6 +88,11 @@ func dataSourceIdpSaml() *schema.Resource {
 				Computed:    true,
 				Description: "Key ID reference to the IdP's X.509 signature certificate.",
 			},
+			"trust_claims": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether to trust authentication claims from the IdP.",
+			},
 		},
 		Description: "Get a SAML IdP from Okta.",
 	}
@@ -144,5 +149,6 @@ func dataSourceIdpSamlRead(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.Errorf("failed to set SAML identity provider properties: %v", err)
 	}
+	d.Set("trust_claims", idp.Policy.TrustClaims)
 	return nil
 }

--- a/okta/services/idaas/data_source_okta_idp_saml_test.go
+++ b/okta/services/idaas/data_source_okta_idp_saml_test.go
@@ -26,12 +26,14 @@ func TestAccDataSourceOktaIdpSaml_read(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_idp_saml.test", "id"),
+					resource.TestCheckResourceAttrSet("data.okta_idp_saml.test", "trust_claims"),
 				),
 			},
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.okta_idp_saml.test", "id"),
+					resource.TestCheckResourceAttrSet("data.okta_idp_saml.test", "trust_claims"),
 				),
 			},
 		},

--- a/okta/services/idaas/resource_okta_idp_oidc.go
+++ b/okta/services/idaas/resource_okta_idp_oidc.go
@@ -133,6 +133,12 @@ func resourceIdpOidc() *schema.Resource {
 				Optional:    true,
 				Description: "Optional regular expression pattern used to filter untrusted IdP usernames.",
 			},
+			"trust_claims": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether to trust authentication claims from the IdP.",
+				Default:     false,
+			},
 		}),
 	}
 }
@@ -235,6 +241,9 @@ func resourceIdpRead(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.Errorf("failed to set OIDC identity provider properties: %v", err)
 	}
+	if err = d.Set("trust_claims", idp.Policy.TrustClaims); err != nil {
+		return diag.Errorf("failed to set provider property 'Trust claims from this identity provider': %v", err)
+	}
 	return nil
 }
 
@@ -296,6 +305,10 @@ func buildIdPOidc(d *schema.ResourceData) (sdk.IdentityProvider, error) {
 				Url: d.Get("issuer_url").(string),
 			},
 		},
+	}
+	trustClaims := d.GetRawConfig().GetAttr("trust_claims")
+	if !trustClaims.IsNull() {
+		idp.Policy.TrustClaims = utils.BoolPtr(d.Get("trust_claims").(bool))
 	}
 	if d.Get("status") != nil {
 		idp.Status = d.Get("status").(string)

--- a/okta/services/idaas/resource_okta_idp_oidc_test.go
+++ b/okta/services/idaas/resource_okta_idp_oidc_test.go
@@ -44,6 +44,7 @@ func TestAccResourceOktaIdpOidc_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_signature_algorithm", "HS256"),
 					resource.TestCheckResourceAttr(resourceName, "request_signature_scope", "REQUEST"),
 					resource.TestCheckResourceAttr(resourceName, "filter", "abc"),
+					resource.TestCheckResourceAttr(resourceName, "trust_claims", "true"),
 				),
 			},
 			{
@@ -66,6 +67,7 @@ func TestAccResourceOktaIdpOidc_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_signature_algorithm", "HS256"),
 					resource.TestCheckResourceAttr(resourceName, "request_signature_scope", "REQUEST"),
 					resource.TestCheckResourceAttr(resourceName, "filter", "xyz"),
+					resource.TestCheckResourceAttr(resourceName, "trust_claims", "false"),
 				),
 			},
 		},

--- a/okta/services/idaas/resource_okta_idp_saml.go
+++ b/okta/services/idaas/resource_okta_idp_saml.go
@@ -121,6 +121,12 @@ func resourceIdpSaml() *schema.Resource {
 				Description: "Specifies whether to verify a `SAMLResponse` message or Assertion element XML digital signature. It can be `RESPONSE`, `ASSERTION`, or `ANY`. Default: `ANY`",
 				Default:     "ANY",
 			},
+			"trust_claims": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether to trust authentication claims from the IdP.",
+				Default:     false,
+			},
 		}),
 	}
 }
@@ -230,6 +236,9 @@ func resourceIdpSamlRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.Errorf("failed to set SAML identity provider properties: %v", err)
 	}
+	if err = d.Set("trust_claims", idp.Policy.TrustClaims); err != nil {
+		return diag.Errorf("failed to set provider property 'Trust claims from this identity provider': %v", err)
+	}
 	return nil
 }
 
@@ -300,6 +309,10 @@ func buildIdPSaml(d *schema.ResourceData) (sdk.IdentityProvider, error) {
 				HonorPersistentNameId: d.Get("honor_persistent_name_id").(bool),
 			},
 		},
+	}
+	trustClaims := d.GetRawConfig().GetAttr("trust_claims")
+	if !trustClaims.IsNull() {
+		idp.Policy.TrustClaims = utils.BoolPtr(d.Get("trust_claims").(bool))
 	}
 	if d.Get("status") != nil {
 		idp.Status = d.Get("status").(string)

--- a/okta/services/idaas/resource_okta_idp_saml_test.go
+++ b/okta/services/idaas/resource_okta_idp_saml_test.go
@@ -42,6 +42,7 @@ func TestAccResourceOktaIdpSaml_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name_format", "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"),
 					resource.TestCheckResourceAttr(resourceName, "honor_persistent_name_id", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "kid"),
+					resource.TestCheckResourceAttr(resourceName, "trust_claims", "true"),
 				),
 			},
 			{
@@ -63,6 +64,7 @@ func TestAccResourceOktaIdpSaml_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name_format", "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"),
 					resource.TestCheckResourceAttr(resourceName, "honor_persistent_name_id", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "kid"),
+					resource.TestCheckResourceAttr(resourceName, "trust_claims", "false"),
 				),
 			},
 			{

--- a/sdk/v2_identityProviderPolicy.go
+++ b/sdk/v2_identityProviderPolicy.go
@@ -25,6 +25,7 @@ type IdentityProviderPolicy struct {
 	MaxClockSkewPtr *int64                `json:"maxClockSkew,omitempty"`
 	Provisioning    *Provisioning         `json:"provisioning,omitempty"`
 	Subject         *PolicySubject        `json:"subject,omitempty"`
+	TrustClaims     *bool                 `json:"trustClaims,omitempty"`
 }
 
 func NewIdentityProviderPolicy() *IdentityProviderPolicy {

--- a/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpOidc_read/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpOidc_read/classic-00.yaml
@@ -6,10 +6,10 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 999
+        content_length: 1018
         host: classic-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_2314573173","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
+            {"issuerMode":"ORG_URL","name":"testAcc_2314573173","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
         headers:
             Accept:
                 - application/json
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:18:55 GMT
+                - Tue, 03 Mar 2026 17:16:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.934868375s
+        duration: 2.637057875s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:18:56 GMT
+                - Tue, 03 Mar 2026 17:16:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.364612333s
+        duration: 1.262045375s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -82,13 +82,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmn8iiTaqns2M1d7
+                - 0oavrb8j0lbBSham61d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}},{"id":"prmsxmn8j9YdqHVvq1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8j9YdqHVvq1d7"}}},{"id":"prmsxmn8jtjVwh4H81d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8jtjVwh4H81d7"}}},{"id":"prmsxmn8kdU84KjY91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kdU84KjY91d7"}}},{"id":"prmsxmn8kxBUIP5Dk1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kxBUIP5Dk1d7"}}},{"id":"prmsxmn8lhwgVEeet1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8lhwgVEeet1d7"}}},{"id":"prmsxmn8m1y2OYvB11d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8m1y2OYvB11d7"}}},{"id":"prmsxmn8mlZZTbZrJ1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8mlZZTbZrJ1d7"}}}]'
+        body: '[{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}},{"id":"prmvrbiu7jThYTDHT1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu7jThYTDHT1d7"}}},{"id":"prmvrbiu83dtOnyoJ1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu83dtOnyoJ1d7"}}},{"id":"prmvrbiu8n5OlM3pp1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu8n5OlM3pp1d7"}}},{"id":"prmvrbiu97mQgoMNe1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu97mQgoMNe1d7"}}},{"id":"prmvrbiu9r9e07xNE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu9r9e07xNE1d7"}}},{"id":"prmvrbiuab5qZzLUo1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuab5qZzLUo1d7"}}},{"id":"prmvrbiuav0XIOu4o1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuav0XIOu4o1d7"}}},{"id":"prmvrbiubfMr5UXzE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiubfMr5UXzE1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:18:57 GMT
+                - Tue, 03 Mar 2026 17:16:18 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.121276667s
+        duration: 1.113765542s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,19 +131,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}}'
+        body: '{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:18:58 GMT
+                - Tue, 03 Mar 2026 17:16:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.09706s
+        duration: 1.067524958s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -156,7 +156,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -164,19 +164,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:00 GMT
+                - Tue, 03 Mar 2026 17:16:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.261916792s
+        duration: 1.0451775s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -188,13 +188,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmn8iiTaqns2M1d7
+                - 0oavrb8j0lbBSham61d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -202,21 +202,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}},{"id":"prmsxmn8j9YdqHVvq1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8j9YdqHVvq1d7"}}},{"id":"prmsxmn8jtjVwh4H81d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8jtjVwh4H81d7"}}},{"id":"prmsxmn8kdU84KjY91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kdU84KjY91d7"}}},{"id":"prmsxmn8kxBUIP5Dk1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kxBUIP5Dk1d7"}}},{"id":"prmsxmn8lhwgVEeet1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8lhwgVEeet1d7"}}},{"id":"prmsxmn8m1y2OYvB11d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8m1y2OYvB11d7"}}},{"id":"prmsxmn8mlZZTbZrJ1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8mlZZTbZrJ1d7"}}}]'
+        body: '[{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}},{"id":"prmvrbiu7jThYTDHT1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu7jThYTDHT1d7"}}},{"id":"prmvrbiu83dtOnyoJ1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu83dtOnyoJ1d7"}}},{"id":"prmvrbiu8n5OlM3pp1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu8n5OlM3pp1d7"}}},{"id":"prmvrbiu97mQgoMNe1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu97mQgoMNe1d7"}}},{"id":"prmvrbiu9r9e07xNE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu9r9e07xNE1d7"}}},{"id":"prmvrbiuab5qZzLUo1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuab5qZzLUo1d7"}}},{"id":"prmvrbiuav0XIOu4o1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuav0XIOu4o1d7"}}},{"id":"prmvrbiubfMr5UXzE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiubfMr5UXzE1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:01 GMT
+                - Tue, 03 Mar 2026 17:16:22 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.216725958s
+        duration: 1.1475405s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -237,19 +237,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}}'
+        body: '{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:02 GMT
+                - Tue, 03 Mar 2026 17:16:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.078920833s
+        duration: 1.081535875s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -262,7 +262,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -270,19 +270,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:03 GMT
+                - Tue, 03 Mar 2026 17:16:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.329641459s
+        duration: 1.218184167s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -294,13 +294,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmn8iiTaqns2M1d7
+                - 0oavrb8j0lbBSham61d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -308,21 +308,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}},{"id":"prmsxmn8j9YdqHVvq1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8j9YdqHVvq1d7"}}},{"id":"prmsxmn8jtjVwh4H81d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8jtjVwh4H81d7"}}},{"id":"prmsxmn8kdU84KjY91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kdU84KjY91d7"}}},{"id":"prmsxmn8kxBUIP5Dk1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kxBUIP5Dk1d7"}}},{"id":"prmsxmn8lhwgVEeet1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8lhwgVEeet1d7"}}},{"id":"prmsxmn8m1y2OYvB11d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8m1y2OYvB11d7"}}},{"id":"prmsxmn8mlZZTbZrJ1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8mlZZTbZrJ1d7"}}}]'
+        body: '[{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}},{"id":"prmvrbiu7jThYTDHT1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu7jThYTDHT1d7"}}},{"id":"prmvrbiu83dtOnyoJ1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu83dtOnyoJ1d7"}}},{"id":"prmvrbiu8n5OlM3pp1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu8n5OlM3pp1d7"}}},{"id":"prmvrbiu97mQgoMNe1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu97mQgoMNe1d7"}}},{"id":"prmvrbiu9r9e07xNE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu9r9e07xNE1d7"}}},{"id":"prmvrbiuab5qZzLUo1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuab5qZzLUo1d7"}}},{"id":"prmvrbiuav0XIOu4o1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuav0XIOu4o1d7"}}},{"id":"prmvrbiubfMr5UXzE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiubfMr5UXzE1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:05 GMT
+                - Tue, 03 Mar 2026 17:16:25 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.196470459s
+        duration: 1.113153209s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -335,7 +335,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -343,19 +343,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}}'
+        body: '{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:06 GMT
+                - Tue, 03 Mar 2026 17:16:26 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.216859542s
+        duration: 1.103131084s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -383,21 +383,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:07 GMT
+                - Tue, 03 Mar 2026 17:16:27 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.282044541s
+        duration: 1.234599042s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -425,21 +425,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:08 GMT
+                - Tue, 03 Mar 2026 17:16:29 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.231746083s
+        duration: 1.253063666s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -467,21 +467,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:10 GMT
+                - Tue, 03 Mar 2026 17:16:30 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.231568458s
+        duration: 1.2688455s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -494,7 +494,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -502,19 +502,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:11 GMT
+                - Tue, 03 Mar 2026 17:16:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.348684959s
+        duration: 1.249246125s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -526,13 +526,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmn8iiTaqns2M1d7
+                - 0oavrb8j0lbBSham61d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrb8j0lbBSham61d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -540,21 +540,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}},{"id":"prmsxmn8j9YdqHVvq1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8j9YdqHVvq1d7"}}},{"id":"prmsxmn8jtjVwh4H81d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8jtjVwh4H81d7"}}},{"id":"prmsxmn8kdU84KjY91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kdU84KjY91d7"}}},{"id":"prmsxmn8kxBUIP5Dk1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8kxBUIP5Dk1d7"}}},{"id":"prmsxmn8lhwgVEeet1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8lhwgVEeet1d7"}}},{"id":"prmsxmn8m1y2OYvB11d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8m1y2OYvB11d7"}}},{"id":"prmsxmn8mlZZTbZrJ1d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8mlZZTbZrJ1d7"}}}]'
+        body: '[{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}},{"id":"prmvrbiu7jThYTDHT1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu7jThYTDHT1d7"}}},{"id":"prmvrbiu83dtOnyoJ1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu83dtOnyoJ1d7"}}},{"id":"prmvrbiu8n5OlM3pp1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu8n5OlM3pp1d7"}}},{"id":"prmvrbiu97mQgoMNe1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu97mQgoMNe1d7"}}},{"id":"prmvrbiu9r9e07xNE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiu9r9e07xNE1d7"}}},{"id":"prmvrbiuab5qZzLUo1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuab5qZzLUo1d7"}}},{"id":"prmvrbiuav0XIOu4o1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiuav0XIOu4o1d7"}}},{"id":"prmvrbiubfMr5UXzE1d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrbiubfMr5UXzE1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:12 GMT
+                - Tue, 03 Mar 2026 17:16:33 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.119212375s
+        duration: 1.108472125s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -567,7 +567,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -575,19 +575,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn8ipxtUKEF91d7","source":{"id":"0oasxmn8iiTaqns2M1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmn8iiTaqns2M1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn8iiTaqns2M1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmn8ipxtUKEF91d7"}}}'
+        body: '{"id":"prmvrb8j0tpgVO8F41d7","source":{"id":"0oavrb8j0lbBSham61d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrb8j0lbBSham61d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrb8j0lbBSham61d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrb8j0tpgVO8F41d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:14 GMT
+                - Tue, 03 Mar 2026 17:16:34 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.179787917s
+        duration: 1.068678167s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -615,21 +615,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:15 GMT
+                - Tue, 03 Mar 2026 17:16:35 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.347504083s
+        duration: 1.062079292s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -657,21 +657,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:18:53.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:14.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:16 GMT
+                - Tue, 03 Mar 2026 17:16:36 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.31778875s
+        duration: 1.08797825s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -684,7 +684,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmn8iiTaqns2M1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrb8j0lbBSham61d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -692,19 +692,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn8iiTaqns2M1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"INACTIVE","created":"2025-12-21T17:18:53.000Z","lastUpdated":"2025-12-21T17:19:18.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmn8iiTaqns2M1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrb8j0lbBSham61d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"INACTIVE","created":"2026-03-03T17:16:14.000Z","lastUpdated":"2026-03-03T17:16:37.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrb8j0lbBSham61d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:18 GMT
+                - Tue, 03 Mar 2026 17:16:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.337135334s
+        duration: 1.351150958s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -717,7 +717,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmn8iiTaqns2M1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrb8j0lbBSham61d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -729,9 +729,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 17:19:20 GMT
+                - Tue, 03 Mar 2026 17:16:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.615626292s
+        duration: 1.768702375s

--- a/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpOidc_read/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpOidc_read/oie-00.yaml
@@ -6,10 +6,10 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 999
+        content_length: 1018
         host: oie-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_2314573173","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
+            {"issuerMode":"ORG_URL","name":"testAcc_2314573173","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
         headers:
             Accept:
                 - application/json
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:43 GMT
+                - Tue, 03 Mar 2026 17:14:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.791759917s
+        duration: 2.562984542s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:45 GMT
+                - Tue, 03 Mar 2026 17:15:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.363325417s
+        duration: 1.269224709s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -82,13 +82,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmb7adxHSo5Rn1d7
+                - 0oavrbf9ucnv79Ed71d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}},{"id":"prmsxmp9hcoQGgPEm1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hcoQGgPEm1d7"}}},{"id":"prmsxmp9hwiATDpWh1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hwiATDpWh1d7"}}},{"id":"prmsxmp9igL8S3W1B1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9igL8S3W1B1d7"}}},{"id":"prmsxmp9j0mPhO6xe1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9j0mPhO6xe1d7"}}},{"id":"prmsxmp9jkqzScI171d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9jkqzScI171d7"}}},{"id":"prmsxmp9k4fKhQJLy1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9k4fKhQJLy1d7"}}},{"id":"prmsxmp9koZxLrKiX1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9koZxLrKiX1d7"}}}]'
+        body: '[{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}},{"id":"prmvrbf9v30Sk9HLI1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9v30Sk9HLI1d7"}}},{"id":"prmvrbf9vn8QX6jmb1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9vn8QX6jmb1d7"}}},{"id":"prmvrbf9w9H7nBV5U1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9w9H7nBV5U1d7"}}},{"id":"prmvrbf9wtCLBf2k01d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9wtCLBf2k01d7"}}},{"id":"prmvrbf9xdXIwrflW1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xdXIwrflW1d7"}}},{"id":"prmvrbf9xxLPDp3uE1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xxLPDp3uE1d7"}}},{"id":"prmvrbf9yhTGmpq981d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9yhTGmpq981d7"}}},{"id":"prmvrbf9z1mtCDVpj1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9z1mtCDVpj1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:46 GMT
+                - Tue, 03 Mar 2026 17:15:01 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.16500275s
+        duration: 1.136198708s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,19 +131,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}}'
+        body: '{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:47 GMT
+                - Tue, 03 Mar 2026 17:15:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.08278525s
+        duration: 1.111031583s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -156,7 +156,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -164,19 +164,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:48 GMT
+                - Tue, 03 Mar 2026 17:15:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.279477625s
+        duration: 1.271553208s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -188,13 +188,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmb7adxHSo5Rn1d7
+                - 0oavrbf9ucnv79Ed71d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -202,21 +202,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}},{"id":"prmsxmp9hcoQGgPEm1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hcoQGgPEm1d7"}}},{"id":"prmsxmp9hwiATDpWh1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hwiATDpWh1d7"}}},{"id":"prmsxmp9igL8S3W1B1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9igL8S3W1B1d7"}}},{"id":"prmsxmp9j0mPhO6xe1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9j0mPhO6xe1d7"}}},{"id":"prmsxmp9jkqzScI171d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9jkqzScI171d7"}}},{"id":"prmsxmp9k4fKhQJLy1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9k4fKhQJLy1d7"}}},{"id":"prmsxmp9koZxLrKiX1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9koZxLrKiX1d7"}}}]'
+        body: '[{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}},{"id":"prmvrbf9v30Sk9HLI1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9v30Sk9HLI1d7"}}},{"id":"prmvrbf9vn8QX6jmb1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9vn8QX6jmb1d7"}}},{"id":"prmvrbf9w9H7nBV5U1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9w9H7nBV5U1d7"}}},{"id":"prmvrbf9wtCLBf2k01d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9wtCLBf2k01d7"}}},{"id":"prmvrbf9xdXIwrflW1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xdXIwrflW1d7"}}},{"id":"prmvrbf9xxLPDp3uE1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xxLPDp3uE1d7"}}},{"id":"prmvrbf9yhTGmpq981d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9yhTGmpq981d7"}}},{"id":"prmvrbf9z1mtCDVpj1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9z1mtCDVpj1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:50 GMT
+                - Tue, 03 Mar 2026 17:15:05 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.191808458s
+        duration: 1.104661667s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -237,19 +237,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}}'
+        body: '{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:51 GMT
+                - Tue, 03 Mar 2026 17:15:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.199617166s
+        duration: 1.129174042s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -262,7 +262,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -270,19 +270,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:52 GMT
+                - Tue, 03 Mar 2026 17:15:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.16676725s
+        duration: 1.253407625s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -294,13 +294,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmb7adxHSo5Rn1d7
+                - 0oavrbf9ucnv79Ed71d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -308,21 +308,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}},{"id":"prmsxmp9hcoQGgPEm1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hcoQGgPEm1d7"}}},{"id":"prmsxmp9hwiATDpWh1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hwiATDpWh1d7"}}},{"id":"prmsxmp9igL8S3W1B1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9igL8S3W1B1d7"}}},{"id":"prmsxmp9j0mPhO6xe1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9j0mPhO6xe1d7"}}},{"id":"prmsxmp9jkqzScI171d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9jkqzScI171d7"}}},{"id":"prmsxmp9k4fKhQJLy1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9k4fKhQJLy1d7"}}},{"id":"prmsxmp9koZxLrKiX1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9koZxLrKiX1d7"}}}]'
+        body: '[{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}},{"id":"prmvrbf9v30Sk9HLI1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9v30Sk9HLI1d7"}}},{"id":"prmvrbf9vn8QX6jmb1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9vn8QX6jmb1d7"}}},{"id":"prmvrbf9w9H7nBV5U1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9w9H7nBV5U1d7"}}},{"id":"prmvrbf9wtCLBf2k01d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9wtCLBf2k01d7"}}},{"id":"prmvrbf9xdXIwrflW1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xdXIwrflW1d7"}}},{"id":"prmvrbf9xxLPDp3uE1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xxLPDp3uE1d7"}}},{"id":"prmvrbf9yhTGmpq981d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9yhTGmpq981d7"}}},{"id":"prmvrbf9z1mtCDVpj1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9z1mtCDVpj1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:53 GMT
+                - Tue, 03 Mar 2026 17:15:09 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.161109541s
+        duration: 1.094376041s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -335,7 +335,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -343,19 +343,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}}'
+        body: '{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:55 GMT
+                - Tue, 03 Mar 2026 17:15:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.184168125s
+        duration: 1.07285525s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -383,21 +383,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:56 GMT
+                - Tue, 03 Mar 2026 17:15:11 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.328457s
+        duration: 1.308713208s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -425,21 +425,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:57 GMT
+                - Tue, 03 Mar 2026 17:15:12 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.263542166s
+        duration: 1.260289583s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -467,21 +467,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:19:59 GMT
+                - Tue, 03 Mar 2026 17:15:14 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.240807583s
+        duration: 1.247572416s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -494,7 +494,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -502,19 +502,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:20:00 GMT
+                - Tue, 03 Mar 2026 17:15:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.273610208s
+        duration: 1.170768625s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -526,13 +526,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmb7adxHSo5Rn1d7
+                - 0oavrbf9ucnv79Ed71d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbf9ucnv79Ed71d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -540,21 +540,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}},{"id":"prmsxmp9hcoQGgPEm1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hcoQGgPEm1d7"}}},{"id":"prmsxmp9hwiATDpWh1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9hwiATDpWh1d7"}}},{"id":"prmsxmp9igL8S3W1B1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9igL8S3W1B1d7"}}},{"id":"prmsxmp9j0mPhO6xe1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9j0mPhO6xe1d7"}}},{"id":"prmsxmp9jkqzScI171d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9jkqzScI171d7"}}},{"id":"prmsxmp9k4fKhQJLy1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9k4fKhQJLy1d7"}}},{"id":"prmsxmp9koZxLrKiX1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmp9koZxLrKiX1d7"}}}]'
+        body: '[{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}},{"id":"prmvrbf9v30Sk9HLI1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9v30Sk9HLI1d7"}}},{"id":"prmvrbf9vn8QX6jmb1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9vn8QX6jmb1d7"}}},{"id":"prmvrbf9w9H7nBV5U1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9w9H7nBV5U1d7"}}},{"id":"prmvrbf9wtCLBf2k01d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9wtCLBf2k01d7"}}},{"id":"prmvrbf9xdXIwrflW1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xdXIwrflW1d7"}}},{"id":"prmvrbf9xxLPDp3uE1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9xxLPDp3uE1d7"}}},{"id":"prmvrbf9yhTGmpq981d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9yhTGmpq981d7"}}},{"id":"prmvrbf9z1mtCDVpj1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9z1mtCDVpj1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:20:01 GMT
+                - Tue, 03 Mar 2026 17:15:16 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.132063625s
+        duration: 1.123162292s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -567,7 +567,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -575,19 +575,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmb7akjh2x3sH1d7","source":{"id":"0oasxmb7adxHSo5Rn1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmb7adxHSo5Rn1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmb7adxHSo5Rn1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmb7akjh2x3sH1d7"}}}'
+        body: '{"id":"prmvrbf9ujCF3iaIQ1d7","source":{"id":"0oavrbf9ucnv79Ed71d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbf9ucnv79Ed71d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbf9ucnv79Ed71d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbf9ujCF3iaIQ1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:20:02 GMT
+                - Tue, 03 Mar 2026 17:15:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.16928875s
+        duration: 1.103622375s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -615,21 +615,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:20:04 GMT
+                - Tue, 03 Mar 2026 17:15:18 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.209260042s
+        duration: 1.273413583s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -657,21 +657,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:19:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"ACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:14:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:20:05 GMT
+                - Tue, 03 Mar 2026 17:15:20 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.265337708s
+        duration: 1.154033583s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -684,7 +684,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmb7adxHSo5Rn1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbf9ucnv79Ed71d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -692,19 +692,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmb7adxHSo5Rn1d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"INACTIVE","created":"2025-12-21T17:19:42.000Z","lastUpdated":"2025-12-21T17:20:06.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxmb7adxHSo5Rn1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbf9ucnv79Ed71d7","issuerMode":"ORG_URL","name":"testAcc_2314573173","status":"INACTIVE","created":"2026-03-03T17:14:58.000Z","lastUpdated":"2026-03-03T17:15:21.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavrbf9ucnv79Ed71d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:20:06 GMT
+                - Tue, 03 Mar 2026 17:15:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.229264708s
+        duration: 1.478064916s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -717,7 +717,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmb7adxHSo5Rn1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbf9ucnv79Ed71d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -729,9 +729,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 17:20:08 GMT
+                - Tue, 03 Mar 2026 17:15:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.845301083s
+        duration: 2.001008583s

--- a/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpSaml_read/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpSaml_read/classic-00.yaml
@@ -28,19 +28,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw3f06HCBYg1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_2:0oasxmlw3f06HCBYg1d7","name":"classic-00_testacc2166628549_2","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:23:37.000Z","created":"2025-12-21T17:23:36.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_2_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/alnsxn2rl1zDBHpa81d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrbyb7ktsOgyyn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_6:0oavrbyb7ktsOgyyn1d7","name":"classic-00_testacc2166628549_6","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:30:11.000Z","created":"2026-03-03T17:30:10.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_6_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_6_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/alnvrcevulBkAvi7M1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:37 GMT
+                - Tue, 03 Mar 2026 17:30:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.416312708s
+        duration: 2.297405542s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,12 +67,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:38 GMT
+                - Tue, 03 Mar 2026 17:30:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.094195917s
+        duration: 1.092754875s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
+        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttgu86y5cqPXYVT1d7","status":"ACTIVE","name":"Case-OKTA-1059814-1","priority":1,"system":false,"conditions":null,"created":"2026-01-05T13:32:57.000Z","lastUpdated":"2026-01-05T13:32:57.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnr1lke47WiZr71d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T03:07:20.000Z","lastUpdated":"2026-01-09T03:07:20.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:39 GMT
+                - Tue, 03 Mar 2026 17:30:13 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.216390208s
+        duration: 1.067641667s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies/rstnkw1sgxfqkDUtx1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies/rstnkw1sgxfqkDUtx1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -135,12 +135,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 17:23:40 GMT
+                - Tue, 03 Mar 2026 17:30:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.19008375s
+        duration: 1.22275775s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw3f06HCBYg1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_2:0oasxmlw3f06HCBYg1d7","name":"classic-00_testacc2166628549_2","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:23:37.000Z","created":"2025-12-21T17:23:36.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_2_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/alnsxn2rl1zDBHpa81d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrbyb7ktsOgyyn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_6:0oavrbyb7ktsOgyyn1d7","name":"classic-00_testacc2166628549_6","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:30:11.000Z","created":"2026-03-03T17:30:10.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_6_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_6_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/alnvrcevulBkAvi7M1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:41 GMT
+                - Tue, 03 Mar 2026 17:30:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.094083459s
+        duration: 1.145689167s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,13 +183,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
+                - kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata?kid=IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata?kid=kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,23 +197,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmlw3egVlUtuZ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrbyb7jexx5ICF1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3
-            MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3
+            MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE
-            YhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z
-            dhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100
-            qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi
-            tje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx
-            My1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/
-            6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+
-            uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz
-            3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn
-            NCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA
+            F/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU
+            w+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5
+            QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL
+            NVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ
+            lZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt
+            C2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK
+            Mov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d
+            x9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR
+            wwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -222,12 +222,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:23:43 GMT
+                - Tue, 03 Mar 2026 17:30:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.336270708s
+        duration: 1.208577s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -248,19 +248,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:23:36.000Z","lastUpdated":"2025-12-21T17:23:36.000Z","expiresAt":"2035-12-21T17:23:36.000Z","kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwEYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Zdhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGitje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yxMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGnNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:30:10.000Z","lastUpdated":"2026-03-03T17:30:10.000Z","expiresAt":"2036-03-03T17:30:10.000Z","kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsAF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AUw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaLNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3XrtC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGKMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1dx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyRwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:44 GMT
+                - Tue, 03 Mar 2026 17:30:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.363435292s
+        duration: 1.236156792s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -269,7 +269,7 @@ interactions:
         content_length: 1337
         host: classic-00.dne-okta.com
         body: |
-            {"x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="]}
+            {"x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="]}
         headers:
             Accept:
                 - application/json
@@ -285,19 +285,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:23:45.000Z","lastUpdated":"2025-12-21T17:23:45.000Z","expiresAt":"2035-12-21T17:23:36.000Z","alg":"RSA","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:30:19.000Z","lastUpdated":"2026-03-03T17:30:19.000Z","expiresAt":"2036-03-03T17:30:10.000Z","alg":"RSA","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:45 GMT
+                - Tue, 03 Mar 2026 17:30:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.085008s
+        duration: 1.155923708s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -310,7 +310,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/8fe60395-e563-4a68-89f8-c56959c7c938
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/2a141d92-2508-4e32-ba42-f8d44177b874
         method: GET
       response:
         proto: HTTP/2.0
@@ -318,19 +318,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:23:45.000Z","lastUpdated":"2025-12-21T17:23:45.000Z","expiresAt":"2035-12-21T17:23:36.000Z","alg":"RSA","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:30:19.000Z","lastUpdated":"2026-03-03T17:30:19.000Z","expiresAt":"2036-03-03T17:30:10.000Z","alg":"RSA","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:46 GMT
+                - Tue, 03 Mar 2026 17:30:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.195392125s
+        duration: 1.096751208s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -339,7 +339,7 @@ interactions:
         content_length: 944
         host: classic-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"8fe60395-e563-4a68-89f8-c56959c7c938"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
+            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"2a141d92-2508-4e32-ba42-f8d44177b874"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
@@ -355,19 +355,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:21.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:49 GMT
+                - Tue, 03 Mar 2026 17:30:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.174339833s
+        duration: 2.055302167s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -380,7 +380,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -388,19 +388,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:21.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:50 GMT
+                - Tue, 03 Mar 2026 17:30:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.153776542s
+        duration: 1.171619375s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -412,13 +412,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmlw6aORx4kxX1d7
+                - 0oavrc66menWC6NTZ1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -426,21 +426,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}},{"id":"prmsxmlw6yT1a04ux1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6yT1a04ux1d7"}}},{"id":"prmsxmlw790Xc7o531d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw790Xc7o531d7"}}},{"id":"prmsxmlw7kRqXxrTO1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7kRqXxrTO1d7"}}},{"id":"prmsxmlw7veTz2Id71d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7veTz2Id71d7"}}},{"id":"prmsxmlw86m1kEs9w1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw86m1kEs9w1d7"}}},{"id":"prmsxmlw8hfElLsZt1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8hfElLsZt1d7"}}},{"id":"prmsxmlw8sVA8iLhc1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8sVA8iLhc1d7"}}}]'
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:51 GMT
+                - Tue, 03 Mar 2026 17:30:24 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.195047s
+        duration: 1.111853417s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -453,7 +453,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -461,19 +461,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}}'
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:52 GMT
+                - Tue, 03 Mar 2026 17:30:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.196052292s
+        duration: 1.079181375s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -486,7 +486,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -494,19 +494,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw3f06HCBYg1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_2:0oasxmlw3f06HCBYg1d7","name":"classic-00_testacc2166628549_2","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:23:37.000Z","created":"2025-12-21T17:23:36.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_2_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/alnsxn2rl1zDBHpa81d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrbyb7ktsOgyyn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_6:0oavrbyb7ktsOgyyn1d7","name":"classic-00_testacc2166628549_6","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:30:11.000Z","created":"2026-03-03T17:30:10.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_6_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_6_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/alnvrcevulBkAvi7M1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:53 GMT
+                - Tue, 03 Mar 2026 17:30:27 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.117569417s
+        duration: 1.092832167s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -516,13 +516,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
+                - kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata?kid=IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata?kid=kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,23 +530,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmlw3egVlUtuZ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrbyb7jexx5ICF1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3
-            MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3
+            MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE
-            YhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z
-            dhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100
-            qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi
-            tje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx
-            My1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/
-            6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+
-            uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz
-            3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn
-            NCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA
+            F/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU
+            w+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5
+            QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL
+            NVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ
+            lZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt
+            C2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK
+            Mov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d
+            x9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR
+            wwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -555,12 +555,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:23:55 GMT
+                - Tue, 03 Mar 2026 17:30:28 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.323579667s
+        duration: 1.241992375s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -573,7 +573,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -581,19 +581,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:23:36.000Z","lastUpdated":"2025-12-21T17:23:36.000Z","expiresAt":"2035-12-21T17:23:36.000Z","kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwEYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Zdhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGitje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yxMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGnNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:30:10.000Z","lastUpdated":"2026-03-03T17:30:10.000Z","expiresAt":"2036-03-03T17:30:10.000Z","kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsAF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AUw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaLNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3XrtC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGKMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1dx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyRwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:56 GMT
+                - Tue, 03 Mar 2026 17:30:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.263931459s
+        duration: 1.253699542s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -606,7 +606,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/8fe60395-e563-4a68-89f8-c56959c7c938
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/2a141d92-2508-4e32-ba42-f8d44177b874
         method: GET
       response:
         proto: HTTP/2.0
@@ -614,19 +614,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:23:45.000Z","lastUpdated":"2025-12-21T17:23:45.000Z","expiresAt":"2035-12-21T17:23:36.000Z","alg":"RSA","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:30:19.000Z","lastUpdated":"2026-03-03T17:30:19.000Z","expiresAt":"2036-03-03T17:30:10.000Z","alg":"RSA","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:57 GMT
+                - Tue, 03 Mar 2026 17:30:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.09973225s
+        duration: 1.044526833s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -639,7 +639,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -647,19 +647,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:21.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:58 GMT
+                - Tue, 03 Mar 2026 17:30:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.206689625s
+        duration: 1.034473292s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -671,13 +671,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmlw6aORx4kxX1d7
+                - 0oavrc66menWC6NTZ1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -685,21 +685,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}},{"id":"prmsxmlw6yT1a04ux1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6yT1a04ux1d7"}}},{"id":"prmsxmlw790Xc7o531d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw790Xc7o531d7"}}},{"id":"prmsxmlw7kRqXxrTO1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7kRqXxrTO1d7"}}},{"id":"prmsxmlw7veTz2Id71d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7veTz2Id71d7"}}},{"id":"prmsxmlw86m1kEs9w1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw86m1kEs9w1d7"}}},{"id":"prmsxmlw8hfElLsZt1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8hfElLsZt1d7"}}},{"id":"prmsxmlw8sVA8iLhc1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8sVA8iLhc1d7"}}}]'
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:23:59 GMT
+                - Tue, 03 Mar 2026 17:30:32 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.145752916s
+        duration: 1.087386875s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -712,7 +712,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -720,19 +720,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}}'
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:01 GMT
+                - Tue, 03 Mar 2026 17:30:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.083765125s
+        duration: 1.071043625s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -745,7 +745,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -753,19 +753,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw3f06HCBYg1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_2:0oasxmlw3f06HCBYg1d7","name":"classic-00_testacc2166628549_2","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:23:37.000Z","created":"2025-12-21T17:23:36.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_2_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/alnsxn2rl1zDBHpa81d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrbyb7ktsOgyyn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_6:0oavrbyb7ktsOgyyn1d7","name":"classic-00_testacc2166628549_6","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:30:11.000Z","created":"2026-03-03T17:30:10.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_6_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_6_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/alnvrcevulBkAvi7M1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:02 GMT
+                - Tue, 03 Mar 2026 17:30:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.124006s
+        duration: 1.081823208s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -775,13 +775,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
+                - kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata?kid=IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata?kid=kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,23 +789,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmlw3egVlUtuZ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrbyb7jexx5ICF1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3
-            MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3
+            MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE
-            YhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z
-            dhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100
-            qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi
-            tje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx
-            My1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/
-            6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+
-            uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz
-            3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn
-            NCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA
+            F/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU
+            w+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5
+            QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL
+            NVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ
+            lZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt
+            C2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK
+            Mov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d
+            x9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR
+            wwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -814,12 +814,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:24:03 GMT
+                - Tue, 03 Mar 2026 17:30:36 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.247651208s
+        duration: 1.223813292s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -832,7 +832,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -840,19 +840,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:23:36.000Z","lastUpdated":"2025-12-21T17:23:36.000Z","expiresAt":"2035-12-21T17:23:36.000Z","kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwEYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Zdhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGitje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yxMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGnNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:30:10.000Z","lastUpdated":"2026-03-03T17:30:10.000Z","expiresAt":"2036-03-03T17:30:10.000Z","kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsAF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AUw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaLNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3XrtC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGKMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1dx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyRwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:04 GMT
+                - Tue, 03 Mar 2026 17:30:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.238513792s
+        duration: 1.203556833s
     - id: 23
       request:
         proto: HTTP/1.1
@@ -865,7 +865,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/8fe60395-e563-4a68-89f8-c56959c7c938
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/2a141d92-2508-4e32-ba42-f8d44177b874
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,19 +873,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:23:45.000Z","lastUpdated":"2025-12-21T17:23:45.000Z","expiresAt":"2035-12-21T17:23:36.000Z","alg":"RSA","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:30:19.000Z","lastUpdated":"2026-03-03T17:30:19.000Z","expiresAt":"2036-03-03T17:30:10.000Z","alg":"RSA","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:05 GMT
+                - Tue, 03 Mar 2026 17:30:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.07218375s
+        duration: 1.04988625s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -898,7 +898,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -906,19 +906,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:21.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:06 GMT
+                - Tue, 03 Mar 2026 17:30:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.085425791s
+        duration: 1.055887167s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -930,13 +930,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmlw6aORx4kxX1d7
+                - 0oavrc66menWC6NTZ1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -944,21 +944,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}},{"id":"prmsxmlw6yT1a04ux1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6yT1a04ux1d7"}}},{"id":"prmsxmlw790Xc7o531d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw790Xc7o531d7"}}},{"id":"prmsxmlw7kRqXxrTO1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7kRqXxrTO1d7"}}},{"id":"prmsxmlw7veTz2Id71d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7veTz2Id71d7"}}},{"id":"prmsxmlw86m1kEs9w1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw86m1kEs9w1d7"}}},{"id":"prmsxmlw8hfElLsZt1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8hfElLsZt1d7"}}},{"id":"prmsxmlw8sVA8iLhc1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8sVA8iLhc1d7"}}}]'
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:08 GMT
+                - Tue, 03 Mar 2026 17:30:40 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.116538125s
+        duration: 1.118171958s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -971,7 +971,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -979,61 +979,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}}'
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:09 GMT
+                - Tue, 03 Mar 2026 17:30:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.099087s
+        duration: 1.053191125s
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 1041
         host: classic-00.dne-okta.com
-        form:
-            limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
+        body: |
+            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","issuer":"https://idp.example.com","kid":"2a141d92-2508-4e32-ba42-f8d44177b874"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
-        method: GET
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:10 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - Tue, 03 Mar 2026 17:30:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.096104917s
+        duration: 1.352450959s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1041,19 +1036,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1061,21 +1049,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:11 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - Tue, 03 Mar 2026 17:30:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.103116541s
+        duration: 1.059809916s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1085,17 +1071,15 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
+                - "200"
+            sourceId:
+                - 0oavrc66menWC6NTZ1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1103,21 +1087,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:12 GMT
+                - Tue, 03 Mar 2026 17:30:45 GMT
             Link:
-                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.118842125s
+        duration: 1.078946917s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1130,7 +1114,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1138,19 +1122,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw3f06HCBYg1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_2:0oasxmlw3f06HCBYg1d7","name":"classic-00_testacc2166628549_2","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:23:37.000Z","created":"2025-12-21T17:23:36.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_2_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/alnsxn2rl1zDBHpa81d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:14 GMT
+                - Tue, 03 Mar 2026 17:30:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.094291375s
+        duration: 1.059421583s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1159,65 +1143,18 @@ interactions:
         content_length: 0
         host: classic-00.dne-okta.com
         form:
-            kid:
-                - IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
-        headers:
-            Accept:
-                - application/xml
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata?kid=IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2363
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmlw3egVlUtuZ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3
-            MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
-            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
-            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE
-            YhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z
-            dhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100
-            qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi
-            tje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx
-            My1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/
-            6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+
-            uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz
-            3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn
-            NCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2363"
-            Content-Type:
-                - application/xml;charset=ISO-8859-1
-            Date:
-                - Sun, 21 Dec 2025 17:24:15 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.310933458s
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1225,19 +1162,63 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:23:36.000Z","lastUpdated":"2025-12-21T17:23:36.000Z","expiresAt":"2035-12-21T17:23:36.000Z","kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwEYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Zdhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGitje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yxMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGnNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}]'
+        body: '[{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:16 GMT
+                - Tue, 03 Mar 2026 17:30:47 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.29169225s
+        duration: 1.058788833s
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:30:48 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.073556791s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1250,7 +1231,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/8fe60395-e563-4a68-89f8-c56959c7c938
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,19 +1239,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:23:45.000Z","lastUpdated":"2025-12-21T17:23:45.000Z","expiresAt":"2035-12-21T17:23:36.000Z","alg":"RSA","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}'
+        body: '{"id":"0oavrbyb7ktsOgyyn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_6:0oavrbyb7ktsOgyyn1d7","name":"classic-00_testacc2166628549_6","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:30:11.000Z","created":"2026-03-03T17:30:10.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_6_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_6_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/alnvrcevulBkAvi7M1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:17 GMT
+                - Tue, 03 Mar 2026 17:30:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.142467125s
+        duration: 1.122305s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1278,32 +1259,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
+        form:
+            kid:
+                - kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata?kid=kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        content_length: 2363
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrbyb7jexx5ICF1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3
+            MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
+            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA
+            F/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU
+            w+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5
+            QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL
+            NVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ
+            lZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt
+            C2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK
+            Mov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d
+            x9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR
+            wwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2363"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:24:18 GMT
+                - Tue, 03 Mar 2026 17:30:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.067946875s
+        duration: 1.253205458s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1311,17 +1313,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            limit:
-                - "200"
-            sourceId:
-                - 0oasxmlw6aORx4kxX1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -1329,21 +1326,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}},{"id":"prmsxmlw6yT1a04ux1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6yT1a04ux1d7"}}},{"id":"prmsxmlw790Xc7o531d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw790Xc7o531d7"}}},{"id":"prmsxmlw7kRqXxrTO1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7kRqXxrTO1d7"}}},{"id":"prmsxmlw7veTz2Id71d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7veTz2Id71d7"}}},{"id":"prmsxmlw86m1kEs9w1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw86m1kEs9w1d7"}}},{"id":"prmsxmlw8hfElLsZt1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8hfElLsZt1d7"}}},{"id":"prmsxmlw8sVA8iLhc1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8sVA8iLhc1d7"}}}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:30:10.000Z","lastUpdated":"2026-03-03T17:30:10.000Z","expiresAt":"2036-03-03T17:30:10.000Z","kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsAF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AUw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaLNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3XrtC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGKMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1dx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyRwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:19 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+                - Tue, 03 Mar 2026 17:30:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.136646833s
+        duration: 1.205201375s
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1356,7 +1351,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/2a141d92-2508-4e32-ba42-f8d44177b874
         method: GET
       response:
         proto: HTTP/2.0
@@ -1364,19 +1359,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:30:19.000Z","lastUpdated":"2026-03-03T17:30:19.000Z","expiresAt":"2036-03-03T17:30:10.000Z","alg":"RSA","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:21 GMT
+                - Tue, 03 Mar 2026 17:30:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.1088035s
+        duration: 1.098201083s
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1384,19 +1379,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1404,21 +1392,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:22 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - Tue, 03 Mar 2026 17:30:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.107724375s
+        duration: 1.050691791s
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1428,17 +1414,15 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
+                - "200"
+            sourceId:
+                - 0oavrc66menWC6NTZ1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1446,21 +1430,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:23 GMT
+                - Tue, 03 Mar 2026 17:30:55 GMT
             Link:
-                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.108794666s
+        duration: 1.07172625s
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1473,7 +1457,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1481,19 +1465,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw3f06HCBYg1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_2:0oasxmlw3f06HCBYg1d7","name":"classic-00_testacc2166628549_2","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:23:37.000Z","created":"2025-12-21T17:23:36.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_2_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/alnsxn2rl1zDBHpa81d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:24 GMT
+                - Tue, 03 Mar 2026 17:30:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.112558833s
+        duration: 1.056325375s
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1502,65 +1486,18 @@ interactions:
         content_length: 0
         host: classic-00.dne-okta.com
         form:
-            kid:
-                - IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
-        headers:
-            Accept:
-                - application/xml
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata?kid=IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2363
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmlw3egVlUtuZ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3
-            MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
-            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
-            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE
-            YhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z
-            dhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100
-            qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi
-            tje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx
-            My1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/
-            6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+
-            uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz
-            3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn
-            NCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2363"
-            Content-Type:
-                - application/xml;charset=ISO-8859-1
-            Date:
-                - Sun, 21 Dec 2025 17:24:25 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.264508209s
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1568,19 +1505,63 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:23:36.000Z","lastUpdated":"2025-12-21T17:23:36.000Z","expiresAt":"2035-12-21T17:23:36.000Z","kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwEYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Zdhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGitje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yxMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGnNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}]'
+        body: '[{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:27 GMT
+                - Tue, 03 Mar 2026 17:30:57 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.271653291s
+        duration: 1.055693375s
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:30:58 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.038420333s
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1593,7 +1574,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/8fe60395-e563-4a68-89f8-c56959c7c938
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,19 +1582,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:23:45.000Z","lastUpdated":"2025-12-21T17:23:45.000Z","expiresAt":"2035-12-21T17:23:36.000Z","alg":"RSA","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}'
+        body: '{"id":"0oavrbyb7ktsOgyyn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_6:0oavrbyb7ktsOgyyn1d7","name":"classic-00_testacc2166628549_6","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:30:11.000Z","created":"2026-03-03T17:30:10.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_6_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_6_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/alnvrcevulBkAvi7M1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:28 GMT
+                - Tue, 03 Mar 2026 17:31:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.062333875s
+        duration: 1.085885167s
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1621,32 +1602,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
+        form:
+            kid:
+                - kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata?kid=kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        content_length: 2363
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrbyb7jexx5ICF1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3
+            MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
+            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA
+            F/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU
+            w+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5
+            QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL
+            NVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ
+            lZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt
+            C2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK
+            Mov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d
+            x9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR
+            wwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2363"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:24:29 GMT
+                - Tue, 03 Mar 2026 17:31:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.066236916s
+        duration: 1.202423958s
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1654,17 +1656,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            limit:
-                - "200"
-            sourceId:
-                - 0oasxmlw6aORx4kxX1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -1672,21 +1669,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}},{"id":"prmsxmlw6yT1a04ux1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6yT1a04ux1d7"}}},{"id":"prmsxmlw790Xc7o531d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw790Xc7o531d7"}}},{"id":"prmsxmlw7kRqXxrTO1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7kRqXxrTO1d7"}}},{"id":"prmsxmlw7veTz2Id71d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7veTz2Id71d7"}}},{"id":"prmsxmlw86m1kEs9w1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw86m1kEs9w1d7"}}},{"id":"prmsxmlw8hfElLsZt1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8hfElLsZt1d7"}}},{"id":"prmsxmlw8sVA8iLhc1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8sVA8iLhc1d7"}}}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:30:10.000Z","lastUpdated":"2026-03-03T17:30:10.000Z","expiresAt":"2036-03-03T17:30:10.000Z","kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsAF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AUw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaLNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3XrtC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGKMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1dx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyRwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:30 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+                - Tue, 03 Mar 2026 17:31:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.098663625s
+        duration: 1.044139417s
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1699,7 +1694,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/2a141d92-2508-4e32-ba42-f8d44177b874
         method: GET
       response:
         proto: HTTP/2.0
@@ -1707,19 +1702,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:30:19.000Z","lastUpdated":"2026-03-03T17:30:19.000Z","expiresAt":"2036-03-03T17:30:10.000Z","alg":"RSA","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:31 GMT
+                - Tue, 03 Mar 2026 17:31:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.066625208s
+        duration: 1.170610042s
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1732,7 +1727,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1740,19 +1735,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:30:43.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:32 GMT
+                - Tue, 03 Mar 2026 17:31:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0814535s
+        duration: 1.050638958s
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1760,12 +1755,17 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oavrc66menWC6NTZ1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1773,19 +1773,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:33 GMT
+                - Tue, 03 Mar 2026 17:31:05 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.057871958s
+        duration: 1.106463208s
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1798,7 +1800,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1806,52 +1808,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:34 GMT
+                - Tue, 03 Mar 2026 17:31:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.067941375s
+        duration: 1.111691834s
     - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 1042
         host: classic-00.dne-okta.com
+        body: |
+            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":false},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","issuer":"https://idp.example.com","kid":"2a141d92-2508-4e32-ba42-f8d44177b874"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7
-        method: GET
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw3f06HCBYg1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_2:0oasxmlw3f06HCBYg1d7","name":"classic-00_testacc2166628549_2","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:23:37.000Z","created":"2025-12-21T17:23:36.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_2_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_2/0oasxmlw3f06HCBYg1d7/alnsxn2rl1zDBHpa81d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T17:31:08.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:36 GMT
+                - Tue, 03 Mar 2026 17:31:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.143393584s
+        duration: 1.15348025s
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1859,66 +1865,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            kid:
-                - IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
-        headers:
-            Accept:
-                - application/xml
-            Authorization:
-                - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/sso/saml/metadata?kid=IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2363
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmlw3egVlUtuZ1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3
-            MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
-            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
-            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE
-            YhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z
-            dhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100
-            qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi
-            tje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx
-            My1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/
-            6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+
-            uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz
-            3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn
-            NCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_2/exksxmlw3egVlUtuZ1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2363"
-            Content-Type:
-                - application/xml;charset=ISO-8859-1
-            Date:
-                - Sun, 21 Dec 2025 17:24:37 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.273662542s
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: classic-00.dne-okta.com
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1926,19 +1878,59 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:23:36.000Z","lastUpdated":"2025-12-21T17:23:36.000Z","expiresAt":"2035-12-21T17:23:36.000Z","kid":"IY5hQQEQpXwgMvfD_FPGSJ_8EOXx7NYR3oVy8H_4WEA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3MjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwEYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Zdhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100qZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGitje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yxMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+uYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGnNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}]'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:31:08.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:38 GMT
+                - Tue, 03 Mar 2026 17:31:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.143707791s
+        duration: 1.140720209s
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oavrc66menWC6NTZ1d7
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:31:10 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.101045917s
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1951,7 +1943,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/8fe60395-e563-4a68-89f8-c56959c7c938
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1959,19 +1951,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:23:45.000Z","lastUpdated":"2025-12-21T17:23:45.000Z","expiresAt":"2035-12-21T17:23:36.000Z","alg":"RSA","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB8CcKMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjIzNloXDTM1MTIyMTE3\nMjMzNlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCl6gZhJIAN49ItQndhpPGsBn7fNdVV+TwE\nYhE5OOpG6YgF9P9L1AGjfIhlqBB4pI3ffRxXVaBODsqvn/l1y3jTxv2EsaTBJF3QgnCUPOAxBH8Z\ndhto3z6pf+jf/GT/+dnWA8ojMM4pw5rEzQx/F3GLqx/emsWibMdEtqPoWyubNbc3n3vFlg4UP100\nqZ86ndmCgj01Z/hOMBq8NHRi8GaZgChGRyXCffN7pVWj50BgBFPvZPD8gJ9gkKwkp56nNgpfYrGi\ntje/+xjR+83JUIed6RW7AXoV/i+TIeaNBSzJWW1UyT7Wo3iUq9qLHbTYrEO23k+u96aqfdB0T1yx\nMy1xAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACjfC7gWr5bC6pphpavVgRMfgU1HEUBqD6g/n2+/\n6wBlpxTVyp8N0YG6vDy/Qu0GXdv2/3lza6rBiIpqi+WatSdeAWlK36isiM2OlDGdEa+qr9TlhmP+\nuYuMFj5t1PTUIQG44YGA9yVTmd0jVRBpjy29if2SGpXd+Mf/i10go1nP5XUpfR8VhjYlQLaXsbuz\n3WKDg6cIX/TYk3VfWAwXzHHcQglP2PPNAVtoVL5ujDs30t5htjO6p5reRBeRJ8QansUMATMg6XGn\nNCSqdJodaJEwVILnLKrPcBADuw7oir+FaohsAuHgcvz6sXT78Ug37rbcwqoJUVEB8bIAgTQCXHI="],"x5t#S256":"lIQUTenAZ2CSDwIDxEveoAF80pgFhsFZiiDm2csB700","e":"AQAB","n":"peoGYSSADePSLUJ3YaTxrAZ-3zXVVfk8BGIROTjqRumIBfT_S9QBo3yIZagQeKSN330cV1WgTg7Kr5_5dct408b9hLGkwSRd0IJwlDzgMQR_GXYbaN8-qX_o3_xk__nZ1gPKIzDOKcOaxM0Mfxdxi6sf3prFomzHRLaj6FsrmzW3N597xZYOFD9dNKmfOp3ZgoI9NWf4TjAavDR0YvBmmYAoRkclwn3ze6VVo-dAYART72Tw_ICfYJCsJKeepzYKX2KxorY3v_sY0fvNyVCHnekVuwF6Ff4vkyHmjQUsyVltVMk-1qN4lKvaix202KxDtt5Prvemqn3QdE9csTMtcQ"}'
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:39 GMT
+                - Tue, 03 Mar 2026 17:31:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.114498417s
+        duration: 1.090125666s
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1984,7 +1976,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1992,19 +1984,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:31:08.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:40 GMT
+                - Tue, 03 Mar 2026 17:31:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.105615291s
+        duration: 1.043833209s
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2012,17 +2004,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
-        form:
-            limit:
-                - "200"
-            sourceId:
-                - 0oasxmlw6aORx4kxX1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2030,21 +2017,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}},{"id":"prmsxmlw6yT1a04ux1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6yT1a04ux1d7"}}},{"id":"prmsxmlw790Xc7o531d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw790Xc7o531d7"}}},{"id":"prmsxmlw7kRqXxrTO1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7kRqXxrTO1d7"}}},{"id":"prmsxmlw7veTz2Id71d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw7veTz2Id71d7"}}},{"id":"prmsxmlw86m1kEs9w1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw86m1kEs9w1d7"}}},{"id":"prmsxmlw8hfElLsZt1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8hfElLsZt1d7"}}},{"id":"prmsxmlw8sVA8iLhc1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw8sVA8iLhc1d7"}}}]'
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:31:08.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:42 GMT
-            Link:
-                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+                - Tue, 03 Mar 2026 17:31:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.126587709s
+        duration: 1.042331167s
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2057,7 +2042,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2065,19 +2050,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmlw6n80iACYL1d7","source":{"id":"0oasxmlw6aORx4kxX1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw6aORx4kxX1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmlw6aORx4kxX1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxmlw6n80iACYL1d7"}}}'
+        body: '{"id":"0oavrbyb7ktsOgyyn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc2166628549_6:0oavrbyb7ktsOgyyn1d7","name":"classic-00_testacc2166628549_6","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:30:11.000Z","created":"2026-03-03T17:30:10.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc2166628549_6_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc2166628549_6_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc2166628549_6/0oavrbyb7ktsOgyyn1d7/alnvrcevulBkAvi7M1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:43 GMT
+                - Tue, 03 Mar 2026 17:31:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.180062625s
+        duration: 1.076326917s
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2085,32 +2070,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
+        form:
+            kid:
+                - kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/sso/saml/metadata?kid=kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        content_length: 2363
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrbyb7jexx5ICF1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3
+            MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
+            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA
+            F/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU
+            w+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5
+            QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL
+            NVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ
+            lZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt
+            C2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK
+            Mov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d
+            x9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR
+            wwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc2166628549_6/exkvrbyb7jexx5ICF1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2363"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:24:44 GMT
+                - Tue, 03 Mar 2026 17:31:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.072222s
+        duration: 1.212870917s
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2123,7 +2129,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -2131,19 +2137,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:23:48.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:30:10.000Z","lastUpdated":"2026-03-03T17:30:10.000Z","expiresAt":"2036-03-03T17:30:10.000Z","kid":"kVvgI-6Xw9c38u4ZPvsu5-vDuTEooZH8vPo5PQTE8Wo","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3MzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsAF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AUw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5QZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaLNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3XrtC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGKMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1dx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyRwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:45 GMT
+                - Tue, 03 Mar 2026 17:31:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.098146375s
+        duration: 1.238683959s
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2156,27 +2162,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/deactivate
-        method: POST
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/2a141d92-2508-4e32-ba42-f8d44177b874
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmlw6aORx4kxX1d7","name":"testAcc_2166628549","status":"INACTIVE","created":"2025-12-21T17:23:48.000Z","lastUpdated":"2025-12-21T17:24:46.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spvtkwbizfjgpmjuxrfs","kid":"8fe60395-e563-4a68-89f8-c56959c7c938","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxmlw6aORx4kxX1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:30:19.000Z","lastUpdated":"2026-03-03T17:30:19.000Z","expiresAt":"2036-03-03T17:30:10.000Z","alg":"RSA","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0wAnyMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjkxMFoXDTM2MDMwMzE3\nMzAxMFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqzBo/Z5qcZd2nk09MsvTSflrIWjP60tsA\nF/zntJyLHEkFOi+pmTZIjtE8YovxogLoP09P9mk9RMotuHUOq8mXBuMMJb0gD/0FaGuJ9OBK97AU\nw+JUo4iTqgUCEV35OmbZQmurWlXxuWn7+MxBBMP40rsFmictC5QKjz9Khgh0QIUSLfunIi6olVX5\nQZa+S6AT8tk+kTDc9grvFcKj+An/rEZSihRbZcIFaLuPhQI10ly3qbw7QQwyoCoKjJ0KoJ0KMPaL\nNVlqjjSoqFVRS7qFNtVCbTzOvCYYjbrVSl8KxOQHlfK27y+l5EwRq1jhZurLqXWcsGrFlW+aXFdQ\nlZoHAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJE/AN4+4R8i/JY7qbStZVtXpGRPxWfFomEv3Xrt\nC2sZriKfFwg2gyqkcYLdtMwlPKsqEQX6aFhuwCxYA9H+RTKZ5fRjN2nVpnYLR0W/jDjdrx+qiXGK\nMov7iZTZg3hJVuVNW4lHmz4/mvxR4Mpe4VCSgcDfyH213EUu9LBjM1dDaVHXRq6IAcJPS/pBrL1d\nx9go1TJ9IjiSIpcnimRD7N7/140TTG+jA8+MZVNyv93s25iEHhHXYrXmsqUwnbr2oTnAOqgRsUyR\nwwJ8QBrvc4tUbOVRq8sS83n45ksWg/eeN36f2G7yQlZ4irPQ5mOJc916crqIJU+ABNTYPCGAlK0="],"x5t#S256":"f2xxMzzeiteNAY5P2_wtU87d0jMN88iobjIfD3YUdYs","e":"AQAB","n":"qswaP2eanGXdp5NPTLL00n5ayFoz-tLbABf857ScixxJBTovqZk2SI7RPGKL8aIC6D9PT_ZpPUTKLbh1DqvJlwbjDCW9IA_9BWhrifTgSvewFMPiVKOIk6oFAhFd-Tpm2UJrq1pV8blp-_jMQQTD-NK7BZonLQuUCo8_SoYIdECFEi37pyIuqJVV-UGWvkugE_LZPpEw3PYK7xXCo_gJ_6xGUooUW2XCBWi7j4UCNdJct6m8O0EMMqAqCoydCqCdCjD2izVZao40qKhVUUu6hTbVQm08zrwmGI261UpfCsTkB5Xytu8vpeRMEatY4Wbqy6l1nLBqxZVvmlxXUJWaBw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:46 GMT
+                - Tue, 03 Mar 2026 17:31:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.149096666s
+        duration: 1.042934208s
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2189,24 +2195,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxmlw6aORx4kxX1d7
-        method: DELETE
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:31:08.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:48 GMT
+                - Tue, 03 Mar 2026 17:31:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.602944416s
+        status: 200 OK
+        code: 200
+        duration: 1.119383459s
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2214,29 +2223,39 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oavrc66menWC6NTZ1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/8fe60395-e563-4a68-89f8-c56959c7c938
-        method: DELETE
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrc66menWC6NTZ1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}},{"id":"prmvrc66mxz6U54tn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mxz6U54tn1d7"}}},{"id":"prmvrc66n8ndcpwqA1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66n8ndcpwqA1d7"}}},{"id":"prmvrc66nj8kiWC6j1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nj8kiWC6j1d7"}}},{"id":"prmvrc66nu8P9c6Ik1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66nu8P9c6Ik1d7"}}},{"id":"prmvrc66o5kaKg9Xg1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66o5kaKg9Xg1d7"}}},{"id":"prmvrc66ogzLQve1E1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66ogzLQve1E1d7"}}},{"id":"prmvrc66orVqoAs041d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66orVqoAs041d7"}}},{"id":"prmvrc66p3g8rbeOR1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66p3g8rbeOR1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:49 GMT
+                - Tue, 03 Mar 2026 17:31:20 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.217476834s
+        status: 200 OK
+        code: 200
+        duration: 1.125262041s
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2249,7 +2268,199 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"prmvrc66mm9rutFtn1d7","source":{"id":"0oavrc66menWC6NTZ1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavrc66menWC6NTZ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrc66menWC6NTZ1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvrc66mm9rutFtn1d7"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:31:21 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.127125959s
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:31:08.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:31:22 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.136666958s
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:31:08.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:31:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.032404875s
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrc66menWC6NTZ1d7","name":"testAcc_2166628549","status":"INACTIVE","created":"2026-03-03T17:30:21.000Z","lastUpdated":"2026-03-03T17:31:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sphjielisjbtjtktdroi","kid":"2a141d92-2508-4e32-ba42-f8d44177b874","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavrc66menWC6NTZ1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:31:25 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.089239041s
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavrc66menWC6NTZ1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Tue, 03 Mar 2026 17:31:26 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.58702975s
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/2a141d92-2508-4e32-ba42-f8d44177b874
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Tue, 03 Mar 2026 17:31:27 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.0619165s
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -2264,13 +2475,13 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:24:50 GMT
+                - Tue, 03 Mar 2026 17:31:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.122896042s
-    - id: 62
+        duration: 1.11291625s
+    - id: 68
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2282,7 +2493,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxmlw3f06HCBYg1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavrbyb7ktsOgyyn1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2294,9 +2505,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 17:24:52 GMT
+                - Tue, 03 Mar 2026 17:31:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.584395041s
+        duration: 1.590676917s

--- a/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpSaml_read/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccDataSourceOktaIdpSaml_read/oie-00.yaml
@@ -28,19 +28,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmh67nLPhxxbq1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_1:0oasxmh67nLPhxxbq1d7","name":"oie-00_testacc2166628549_1","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:21:05.000Z","created":"2025-12-21T17:21:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_1_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/alnsxn16hcPopCnAK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrc2k6vXVxRqyd1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_5:0oavrc2k6vXVxRqyd1d7","name":"oie-00_testacc2166628549_5","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:27:53.000Z","created":"2026-03-03T17:27:52.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_5_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_5_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/alnvrcbl0lmjEFuPK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:05 GMT
+                - Tue, 03 Mar 2026 17:27:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.487565834s
+        duration: 2.228111041s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,12 +67,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:06 GMT
+                - Tue, 03 Mar 2026 17:27:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079541458s
+        duration: 1.051301458s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
+        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttgu86y5cqPXYVT1d7","status":"ACTIVE","name":"Case-OKTA-1059814-1","priority":1,"system":false,"conditions":null,"created":"2026-01-05T13:32:57.000Z","lastUpdated":"2026-01-05T13:32:57.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnr1lke47WiZr71d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T03:07:20.000Z","lastUpdated":"2026-01-09T03:07:20.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:07 GMT
+                - Tue, 03 Mar 2026 17:27:55 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.160519625s
+        duration: 1.083225042s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies/rstnkw1sgxfqkDUtx1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies/rstnkw1sgxfqkDUtx1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -135,12 +135,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 17:21:09 GMT
+                - Tue, 03 Mar 2026 17:27:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.147759583s
+        duration: 1.11351575s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmh67nLPhxxbq1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_1:0oasxmh67nLPhxxbq1d7","name":"oie-00_testacc2166628549_1","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:21:05.000Z","created":"2025-12-21T17:21:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_1_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/alnsxn16hcPopCnAK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrc2k6vXVxRqyd1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_5:0oavrc2k6vXVxRqyd1d7","name":"oie-00_testacc2166628549_5","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:27:53.000Z","created":"2026-03-03T17:27:52.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_5_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_5_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/alnvrcbl0lmjEFuPK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:10 GMT
+                - Tue, 03 Mar 2026 17:27:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.088846292s
+        duration: 1.131735875s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,13 +183,13 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
+                - IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata?kid=DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata?kid=IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,23 +197,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmh67m3gss6dB1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrc2k6uYKXGhus1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3
-            MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3
+            Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV
-            9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL
-            0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h
-            jrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf
-            AAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX
-            5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+
-            XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu
-            qZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL
-            WdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE
-            +awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj
+            ByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg
+            XS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9
+            DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn
+            YXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy
+            4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo
+            XXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP
+            +I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso
+            WCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ
+            RrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -222,12 +222,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:21:11 GMT
+                - Tue, 03 Mar 2026 17:27:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.277352917s
+        duration: 1.250635458s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -248,19 +248,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:21:04.000Z","lastUpdated":"2025-12-21T17:21:04.000Z","expiresAt":"2035-12-21T17:21:04.000Z","kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2hjrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIfAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcuqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWLWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:27:52.000Z","lastUpdated":"2026-03-03T17:27:52.000Z","expiresAt":"2036-03-03T17:27:52.000Z","kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBjByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAgXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnnYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVoXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYsoWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:12 GMT
+                - Tue, 03 Mar 2026 17:28:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.243448208s
+        duration: 1.272137s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -269,7 +269,7 @@ interactions:
         content_length: 1337
         host: oie-00.dne-okta.com
         body: |
-            {"x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="]}
+            {"x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="]}
         headers:
             Accept:
                 - application/json
@@ -285,19 +285,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:21:13.000Z","lastUpdated":"2025-12-21T17:21:13.000Z","expiresAt":"2035-12-21T17:21:04.000Z","alg":"RSA","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:28:01.000Z","lastUpdated":"2026-03-03T17:28:01.000Z","expiresAt":"2036-03-03T17:27:52.000Z","alg":"RSA","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:13 GMT
+                - Tue, 03 Mar 2026 17:28:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.231177958s
+        duration: 1.087227208s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -310,7 +310,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/3a337626-b825-4866-9e53-1fafdc0db2c9
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a
         method: GET
       response:
         proto: HTTP/2.0
@@ -318,19 +318,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:21:13.000Z","lastUpdated":"2025-12-21T17:21:13.000Z","expiresAt":"2035-12-21T17:21:04.000Z","alg":"RSA","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:28:01.000Z","lastUpdated":"2026-03-03T17:28:01.000Z","expiresAt":"2036-03-03T17:27:52.000Z","alg":"RSA","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:14 GMT
+                - Tue, 03 Mar 2026 17:28:02 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.111083333s
+        duration: 1.074964167s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -339,7 +339,7 @@ interactions:
         content_length: 944
         host: oie-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
+            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
@@ -355,19 +355,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:03.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:17 GMT
+                - Tue, 03 Mar 2026 17:28:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.222498166s
+        duration: 1.970483625s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -380,7 +380,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -388,19 +388,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:03.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:18 GMT
+                - Tue, 03 Mar 2026 17:28:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.100329417s
+        duration: 1.077630333s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -412,13 +412,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmn38yl1PSyyz1d7
+                - 0oavrbxxuofmnwCOP1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -426,21 +426,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}},{"id":"prmsxmn39hV8Ii0tD1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39hV8Ii0tD1d7"}}},{"id":"prmsxmn39s4bEu4lx1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39s4bEu4lx1d7"}}},{"id":"prmsxmn3a3G6vJPb31d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3a3G6vJPb31d7"}}},{"id":"prmsxmn3aeu8Uc0dG1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3aeu8Uc0dG1d7"}}},{"id":"prmsxmn3apGiDukzn1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3apGiDukzn1d7"}}},{"id":"prmsxmn3b0tw5q9qr1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3b0tw5q9qr1d7"}}},{"id":"prmsxmn3bbuFJM1Hm1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3bbuFJM1Hm1d7"}}}]'
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:19 GMT
+                - Tue, 03 Mar 2026 17:28:06 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.187069125s
+        duration: 1.253029834s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -453,7 +453,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -461,19 +461,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}}'
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:20 GMT
+                - Tue, 03 Mar 2026 17:28:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081554042s
+        duration: 1.161039792s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -486,7 +486,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -494,19 +494,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmh67nLPhxxbq1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_1:0oasxmh67nLPhxxbq1d7","name":"oie-00_testacc2166628549_1","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:21:05.000Z","created":"2025-12-21T17:21:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_1_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/alnsxn16hcPopCnAK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrc2k6vXVxRqyd1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_5:0oavrc2k6vXVxRqyd1d7","name":"oie-00_testacc2166628549_5","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:27:53.000Z","created":"2026-03-03T17:27:52.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_5_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_5_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/alnvrcbl0lmjEFuPK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:21 GMT
+                - Tue, 03 Mar 2026 17:28:09 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.131703833s
+        duration: 1.184986416s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -516,13 +516,13 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
+                - IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata?kid=DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata?kid=IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,23 +530,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmh67m3gss6dB1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrc2k6uYKXGhus1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3
-            MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3
+            Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV
-            9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL
-            0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h
-            jrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf
-            AAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX
-            5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+
-            XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu
-            qZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL
-            WdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE
-            +awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj
+            ByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg
+            XS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9
+            DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn
+            YXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy
+            4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo
+            XXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP
+            +I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso
+            WCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ
+            RrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -555,12 +555,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:21:23 GMT
+                - Tue, 03 Mar 2026 17:28:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.232803083s
+        duration: 1.229070541s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -573,7 +573,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -581,19 +581,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:21:04.000Z","lastUpdated":"2025-12-21T17:21:04.000Z","expiresAt":"2035-12-21T17:21:04.000Z","kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2hjrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIfAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcuqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWLWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:27:52.000Z","lastUpdated":"2026-03-03T17:27:52.000Z","expiresAt":"2036-03-03T17:27:52.000Z","kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBjByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAgXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnnYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVoXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYsoWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:24 GMT
+                - Tue, 03 Mar 2026 17:28:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.246194041s
+        duration: 1.269454792s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -606,7 +606,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/3a337626-b825-4866-9e53-1fafdc0db2c9
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a
         method: GET
       response:
         proto: HTTP/2.0
@@ -614,19 +614,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:21:13.000Z","lastUpdated":"2025-12-21T17:21:13.000Z","expiresAt":"2035-12-21T17:21:04.000Z","alg":"RSA","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:28:01.000Z","lastUpdated":"2026-03-03T17:28:01.000Z","expiresAt":"2036-03-03T17:27:52.000Z","alg":"RSA","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:25 GMT
+                - Tue, 03 Mar 2026 17:28:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.073858959s
+        duration: 1.034461791s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -639,7 +639,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -647,19 +647,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:03.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:26 GMT
+                - Tue, 03 Mar 2026 17:28:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.166976792s
+        duration: 1.039961959s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -671,13 +671,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmn38yl1PSyyz1d7
+                - 0oavrbxxuofmnwCOP1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -685,21 +685,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}},{"id":"prmsxmn39hV8Ii0tD1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39hV8Ii0tD1d7"}}},{"id":"prmsxmn39s4bEu4lx1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39s4bEu4lx1d7"}}},{"id":"prmsxmn3a3G6vJPb31d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3a3G6vJPb31d7"}}},{"id":"prmsxmn3aeu8Uc0dG1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3aeu8Uc0dG1d7"}}},{"id":"prmsxmn3apGiDukzn1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3apGiDukzn1d7"}}},{"id":"prmsxmn3b0tw5q9qr1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3b0tw5q9qr1d7"}}},{"id":"prmsxmn3bbuFJM1Hm1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3bbuFJM1Hm1d7"}}}]'
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:27 GMT
+                - Tue, 03 Mar 2026 17:28:14 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.125366209s
+        duration: 1.086321125s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -712,7 +712,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -720,19 +720,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}}'
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:28 GMT
+                - Tue, 03 Mar 2026 17:28:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.191756542s
+        duration: 1.082299791s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -745,7 +745,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -753,19 +753,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmh67nLPhxxbq1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_1:0oasxmh67nLPhxxbq1d7","name":"oie-00_testacc2166628549_1","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:21:05.000Z","created":"2025-12-21T17:21:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_1_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/alnsxn16hcPopCnAK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrc2k6vXVxRqyd1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_5:0oavrc2k6vXVxRqyd1d7","name":"oie-00_testacc2166628549_5","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:27:53.000Z","created":"2026-03-03T17:27:52.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_5_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_5_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/alnvrcbl0lmjEFuPK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:30 GMT
+                - Tue, 03 Mar 2026 17:28:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.203624958s
+        duration: 1.106543292s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -775,13 +775,13 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
+                - IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata?kid=DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata?kid=IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,23 +789,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmh67m3gss6dB1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrc2k6uYKXGhus1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3
-            MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3
+            Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV
-            9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL
-            0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h
-            jrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf
-            AAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX
-            5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+
-            XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu
-            qZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL
-            WdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE
-            +awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj
+            ByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg
+            XS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9
+            DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn
+            YXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy
+            4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo
+            XXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP
+            +I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso
+            WCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ
+            RrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -814,12 +814,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:21:31 GMT
+                - Tue, 03 Mar 2026 17:28:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.098715s
+        duration: 1.312890375s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -832,7 +832,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -840,19 +840,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:21:04.000Z","lastUpdated":"2025-12-21T17:21:04.000Z","expiresAt":"2035-12-21T17:21:04.000Z","kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2hjrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIfAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcuqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWLWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:27:52.000Z","lastUpdated":"2026-03-03T17:27:52.000Z","expiresAt":"2036-03-03T17:27:52.000Z","kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBjByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAgXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnnYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVoXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYsoWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:32 GMT
+                - Tue, 03 Mar 2026 17:28:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.291261416s
+        duration: 1.318490333s
     - id: 23
       request:
         proto: HTTP/1.1
@@ -865,7 +865,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/3a337626-b825-4866-9e53-1fafdc0db2c9
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,19 +873,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:21:13.000Z","lastUpdated":"2025-12-21T17:21:13.000Z","expiresAt":"2035-12-21T17:21:04.000Z","alg":"RSA","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:28:01.000Z","lastUpdated":"2026-03-03T17:28:01.000Z","expiresAt":"2036-03-03T17:27:52.000Z","alg":"RSA","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:33 GMT
+                - Tue, 03 Mar 2026 17:28:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.172592375s
+        duration: 1.097592333s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -898,7 +898,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -906,19 +906,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:03.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:35 GMT
+                - Tue, 03 Mar 2026 17:28:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.104692458s
+        duration: 1.032343791s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -930,13 +930,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxmn38yl1PSyyz1d7
+                - 0oavrbxxuofmnwCOP1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -944,21 +944,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}},{"id":"prmsxmn39hV8Ii0tD1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39hV8Ii0tD1d7"}}},{"id":"prmsxmn39s4bEu4lx1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39s4bEu4lx1d7"}}},{"id":"prmsxmn3a3G6vJPb31d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3a3G6vJPb31d7"}}},{"id":"prmsxmn3aeu8Uc0dG1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3aeu8Uc0dG1d7"}}},{"id":"prmsxmn3apGiDukzn1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3apGiDukzn1d7"}}},{"id":"prmsxmn3b0tw5q9qr1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3b0tw5q9qr1d7"}}},{"id":"prmsxmn3bbuFJM1Hm1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3bbuFJM1Hm1d7"}}}]'
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:36 GMT
+                - Tue, 03 Mar 2026 17:28:23 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.173197417s
+        duration: 1.092796875s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -971,7 +971,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -979,61 +979,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}}'
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:37 GMT
+                - Tue, 03 Mar 2026 17:28:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.068615958s
+        duration: 1.054099917s
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 1041
         host: oie-00.dne-okta.com
-        form:
-            limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
+        body: |
+            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","issuer":"https://idp.example.com","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
-        method: GET
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:38 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - Tue, 03 Mar 2026 17:28:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.115957042s
+        duration: 1.34935825s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1041,19 +1036,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1061,21 +1049,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:39 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - Tue, 03 Mar 2026 17:28:26 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.106115709s
+        duration: 1.077025458s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1085,17 +1071,15 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
+                - "200"
+            sourceId:
+                - 0oavrbxxuofmnwCOP1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1103,21 +1087,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:40 GMT
+                - Tue, 03 Mar 2026 17:28:27 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071174541s
+        duration: 1.104469834s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1130,7 +1114,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1138,19 +1122,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmh67nLPhxxbq1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_1:0oasxmh67nLPhxxbq1d7","name":"oie-00_testacc2166628549_1","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:21:05.000Z","created":"2025-12-21T17:21:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_1_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/alnsxn16hcPopCnAK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:42 GMT
+                - Tue, 03 Mar 2026 17:28:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.14226175s
+        duration: 1.076839084s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1159,65 +1143,18 @@ interactions:
         content_length: 0
         host: oie-00.dne-okta.com
         form:
-            kid:
-                - DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
-        headers:
-            Accept:
-                - application/xml
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata?kid=DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2363
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmh67m3gss6dB1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3
-            MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
-            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
-            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV
-            9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL
-            0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h
-            jrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf
-            AAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX
-            5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+
-            XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu
-            qZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL
-            WdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE
-            +awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2363"
-            Content-Type:
-                - application/xml;charset=ISO-8859-1
-            Date:
-                - Sun, 21 Dec 2025 17:21:43 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.265839917s
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1225,19 +1162,63 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:21:04.000Z","lastUpdated":"2025-12-21T17:21:04.000Z","expiresAt":"2035-12-21T17:21:04.000Z","kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2hjrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIfAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcuqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWLWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}]'
+        body: '[{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:44 GMT
+                - Tue, 03 Mar 2026 17:28:30 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.769361208s
+        duration: 1.07318925s
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:28:31 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.040021125s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1250,7 +1231,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/3a337626-b825-4866-9e53-1fafdc0db2c9
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,19 +1239,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:21:13.000Z","lastUpdated":"2025-12-21T17:21:13.000Z","expiresAt":"2035-12-21T17:21:04.000Z","alg":"RSA","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}'
+        body: '{"id":"0oavrc2k6vXVxRqyd1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_5:0oavrc2k6vXVxRqyd1d7","name":"oie-00_testacc2166628549_5","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:27:53.000Z","created":"2026-03-03T17:27:52.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_5_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_5_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/alnvrcbl0lmjEFuPK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:46 GMT
+                - Tue, 03 Mar 2026 17:28:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.148604583s
+        duration: 1.089946042s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1278,32 +1259,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
+        form:
+            kid:
+                - IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata?kid=IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        content_length: 2363
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrc2k6uYKXGhus1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3
+            Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
+            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj
+            ByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg
+            XS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9
+            DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn
+            YXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy
+            4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo
+            XXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP
+            +I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso
+            WCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ
+            RrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2363"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:21:47 GMT
+                - Tue, 03 Mar 2026 17:28:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.069514708s
+        duration: 1.235248916s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1311,17 +1313,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            limit:
-                - "200"
-            sourceId:
-                - 0oasxmn38yl1PSyyz1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -1329,21 +1326,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}},{"id":"prmsxmn39hV8Ii0tD1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39hV8Ii0tD1d7"}}},{"id":"prmsxmn39s4bEu4lx1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39s4bEu4lx1d7"}}},{"id":"prmsxmn3a3G6vJPb31d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3a3G6vJPb31d7"}}},{"id":"prmsxmn3aeu8Uc0dG1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3aeu8Uc0dG1d7"}}},{"id":"prmsxmn3apGiDukzn1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3apGiDukzn1d7"}}},{"id":"prmsxmn3b0tw5q9qr1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3b0tw5q9qr1d7"}}},{"id":"prmsxmn3bbuFJM1Hm1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3bbuFJM1Hm1d7"}}}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:27:52.000Z","lastUpdated":"2026-03-03T17:27:52.000Z","expiresAt":"2036-03-03T17:27:52.000Z","kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBjByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAgXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnnYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVoXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYsoWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:48 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+                - Tue, 03 Mar 2026 17:28:34 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.089856209s
+        duration: 1.216908416s
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1356,7 +1351,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1364,19 +1359,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:28:01.000Z","lastUpdated":"2026-03-03T17:28:01.000Z","expiresAt":"2036-03-03T17:27:52.000Z","alg":"RSA","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:49 GMT
+                - Tue, 03 Mar 2026 17:28:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.108566917s
+        duration: 1.083813s
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1384,19 +1379,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1404,21 +1392,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:50 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - Tue, 03 Mar 2026 17:28:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.093462333s
+        duration: 1.080861959s
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1428,17 +1414,15 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             limit:
-                - "1"
-            q:
-                - testAcc_2166628549
-            type:
-                - SAML2
+                - "200"
+            sourceId:
+                - 0oavrbxxuofmnwCOP1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1446,21 +1430,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:52 GMT
+                - Tue, 03 Mar 2026 17:28:38 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.428211583s
+        duration: 1.095797958s
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1473,7 +1457,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1481,19 +1465,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmh67nLPhxxbq1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_1:0oasxmh67nLPhxxbq1d7","name":"oie-00_testacc2166628549_1","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:21:05.000Z","created":"2025-12-21T17:21:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_1_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/alnsxn16hcPopCnAK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:53 GMT
+                - Tue, 03 Mar 2026 17:28:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.118872833s
+        duration: 1.054631583s
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1502,65 +1486,18 @@ interactions:
         content_length: 0
         host: oie-00.dne-okta.com
         form:
-            kid:
-                - DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
-        headers:
-            Accept:
-                - application/xml
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata?kid=DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2363
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmh67m3gss6dB1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3
-            MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
-            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
-            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV
-            9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL
-            0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h
-            jrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf
-            AAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX
-            5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+
-            XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu
-            qZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL
-            WdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE
-            +awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2363"
-            Content-Type:
-                - application/xml;charset=ISO-8859-1
-            Date:
-                - Sun, 21 Dec 2025 17:21:54 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.2262855s
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
         method: GET
       response:
         proto: HTTP/2.0
@@ -1568,19 +1505,63 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:21:04.000Z","lastUpdated":"2025-12-21T17:21:04.000Z","expiresAt":"2035-12-21T17:21:04.000Z","kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2hjrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIfAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcuqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWLWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}]'
+        body: '[{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:55 GMT
+                - Tue, 03 Mar 2026 17:28:40 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.302249959s
+        duration: 1.0646745s
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "1"
+            q:
+                - testAcc_2166628549
+            type:
+                - SAML2
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps?limit=1&q=testAcc_2166628549&type=SAML2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:28:41 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/idps?limit=1>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.081962916s
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1593,7 +1574,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/3a337626-b825-4866-9e53-1fafdc0db2c9
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1601,19 +1582,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:21:13.000Z","lastUpdated":"2025-12-21T17:21:13.000Z","expiresAt":"2035-12-21T17:21:04.000Z","alg":"RSA","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}'
+        body: '{"id":"0oavrc2k6vXVxRqyd1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_5:0oavrc2k6vXVxRqyd1d7","name":"oie-00_testacc2166628549_5","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:27:53.000Z","created":"2026-03-03T17:27:52.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_5_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_5_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/alnvrcbl0lmjEFuPK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:57 GMT
+                - Tue, 03 Mar 2026 17:28:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.090583541s
+        duration: 1.075844334s
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1621,32 +1602,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
+        form:
+            kid:
+                - IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata?kid=IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        content_length: 2363
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrc2k6uYKXGhus1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3
+            Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
+            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj
+            ByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg
+            XS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9
+            DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn
+            YXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy
+            4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo
+            XXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP
+            +I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso
+            WCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ
+            RrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2363"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:21:58 GMT
+                - Tue, 03 Mar 2026 17:28:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.1058345s
+        duration: 1.20946225s
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1654,17 +1656,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            limit:
-                - "200"
-            sourceId:
-                - 0oasxmn38yl1PSyyz1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -1672,21 +1669,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}},{"id":"prmsxmn39hV8Ii0tD1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39hV8Ii0tD1d7"}}},{"id":"prmsxmn39s4bEu4lx1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39s4bEu4lx1d7"}}},{"id":"prmsxmn3a3G6vJPb31d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3a3G6vJPb31d7"}}},{"id":"prmsxmn3aeu8Uc0dG1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3aeu8Uc0dG1d7"}}},{"id":"prmsxmn3apGiDukzn1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3apGiDukzn1d7"}}},{"id":"prmsxmn3b0tw5q9qr1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3b0tw5q9qr1d7"}}},{"id":"prmsxmn3bbuFJM1Hm1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3bbuFJM1Hm1d7"}}}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:27:52.000Z","lastUpdated":"2026-03-03T17:27:52.000Z","expiresAt":"2036-03-03T17:27:52.000Z","kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBjByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAgXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnnYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVoXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYsoWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:21:59 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+                - Tue, 03 Mar 2026 17:28:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.270851959s
+        duration: 1.047313958s
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1699,7 +1694,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a
         method: GET
       response:
         proto: HTTP/2.0
@@ -1707,19 +1702,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:28:01.000Z","lastUpdated":"2026-03-03T17:28:01.000Z","expiresAt":"2036-03-03T17:27:52.000Z","alg":"RSA","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:00 GMT
+                - Tue, 03 Mar 2026 17:28:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.088000916s
+        duration: 1.041002375s
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1732,7 +1727,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1740,19 +1735,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:25.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:01 GMT
+                - Tue, 03 Mar 2026 17:28:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.221426166s
+        duration: 1.07380775s
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1760,12 +1755,17 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oavrbxxuofmnwCOP1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1773,19 +1773,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:02 GMT
+                - Tue, 03 Mar 2026 17:28:48 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.141268541s
+        duration: 1.079701542s
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1798,7 +1800,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1806,52 +1808,56 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:04 GMT
+                - Tue, 03 Mar 2026 17:28:49 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.169655584s
+        duration: 1.087481584s
     - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 1042
         host: oie-00.dne-okta.com
+        body: |
+            {"issuerMode":"ORG_URL","name":"testAcc_2166628549","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":false},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","issuer":"https://idp.example.com","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7
-        method: GET
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmh67nLPhxxbq1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_1:0oasxmh67nLPhxxbq1d7","name":"oie-00_testacc2166628549_1","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2025-12-21T17:21:05.000Z","created":"2025-12-21T17:21:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_1_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_1/0oasxmh67nLPhxxbq1d7/alnsxn16hcPopCnAK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T17:28:50.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:05 GMT
+                - Tue, 03 Mar 2026 17:28:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.077894417s
+        duration: 1.289620583s
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1859,66 +1865,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            kid:
-                - DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
-        headers:
-            Accept:
-                - application/xml
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/sso/saml/metadata?kid=DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2363
-        body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxmh67m3gss6dB1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
-            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
-            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3
-            MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
-            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
-            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV
-            9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL
-            0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h
-            jrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf
-            AAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX
-            5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+
-            XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu
-            qZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL
-            WdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE
-            +awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_1/exksxmh67m3gss6dB1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Length:
-                - "2363"
-            Content-Type:
-                - application/xml;charset=ISO-8859-1
-            Date:
-                - Sun, 21 Dec 2025 17:22:06 GMT
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 1.255007959s
-    - id: 51
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: oie-00.dne-okta.com
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1926,19 +1878,59 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T17:21:04.000Z","lastUpdated":"2025-12-21T17:21:04.000Z","expiresAt":"2035-12-21T17:21:04.000Z","kid":"DXXTLdD9MoTeJdTODv_N10PjTPB5GJl9N3Xs8IDizdE","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3MjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2hjrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIfAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+XCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcuqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWLWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}]'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:50.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:08 GMT
+                - Tue, 03 Mar 2026 17:28:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.354492708s
+        duration: 1.052032166s
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oavrbxxuofmnwCOP1d7
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:28:52 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.122306s
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1951,7 +1943,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/3a337626-b825-4866-9e53-1fafdc0db2c9
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1959,19 +1951,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T17:21:13.000Z","lastUpdated":"2025-12-21T17:21:13.000Z","expiresAt":"2035-12-21T17:21:04.000Z","alg":"RSA","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtB7dazMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE3MjAwNFoXDTM1MTIyMTE3\nMjEwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDADG7QmeQvDzP58n9gS7so8mCZBRWwA0rV\n9LEINxx3kGVqZbIJ+quxPWnzlPL8omAKTjhSArgUMeDSmh0BwYT9wapB0xedRnvHxXvz2CAttuxL\n0Gxalsb1w+cvqt1rs0HBcQiJ/V1GZbUoZDTkyvNOB4oeAc4LcaQnZr16UJdEDx/hdYKdyC7EIu2h\njrECK1ixlyFpvcxMOWsVHfXw2Bm/i6obP4VBydw9yCrUWlJ7hCWBLpOJIjTt2Wk5usIg+7UBJoIf\nAAFAZ9yUXXQbaweKxEDucZCp6MLX85tu/KgddpLfU/lZ+VrOYE4GbNaIriTHGWcX31OddkYWDTCX\n5bZRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE0gA87dXjzrqnrpHRSNH4sEoqnE7u4cKarb4Gc+\nXCXwn4iwGRu0j7AVGmQanRiwuTs1TBs6OsmPJZ2O7kHHbA4o6fSROWKhekTygLjITSMS/qItZUcu\nqZ05gHujFyRGx9iy0Sp9Q4eoHMPPEZ3cW+aXchNvrRjyl+w8By0j2H0CPfsKQ9fxR6uUQpPBfpWL\nWdW4JmPl7pL50IjcZAFFsqI8IF3Qk14EQBemOmWqK4hEsjbWkEAfzpNzKT1eWXwh4FQBZHjRfCQE\n+awUYloFlEPr5ZwgMGXIfbizPkW9wlBhzaU0gJTlnme1mztml5LkNS11f9MruT9MgiFbKTt9a2U="],"x5t#S256":"2TEM3yaIknGCPupXxcZK-70Qu1vl03kc03L2WwHBtZo","e":"AQAB","n":"wAxu0JnkLw8z-fJ_YEu7KPJgmQUVsANK1fSxCDccd5BlamWyCfqrsT1p85Ty_KJgCk44UgK4FDHg0podAcGE_cGqQdMXnUZ7x8V789ggLbbsS9BsWpbG9cPnL6rda7NBwXEIif1dRmW1KGQ05MrzTgeKHgHOC3GkJ2a9elCXRA8f4XWCncguxCLtoY6xAitYsZchab3MTDlrFR318NgZv4uqGz-FQcncPcgq1FpSe4QlgS6TiSI07dlpObrCIPu1ASaCHwABQGfclF10G2sHisRA7nGQqejC1_ObbvyoHXaS31P5WflazmBOBmzWiK4kxxlnF99TnXZGFg0wl-W2UQ"}'
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:09 GMT
+                - Tue, 03 Mar 2026 17:28:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.065417375s
+        duration: 1.082475417s
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1984,7 +1976,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1992,19 +1984,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:50.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:10 GMT
+                - Tue, 03 Mar 2026 17:28:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.102904959s
+        duration: 1.066622584s
     - id: 54
       request:
         proto: HTTP/1.1
@@ -2012,17 +2004,12 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
-        form:
-            limit:
-                - "200"
-            sourceId:
-                - 0oasxmn38yl1PSyyz1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2030,21 +2017,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}},{"id":"prmsxmn39hV8Ii0tD1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39hV8Ii0tD1d7"}}},{"id":"prmsxmn39s4bEu4lx1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn39s4bEu4lx1d7"}}},{"id":"prmsxmn3a3G6vJPb31d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3a3G6vJPb31d7"}}},{"id":"prmsxmn3aeu8Uc0dG1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3aeu8Uc0dG1d7"}}},{"id":"prmsxmn3apGiDukzn1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3apGiDukzn1d7"}}},{"id":"prmsxmn3b0tw5q9qr1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3b0tw5q9qr1d7"}}},{"id":"prmsxmn3bbuFJM1Hm1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn3bbuFJM1Hm1d7"}}}]'
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:50.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:11 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+                - Tue, 03 Mar 2026 17:28:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.167742291s
+        duration: 1.041993375s
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2057,7 +2042,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -2065,19 +2050,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxmn396jziKrut1d7","source":{"id":"0oasxmn38yl1PSyyz1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxmn38yl1PSyyz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxmn38yl1PSyyz1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxmn396jziKrut1d7"}}}'
+        body: '{"id":"0oavrc2k6vXVxRqyd1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc2166628549_5:0oavrc2k6vXVxRqyd1d7","name":"oie-00_testacc2166628549_5","label":"testAcc_2166628549","status":"ACTIVE","lastUpdated":"2026-03-03T17:27:53.000Z","created":"2026-03-03T17:27:52.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc2166628549_5_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc2166628549_5_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc2166628549_5/0oavrc2k6vXVxRqyd1d7/alnvrcbl0lmjEFuPK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:12 GMT
+                - Tue, 03 Mar 2026 17:28:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.198180292s
+        duration: 1.062745208s
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2085,32 +2070,53 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
+        form:
+            kid:
+                - IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         headers:
             Accept:
-                - application/json
+                - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/sso/saml/metadata?kid=IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        content_length: 2363
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvrc2k6uYKXGhus1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3
+            Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
+            ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj
+            ByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg
+            XS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9
+            DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn
+            YXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy
+            4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo
+            XXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP
+            +I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso
+            WCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ
+            RrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc2166628549_5/exkvrc2k6uYKXGhus1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2363"
             Content-Type:
-                - application/json
+                - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 17:22:13 GMT
+                - Tue, 03 Mar 2026 17:28:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.117105042s
+        duration: 1.239061833s
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2123,7 +2129,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -2131,19 +2137,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:21:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '[{"kty":"RSA","created":"2026-03-03T17:27:52.000Z","lastUpdated":"2026-03-03T17:27:52.000Z","expiresAt":"2036-03-03T17:27:52.000Z","kid":"IbHzT9ie0SjWL3LoTf-bBCeMAvnbXJO-Lh8rMcL91LU","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3Mjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBjByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAgXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9DGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnnYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVoXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYsoWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:15 GMT
+                - Tue, 03 Mar 2026 17:28:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.1148325s
+        duration: 1.220122334s
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2156,27 +2162,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/deactivate
-        method: POST
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxmn38yl1PSyyz1d7","name":"testAcc_2166628549","status":"INACTIVE","created":"2025-12-21T17:21:16.000Z","lastUpdated":"2025-12-21T17:22:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spujeufmodvqaxntkjmz","kid":"3a337626-b825-4866-9e53-1fafdc0db2c9","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxmn38yl1PSyyz1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
+        body: '{"kty":"RSA","created":"2026-03-03T17:28:01.000Z","lastUpdated":"2026-03-03T17:28:01.000Z","expiresAt":"2036-03-03T17:27:52.000Z","alg":"RSA","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0ve9vMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE3MjY1MloXDTM2MDMwMzE3\nMjc1MlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3AUpj6plEF5t+j8pQEEazVv06T/Rd7JBj\nByXBfLxKVe+f7F8k2Gzzwsrz/fyALaIQqwY8D83L5d1tf1FurShvao7/Nvj5yKHKAF1F4AzqmPAg\nXS4Y0LSHgr//oFwW7WfotmX4drB1EjnZI7fMQwNaHGZTOthtjO3qQXpa93d3pIaaXv8iaOVagAL9\nDGUHYsRbs7wVGIBTNNSHjztw02dS71AVLorkuaYhNKK/X1+4GmUlTXTOups92hasDpIalm7Q4hnn\nYXaj53pemHZhuOM0RSDHGk05XHZ/cQhI2c/C4A1KnNA8rWYsSR41DxadHYBK7ViQ0p8bhHaaardy\n4Y27AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFvD5l58kXEhwjALYTsgP1F9/KcD9k0ZxQbjWjVo\nXXT4XTOUUz3ymQ8TXb+llC9ZTxOtFdhFncbdADRdBt61wXA7B02L83rSUGvdSQ3e3oUbPyDrwNPP\n+I2k/kRFSoH7qgrhxQNRLfki3uYG5GZUBITtLA7DDHUEIkbMbgDH2jfx1Lj01SsuZlpZyvHznYso\nWCKfS7Rv9AGW3k3EXiNmWb2x2Kj6Wwy4KPwm5mT/BD5r48kL4Wt2vjV5f5XQY0K2ZerPMV1gz2gJ\nRrXu+/ABniW8lNHFFb5AyXoTDDzwLIQn6Pnl1m/nvavTqhvRmaOChY2OpRVhTgOn10Va0e/DS04="],"x5t#S256":"0ovtB_ZGIhSMTLo168hvU6LGvVedFWcxVV8BvxIMfKE","e":"AQAB","n":"twFKY-qZRBebfo_KUBBGs1b9Ok_0XeyQYwclwXy8SlXvn-xfJNhs88LK8_38gC2iEKsGPA_Ny-XdbX9Rbq0ob2qO_zb4-cihygBdReAM6pjwIF0uGNC0h4K__6BcFu1n6LZl-HawdRI52SO3zEMDWhxmUzrYbYzt6kF6Wvd3d6SGml7_ImjlWoAC_QxlB2LEW7O8FRiAUzTUh487cNNnUu9QFS6K5LmmITSiv19fuBplJU10zrqbPdoWrA6SGpZu0OIZ52F2o-d6Xph2YbjjNEUgxxpNOVx2f3EISNnPwuANSpzQPK1mLEkeNQ8WnR2ASu1YkNKfG4R2mmq3cuGNuw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:16 GMT
+                - Tue, 03 Mar 2026 17:29:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.116175334s
+        duration: 1.077074834s
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2189,24 +2195,27 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxmn38yl1PSyyz1d7
-        method: DELETE
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:50.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:17 GMT
+                - Tue, 03 Mar 2026 17:29:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.514399708s
+        status: 200 OK
+        code: 200
+        duration: 1.049865875s
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2214,29 +2223,39 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oavrbxxuofmnwCOP1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/3a337626-b825-4866-9e53-1fafdc0db2c9
-        method: DELETE
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavrbxxuofmnwCOP1d7
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}},{"id":"prmvrbxxv7cKgpj3V1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxv7cKgpj3V1d7"}}},{"id":"prmvrbxxviZlJRzNF1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxviZlJRzNF1d7"}}},{"id":"prmvrbxxvtCL6OXNk1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxvtCL6OXNk1d7"}}},{"id":"prmvrbxxw4gjra5bE1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxw4gjra5bE1d7"}}},{"id":"prmvrbxxwfk5epgML1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwfk5epgML1d7"}}},{"id":"prmvrbxxwqNGZ8DWy1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxwqNGZ8DWy1d7"}}},{"id":"prmvrbxxx1QbOPKq31d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxx1QbOPKq31d7"}}},{"id":"prmvrbxxxc8yCEihU1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxxc8yCEihU1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:18 GMT
+                - Tue, 03 Mar 2026 17:29:03 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
-        status: 204 No Content
-        code: 204
-        duration: 1.11630775s
+        status: 200 OK
+        code: 200
+        duration: 1.093060125s
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2249,7 +2268,199 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"prmvrbxxuwcheSg2s1d7","source":{"id":"0oavrbxxuofmnwCOP1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavrbxxuofmnwCOP1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavrbxxuofmnwCOP1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvrbxxuwcheSg2s1d7"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:29:04 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.0818635s
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:50.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:29:05 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.046289667s
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"ACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:28:50.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:29:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.039541041s
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oavrbxxuofmnwCOP1d7","name":"testAcc_2166628549","status":"INACTIVE","created":"2026-03-03T17:28:03.000Z","lastUpdated":"2026-03-03T17:29:07.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spcrwshddzkkagpcutpy","kid":"6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavrbxxuofmnwCOP1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 03 Mar 2026 17:29:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.116295459s
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavrbxxuofmnwCOP1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Tue, 03 Mar 2026 17:29:09 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.767267459s
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/6718fcf2-81f3-4c6f-9fc1-01b05dc5ad9a
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Tue, 03 Mar 2026 17:29:10 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.0533305s
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -2264,13 +2475,13 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 17:22:20 GMT
+                - Tue, 03 Mar 2026 17:29:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.12749325s
-    - id: 62
+        duration: 1.086031541s
+    - id: 68
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2282,7 +2493,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxmh67nLPhxxbq1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavrc2k6vXVxRqyd1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2294,9 +2505,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 17:22:21 GMT
+                - Tue, 03 Mar 2026 17:29:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.503530084s
+        duration: 1.7623535s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaIdpOidc_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaIdpOidc_crud/classic-00.yaml
@@ -6,10 +6,10 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1014
+        content_length: 1033
         host: classic-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"abc","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
+            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"abc","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
         headers:
             Accept:
                 - application/json
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:35:01.000Z","lastUpdated":"2025-12-21T14:35:01.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:47:42.000Z","lastUpdated":"2026-03-03T16:47:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:02 GMT
+                - Tue, 03 Mar 2026 16:47:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.350058417s
+        duration: 2.627672833s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:35:01.000Z","lastUpdated":"2025-12-21T14:35:01.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:47:42.000Z","lastUpdated":"2026-03-03T16:47:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:03 GMT
+                - Tue, 03 Mar 2026 16:47:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.241730208s
+        duration: 1.2939375s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -82,13 +82,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxicji7xCQZK4k1d7
+                - 0oavra6hdpViZQUhd1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}},{"id":"prmsxicjiySK63bag1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiySK63bag1d7"}}},{"id":"prmsxicjjipVSRDrP1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjjipVSRDrP1d7"}}},{"id":"prmsxicjk2qy5ZfTS1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjk2qy5ZfTS1d7"}}},{"id":"prmsxicjkmO4HIGIs1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjkmO4HIGIs1d7"}}},{"id":"prmsxicjl6OJLh8x21d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjl6OJLh8x21d7"}}},{"id":"prmsxicjlqo6K8eFQ1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjlqo6K8eFQ1d7"}}},{"id":"prmsxicjmaJVhqsYp1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjmaJVhqsYp1d7"}}}]'
+        body: '[{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}},{"id":"prmvra6hegbbkyKzY1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hegbbkyKzY1d7"}}},{"id":"prmvra6hf0GH7oE7k1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hf0GH7oE7k1d7"}}},{"id":"prmvra6hfkzz0CY1i1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hfkzz0CY1i1d7"}}},{"id":"prmvra6hg4g5cliwT1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hg4g5cliwT1d7"}}},{"id":"prmvra6hgoAAaH1h81d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hgoAAaH1h81d7"}}},{"id":"prmvra6hh8hMzEbRz1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hh8hMzEbRz1d7"}}},{"id":"prmvra6hhsz0iN6uj1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hhsz0iN6uj1d7"}}},{"id":"prmvra6hicje13RHq1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hicje13RHq1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:04 GMT
+                - Tue, 03 Mar 2026 16:47:45 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.226246292s
+        duration: 1.118485917s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,19 +131,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}}'
+        body: '{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:06 GMT
+                - Tue, 03 Mar 2026 16:47:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.223870583s
+        duration: 1.199792917s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -156,7 +156,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -164,19 +164,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:35:01.000Z","lastUpdated":"2025-12-21T14:35:01.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:47:42.000Z","lastUpdated":"2026-03-03T16:47:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:07 GMT
+                - Tue, 03 Mar 2026 16:47:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.258567833s
+        duration: 1.366987959s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -188,13 +188,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxicji7xCQZK4k1d7
+                - 0oavra6hdpViZQUhd1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -202,21 +202,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}},{"id":"prmsxicjiySK63bag1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiySK63bag1d7"}}},{"id":"prmsxicjjipVSRDrP1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjjipVSRDrP1d7"}}},{"id":"prmsxicjk2qy5ZfTS1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjk2qy5ZfTS1d7"}}},{"id":"prmsxicjkmO4HIGIs1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjkmO4HIGIs1d7"}}},{"id":"prmsxicjl6OJLh8x21d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjl6OJLh8x21d7"}}},{"id":"prmsxicjlqo6K8eFQ1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjlqo6K8eFQ1d7"}}},{"id":"prmsxicjmaJVhqsYp1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjmaJVhqsYp1d7"}}}]'
+        body: '[{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}},{"id":"prmvra6hegbbkyKzY1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hegbbkyKzY1d7"}}},{"id":"prmvra6hf0GH7oE7k1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hf0GH7oE7k1d7"}}},{"id":"prmvra6hfkzz0CY1i1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hfkzz0CY1i1d7"}}},{"id":"prmvra6hg4g5cliwT1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hg4g5cliwT1d7"}}},{"id":"prmvra6hgoAAaH1h81d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hgoAAaH1h81d7"}}},{"id":"prmvra6hh8hMzEbRz1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hh8hMzEbRz1d7"}}},{"id":"prmvra6hhsz0iN6uj1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hhsz0iN6uj1d7"}}},{"id":"prmvra6hicje13RHq1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hicje13RHq1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:08 GMT
+                - Tue, 03 Mar 2026 16:47:49 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.114352625s
+        duration: 1.273807084s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -237,19 +237,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}}'
+        body: '{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:09 GMT
+                - Tue, 03 Mar 2026 16:47:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.221185167s
+        duration: 1.181375667s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -262,7 +262,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -270,19 +270,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:35:01.000Z","lastUpdated":"2025-12-21T14:35:01.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:47:42.000Z","lastUpdated":"2026-03-03T16:47:42.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:11 GMT
+                - Tue, 03 Mar 2026 16:47:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.326412708s
+        duration: 1.246076333s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -294,13 +294,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxicji7xCQZK4k1d7
+                - 0oavra6hdpViZQUhd1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -308,21 +308,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}},{"id":"prmsxicjiySK63bag1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiySK63bag1d7"}}},{"id":"prmsxicjjipVSRDrP1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjjipVSRDrP1d7"}}},{"id":"prmsxicjk2qy5ZfTS1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjk2qy5ZfTS1d7"}}},{"id":"prmsxicjkmO4HIGIs1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjkmO4HIGIs1d7"}}},{"id":"prmsxicjl6OJLh8x21d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjl6OJLh8x21d7"}}},{"id":"prmsxicjlqo6K8eFQ1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjlqo6K8eFQ1d7"}}},{"id":"prmsxicjmaJVhqsYp1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjmaJVhqsYp1d7"}}}]'
+        body: '[{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}},{"id":"prmvra6hegbbkyKzY1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hegbbkyKzY1d7"}}},{"id":"prmvra6hf0GH7oE7k1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hf0GH7oE7k1d7"}}},{"id":"prmvra6hfkzz0CY1i1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hfkzz0CY1i1d7"}}},{"id":"prmvra6hg4g5cliwT1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hg4g5cliwT1d7"}}},{"id":"prmvra6hgoAAaH1h81d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hgoAAaH1h81d7"}}},{"id":"prmvra6hh8hMzEbRz1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hh8hMzEbRz1d7"}}},{"id":"prmvra6hhsz0iN6uj1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hhsz0iN6uj1d7"}}},{"id":"prmvra6hicje13RHq1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hicje13RHq1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:12 GMT
+                - Tue, 03 Mar 2026 16:47:53 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.144941084s
+        duration: 1.132412666s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -335,7 +335,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -343,28 +343,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}}'
+        body: '{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:13 GMT
+                - Tue, 03 Mar 2026 16:47:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.159591042s
+        duration: 1.171614625s
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1018
+        content_length: 1038
         host: classic-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"xyz","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize2"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys2"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token2"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo2"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
+            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"xyz","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":false},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize2"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys2"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token2"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo2"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
         headers:
             Accept:
                 - application/json
@@ -372,7 +372,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -380,19 +380,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":null,"lastUpdated":"2025-12-21T14:35:15.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T16:47:56.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:15 GMT
+                - Tue, 03 Mar 2026 16:47:56 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.413616625s
+        duration: 1.237797959s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -405,7 +405,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -413,19 +413,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:35:01.000Z","lastUpdated":"2025-12-21T14:35:15.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:47:42.000Z","lastUpdated":"2026-03-03T16:47:56.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:16 GMT
+                - Tue, 03 Mar 2026 16:47:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.264393833s
+        duration: 1.248609083s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -437,13 +437,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxicji7xCQZK4k1d7
+                - 0oavra6hdpViZQUhd1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -451,21 +451,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}},{"id":"prmsxicjiySK63bag1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiySK63bag1d7"}}},{"id":"prmsxicjjipVSRDrP1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjjipVSRDrP1d7"}}},{"id":"prmsxicjk2qy5ZfTS1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjk2qy5ZfTS1d7"}}},{"id":"prmsxicjkmO4HIGIs1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjkmO4HIGIs1d7"}}},{"id":"prmsxicjl6OJLh8x21d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjl6OJLh8x21d7"}}},{"id":"prmsxicjlqo6K8eFQ1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjlqo6K8eFQ1d7"}}},{"id":"prmsxicjmaJVhqsYp1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjmaJVhqsYp1d7"}}}]'
+        body: '[{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}},{"id":"prmvra6hegbbkyKzY1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hegbbkyKzY1d7"}}},{"id":"prmvra6hf0GH7oE7k1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hf0GH7oE7k1d7"}}},{"id":"prmvra6hfkzz0CY1i1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hfkzz0CY1i1d7"}}},{"id":"prmvra6hg4g5cliwT1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hg4g5cliwT1d7"}}},{"id":"prmvra6hgoAAaH1h81d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hgoAAaH1h81d7"}}},{"id":"prmvra6hh8hMzEbRz1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hh8hMzEbRz1d7"}}},{"id":"prmvra6hhsz0iN6uj1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hhsz0iN6uj1d7"}}},{"id":"prmvra6hicje13RHq1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hicje13RHq1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:17 GMT
+                - Tue, 03 Mar 2026 16:47:58 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.122809542s
+        duration: 1.10482025s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -486,19 +486,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}}'
+        body: '{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:18 GMT
+                - Tue, 03 Mar 2026 16:47:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.224447542s
+        duration: 1.163058042s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,19 +519,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:35:01.000Z","lastUpdated":"2025-12-21T14:35:15.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:47:42.000Z","lastUpdated":"2026-03-03T16:47:56.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:20 GMT
+                - Tue, 03 Mar 2026 16:48:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.230327958s
+        duration: 1.273016375s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -543,13 +543,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxicji7xCQZK4k1d7
+                - 0oavra6hdpViZQUhd1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra6hdpViZQUhd1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -557,21 +557,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}},{"id":"prmsxicjiySK63bag1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiySK63bag1d7"}}},{"id":"prmsxicjjipVSRDrP1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjjipVSRDrP1d7"}}},{"id":"prmsxicjk2qy5ZfTS1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjk2qy5ZfTS1d7"}}},{"id":"prmsxicjkmO4HIGIs1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjkmO4HIGIs1d7"}}},{"id":"prmsxicjl6OJLh8x21d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjl6OJLh8x21d7"}}},{"id":"prmsxicjlqo6K8eFQ1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjlqo6K8eFQ1d7"}}},{"id":"prmsxicjmaJVhqsYp1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjmaJVhqsYp1d7"}}}]'
+        body: '[{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}},{"id":"prmvra6hegbbkyKzY1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hegbbkyKzY1d7"}}},{"id":"prmvra6hf0GH7oE7k1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hf0GH7oE7k1d7"}}},{"id":"prmvra6hfkzz0CY1i1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hfkzz0CY1i1d7"}}},{"id":"prmvra6hg4g5cliwT1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hg4g5cliwT1d7"}}},{"id":"prmvra6hgoAAaH1h81d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hgoAAaH1h81d7"}}},{"id":"prmvra6hh8hMzEbRz1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hh8hMzEbRz1d7"}}},{"id":"prmvra6hhsz0iN6uj1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hhsz0iN6uj1d7"}}},{"id":"prmvra6hicje13RHq1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hicje13RHq1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:21 GMT
+                - Tue, 03 Mar 2026 16:48:02 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.132223667s
+        duration: 1.110055875s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -584,7 +584,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -592,19 +592,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxicjiex9I94YV1d7","source":{"id":"0oasxicji7xCQZK4k1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxicji7xCQZK4k1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxicji7xCQZK4k1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxicjiex9I94YV1d7"}}}'
+        body: '{"id":"prmvra6hdwZPSRwMH1d7","source":{"id":"0oavra6hdpViZQUhd1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra6hdpViZQUhd1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra6hdpViZQUhd1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra6hdwZPSRwMH1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:22 GMT
+                - Tue, 03 Mar 2026 16:48:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.087707875s
+        duration: 1.384947916s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -617,7 +617,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,19 +625,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxicji7xCQZK4k1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"INACTIVE","created":"2025-12-21T14:35:01.000Z","lastUpdated":"2025-12-21T14:35:23.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxicji7xCQZK4k1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra6hdpViZQUhd1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"INACTIVE","created":"2026-03-03T16:47:42.000Z","lastUpdated":"2026-03-03T16:48:05.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize?idp=0oavra6hdpViZQUhd1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://classic-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:35:23 GMT
+                - Tue, 03 Mar 2026 16:48:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.29018625s
+        duration: 1.313435167s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -650,7 +650,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxicji7xCQZK4k1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra6hdpViZQUhd1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -662,9 +662,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:35:25 GMT
+                - Tue, 03 Mar 2026 16:48:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.968787625s
+        duration: 1.901741375s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaIdpOidc_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaIdpOidc_crud/oie-00.yaml
@@ -6,10 +6,10 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1014
+        content_length: 1033
         host: oie-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"abc","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
+            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"abc","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
         headers:
             Accept:
                 - application/json
@@ -25,19 +25,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:33:17.000Z","lastUpdated":"2025-12-21T14:33:17.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:41:58.000Z","lastUpdated":"2026-03-03T16:41:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:18 GMT
+                - Tue, 03 Mar 2026 16:42:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.782283542s
+        duration: 3.03592375s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -50,7 +50,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -58,19 +58,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:33:17.000Z","lastUpdated":"2025-12-21T14:33:17.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:41:58.000Z","lastUpdated":"2026-03-03T16:41:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:20 GMT
+                - Tue, 03 Mar 2026 16:42:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.277765625s
+        duration: 1.26064575s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -82,13 +82,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxi4wthvw5hpN51d7
+                - 0oavr9xzt8Bl4qZFe1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}},{"id":"prmsxi4wu8SRZDeKL1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wu8SRZDeKL1d7"}}},{"id":"prmsxi4wusfvZsKzy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wusfvZsKzy1d7"}}},{"id":"prmsxi4wvco1eLKxy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvco1eLKxy1d7"}}},{"id":"prmsxi4wvwUmqi2Fl1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvwUmqi2Fl1d7"}}},{"id":"prmsxi4wwgZonPjtA1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wwgZonPjtA1d7"}}},{"id":"prmsxi4wx05gUsHCd1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wx05gUsHCd1d7"}}},{"id":"prmsxi4wxkLrkIBRr1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wxkLrkIBRr1d7"}}}]'
+        body: '[{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}},{"id":"prmvr9xzu1PO2ooKV1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzu1PO2ooKV1d7"}}},{"id":"prmvr9xzul1niV2xW1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzul1niV2xW1d7"}}},{"id":"prmvr9xzv50p60I631d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzv50p60I631d7"}}},{"id":"prmvr9xzvpDYg1voN1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzvpDYg1voN1d7"}}},{"id":"prmvr9xzw99TUVEhy1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzw99TUVEhy1d7"}}},{"id":"prmvr9xzwtQ13bAYt1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzwtQ13bAYt1d7"}}},{"id":"prmvr9xzxdW031yHX1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxdW031yHX1d7"}}},{"id":"prmvr9xzxxaWHXFQb1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxxaWHXFQb1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:21 GMT
+                - Tue, 03 Mar 2026 16:42:02 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.152922042s
+        duration: 1.177559458s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -131,19 +131,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}}'
+        body: '{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:22 GMT
+                - Tue, 03 Mar 2026 16:42:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.086303334s
+        duration: 1.081793833s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -156,7 +156,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -164,19 +164,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:33:17.000Z","lastUpdated":"2025-12-21T14:33:17.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:41:58.000Z","lastUpdated":"2026-03-03T16:41:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:24 GMT
+                - Tue, 03 Mar 2026 16:42:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.349428959s
+        duration: 1.228247083s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -188,13 +188,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxi4wthvw5hpN51d7
+                - 0oavr9xzt8Bl4qZFe1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -202,21 +202,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}},{"id":"prmsxi4wu8SRZDeKL1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wu8SRZDeKL1d7"}}},{"id":"prmsxi4wusfvZsKzy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wusfvZsKzy1d7"}}},{"id":"prmsxi4wvco1eLKxy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvco1eLKxy1d7"}}},{"id":"prmsxi4wvwUmqi2Fl1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvwUmqi2Fl1d7"}}},{"id":"prmsxi4wwgZonPjtA1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wwgZonPjtA1d7"}}},{"id":"prmsxi4wx05gUsHCd1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wx05gUsHCd1d7"}}},{"id":"prmsxi4wxkLrkIBRr1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wxkLrkIBRr1d7"}}}]'
+        body: '[{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}},{"id":"prmvr9xzu1PO2ooKV1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzu1PO2ooKV1d7"}}},{"id":"prmvr9xzul1niV2xW1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzul1niV2xW1d7"}}},{"id":"prmvr9xzv50p60I631d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzv50p60I631d7"}}},{"id":"prmvr9xzvpDYg1voN1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzvpDYg1voN1d7"}}},{"id":"prmvr9xzw99TUVEhy1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzw99TUVEhy1d7"}}},{"id":"prmvr9xzwtQ13bAYt1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzwtQ13bAYt1d7"}}},{"id":"prmvr9xzxdW031yHX1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxdW031yHX1d7"}}},{"id":"prmvr9xzxxaWHXFQb1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxxaWHXFQb1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:25 GMT
+                - Tue, 03 Mar 2026 16:42:06 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.218773s
+        duration: 1.115760459s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -229,7 +229,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -237,19 +237,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}}'
+        body: '{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:26 GMT
+                - Tue, 03 Mar 2026 16:42:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.18980325s
+        duration: 1.052818792s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -262,7 +262,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -270,19 +270,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:33:17.000Z","lastUpdated":"2025-12-21T14:33:17.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:41:58.000Z","lastUpdated":"2026-03-03T16:41:58.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"abc","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:27 GMT
+                - Tue, 03 Mar 2026 16:42:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.161785167s
+        duration: 1.217157709s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -294,13 +294,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxi4wthvw5hpN51d7
+                - 0oavr9xzt8Bl4qZFe1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -308,21 +308,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}},{"id":"prmsxi4wu8SRZDeKL1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wu8SRZDeKL1d7"}}},{"id":"prmsxi4wusfvZsKzy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wusfvZsKzy1d7"}}},{"id":"prmsxi4wvco1eLKxy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvco1eLKxy1d7"}}},{"id":"prmsxi4wvwUmqi2Fl1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvwUmqi2Fl1d7"}}},{"id":"prmsxi4wwgZonPjtA1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wwgZonPjtA1d7"}}},{"id":"prmsxi4wx05gUsHCd1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wx05gUsHCd1d7"}}},{"id":"prmsxi4wxkLrkIBRr1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wxkLrkIBRr1d7"}}}]'
+        body: '[{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}},{"id":"prmvr9xzu1PO2ooKV1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzu1PO2ooKV1d7"}}},{"id":"prmvr9xzul1niV2xW1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzul1niV2xW1d7"}}},{"id":"prmvr9xzv50p60I631d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzv50p60I631d7"}}},{"id":"prmvr9xzvpDYg1voN1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzvpDYg1voN1d7"}}},{"id":"prmvr9xzw99TUVEhy1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzw99TUVEhy1d7"}}},{"id":"prmvr9xzwtQ13bAYt1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzwtQ13bAYt1d7"}}},{"id":"prmvr9xzxdW031yHX1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxdW031yHX1d7"}}},{"id":"prmvr9xzxxaWHXFQb1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxxaWHXFQb1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:28 GMT
+                - Tue, 03 Mar 2026 16:42:09 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.136438667s
+        duration: 1.154659458s
     - id: 9
       request:
         proto: HTTP/1.1
@@ -335,7 +335,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -343,28 +343,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}}'
+        body: '{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:30 GMT
+                - Tue, 03 Mar 2026 16:42:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.243637583s
+        duration: 1.068135458s
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1018
+        content_length: 1038
         host: oie-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"xyz","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize2"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys2"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token2"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo2"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
+            {"issuerMode":"ORG_URL","name":"testAcc_1189342380","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"filter":"xyz","matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":false},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","pkce_required":null}},"endpoints":{"authorization":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/authorize2"},"jwks":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/keys2"},"token":{"binding":"HTTP-POST","url":"https://idp.example.com/token2"},"userInfo":{"binding":"HTTP-REDIRECT","url":"https://idp.example.com/userinfo2"}},"issuer":{"url":"https://id.example.com"},"scopes":["openid"],"type":"OIDC"},"status":"ACTIVE","type":"OIDC"}
         headers:
             Accept:
                 - application/json
@@ -372,7 +372,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -380,19 +380,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":null,"lastUpdated":"2025-12-21T14:33:31.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T16:42:12.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:31 GMT
+                - Tue, 03 Mar 2026 16:42:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.372110208s
+        duration: 1.412620167s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -405,7 +405,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -413,19 +413,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:33:17.000Z","lastUpdated":"2025-12-21T14:33:31.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:41:58.000Z","lastUpdated":"2026-03-03T16:42:12.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:33 GMT
+                - Tue, 03 Mar 2026 16:42:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.35483275s
+        duration: 1.265851916s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -437,13 +437,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxi4wthvw5hpN51d7
+                - 0oavr9xzt8Bl4qZFe1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -451,21 +451,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}},{"id":"prmsxi4wu8SRZDeKL1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wu8SRZDeKL1d7"}}},{"id":"prmsxi4wusfvZsKzy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wusfvZsKzy1d7"}}},{"id":"prmsxi4wvco1eLKxy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvco1eLKxy1d7"}}},{"id":"prmsxi4wvwUmqi2Fl1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvwUmqi2Fl1d7"}}},{"id":"prmsxi4wwgZonPjtA1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wwgZonPjtA1d7"}}},{"id":"prmsxi4wx05gUsHCd1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wx05gUsHCd1d7"}}},{"id":"prmsxi4wxkLrkIBRr1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wxkLrkIBRr1d7"}}}]'
+        body: '[{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}},{"id":"prmvr9xzu1PO2ooKV1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzu1PO2ooKV1d7"}}},{"id":"prmvr9xzul1niV2xW1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzul1niV2xW1d7"}}},{"id":"prmvr9xzv50p60I631d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzv50p60I631d7"}}},{"id":"prmvr9xzvpDYg1voN1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzvpDYg1voN1d7"}}},{"id":"prmvr9xzw99TUVEhy1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzw99TUVEhy1d7"}}},{"id":"prmvr9xzwtQ13bAYt1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzwtQ13bAYt1d7"}}},{"id":"prmvr9xzxdW031yHX1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxdW031yHX1d7"}}},{"id":"prmvr9xzxxaWHXFQb1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxxaWHXFQb1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:34 GMT
+                - Tue, 03 Mar 2026 16:42:14 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.160854917s
+        duration: 1.094175708s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -486,19 +486,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}}'
+        body: '{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:35 GMT
+                - Tue, 03 Mar 2026 16:42:16 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.236843125s
+        duration: 1.158699791s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -511,7 +511,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -519,19 +519,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2025-12-21T14:33:17.000Z","lastUpdated":"2025-12-21T14:33:31.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"ACTIVE","created":"2026-03-03T16:41:58.000Z","lastUpdated":"2026-03-03T16:42:12.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:36 GMT
+                - Tue, 03 Mar 2026 16:42:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.071746292s
+        duration: 1.252653041s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -543,13 +543,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxi4wthvw5hpN51d7
+                - 0oavr9xzt8Bl4qZFe1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavr9xzt8Bl4qZFe1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -557,21 +557,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}},{"id":"prmsxi4wu8SRZDeKL1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wu8SRZDeKL1d7"}}},{"id":"prmsxi4wusfvZsKzy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wusfvZsKzy1d7"}}},{"id":"prmsxi4wvco1eLKxy1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvco1eLKxy1d7"}}},{"id":"prmsxi4wvwUmqi2Fl1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wvwUmqi2Fl1d7"}}},{"id":"prmsxi4wwgZonPjtA1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wwgZonPjtA1d7"}}},{"id":"prmsxi4wx05gUsHCd1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wx05gUsHCd1d7"}}},{"id":"prmsxi4wxkLrkIBRr1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wxkLrkIBRr1d7"}}}]'
+        body: '[{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}},{"id":"prmvr9xzu1PO2ooKV1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzu1PO2ooKV1d7"}}},{"id":"prmvr9xzul1niV2xW1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzul1niV2xW1d7"}}},{"id":"prmvr9xzv50p60I631d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzv50p60I631d7"}}},{"id":"prmvr9xzvpDYg1voN1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzvpDYg1voN1d7"}}},{"id":"prmvr9xzw99TUVEhy1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzw99TUVEhy1d7"}}},{"id":"prmvr9xzwtQ13bAYt1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzwtQ13bAYt1d7"}}},{"id":"prmvr9xzxdW031yHX1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxdW031yHX1d7"}}},{"id":"prmvr9xzxxaWHXFQb1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzxxaWHXFQb1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:37 GMT
+                - Tue, 03 Mar 2026 16:42:18 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.2175955s
+        duration: 1.109543333s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -584,7 +584,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -592,19 +592,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxi4wtoggUPrhW1d7","source":{"id":"0oasxi4wthvw5hpN51d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxi4wthvw5hpN51d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxi4wthvw5hpN51d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxi4wtoggUPrhW1d7"}}}'
+        body: '{"id":"prmvr9xzthCvPZsfE1d7","source":{"id":"0oavr9xzt8Bl4qZFe1d7","name":"oidc_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavr9xzt8Bl4qZFe1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavr9xzt8Bl4qZFe1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"login":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"displayName":{"expression":"appuser.displayName","pushStatus":"DONT_PUSH"},"nickName":{"expression":"appuser.nickname","pushStatus":"DONT_PUSH"},"firstName":{"expression":"appuser.firstName","pushStatus":"DONT_PUSH"},"middleName":{"expression":"appuser.middleName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"appuser.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"appuser.email","pushStatus":"DONT_PUSH"},"profileUrl":{"expression":"appuser.profile","pushStatus":"DONT_PUSH"},"timezone":{"expression":"appuser.zoneinfo == null ? \"America/Los_Angeles\" : appuser.zoneinfo","pushStatus":"DONT_PUSH"},"primaryPhone":{"expression":"appuser.phoneNumber","pushStatus":"DONT_PUSH"},"streetAddress":{"expression":"appuser.street_address","pushStatus":"DONT_PUSH"},"city":{"expression":"appuser.locality","pushStatus":"DONT_PUSH"},"state":{"expression":"appuser.region","pushStatus":"DONT_PUSH"},"zipCode":{"expression":"appuser.postalCode","pushStatus":"DONT_PUSH"},"countryCode":{"expression":"appuser.country","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvr9xzthCvPZsfE1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:39 GMT
+                - Tue, 03 Mar 2026 16:42:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.196122208s
+        duration: 1.151397083s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -617,7 +617,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,19 +625,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi4wthvw5hpN51d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"INACTIVE","created":"2025-12-21T14:33:17.000Z","lastUpdated":"2025-12-21T14:33:40.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oasxi4wthvw5hpN51d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavr9xzt8Bl4qZFe1d7","issuerMode":"ORG_URL","name":"testAcc_1189342380","status":"INACTIVE","created":"2026-03-03T16:41:58.000Z","lastUpdated":"2026-03-03T16:42:21.000Z","protocol":{"type":"OIDC","endpoints":{"authorization":{"url":"https://idp.example.com/authorize2","binding":"HTTP-REDIRECT"},"token":{"url":"https://idp.example.com/token2","binding":"HTTP-POST"},"userInfo":{"url":"https://idp.example.com/userinfo2","binding":"HTTP-REDIRECT"},"jwks":{"url":"https://idp.example.com/keys2","binding":"HTTP-REDIRECT"}},"algorithms":{"request":{"signature":{"algorithm":"HS256","scope":"REQUEST"}}},"settings":{"nameFormat":null},"scopes":["openid"],"issuer":{"url":"https://id.example.com"},"credentials":{"client":{"client_id":"efg456","client_secret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":"xyz","matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"OIDC","_links":{"authorize":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize?idp=0oavr9xzt8Bl4qZFe1d7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}&nonce={nonce}","templated":true,"hints":{"allow":["GET"]}},"clientRedirectUri":{"href":"https://oie-00.dne-okta.com/oauth2/v1/authorize/callback","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:33:40 GMT
+                - Tue, 03 Mar 2026 16:42:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.35441125s
+        duration: 1.359645166s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -650,7 +650,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxi4wthvw5hpN51d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavr9xzt8Bl4qZFe1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -662,9 +662,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:33:42 GMT
+                - Tue, 03 Mar 2026 16:42:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.896999875s
+        duration: 1.724370583s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaIdpSaml_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaIdpSaml_crud/classic-00.yaml
@@ -28,19 +28,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi0vqaWfoITbh1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_1:0oasxi0vqaWfoITbh1d7","name":"classic-00_testacc3926115512_1","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:27:13.000Z","created":"2025-12-21T14:27:12.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_1_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/alnsxic9g4M1Q9cPF1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra8kgvPuh2nCY1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_4:0oavra8kgvPuh2nCY1d7","name":"classic-00_testacc3926115512_4","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:51:25.000Z","created":"2026-03-03T16:51:25.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_4_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_4_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/alnvrasy17d4HD3DK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:13 GMT
+                - Tue, 03 Mar 2026 16:51:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.347848792s
+        duration: 2.249742833s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,12 +67,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:14 GMT
+                - Tue, 03 Mar 2026 16:51:26 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.093905041s
+        duration: 1.077408417s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
+        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttgu86y5cqPXYVT1d7","status":"ACTIVE","name":"Case-OKTA-1059814-1","priority":1,"system":false,"conditions":null,"created":"2026-01-05T13:32:57.000Z","lastUpdated":"2026-01-05T13:32:57.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnr1lke47WiZr71d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T03:07:20.000Z","lastUpdated":"2026-01-09T03:07:20.000Z","_links":{"mappings":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:15 GMT
+                - Tue, 03 Mar 2026 16:51:27 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.118423625s
+        duration: 1.134465583s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/policies/rstnkw1sgxfqkDUtx1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/policies/rstnkw1sgxfqkDUtx1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -135,12 +135,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:27:16 GMT
+                - Tue, 03 Mar 2026 16:51:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.224925417s
+        duration: 1.174826541s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi0vqaWfoITbh1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_1:0oasxi0vqaWfoITbh1d7","name":"classic-00_testacc3926115512_1","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:27:13.000Z","created":"2025-12-21T14:27:12.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_1_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/alnsxic9g4M1Q9cPF1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra8kgvPuh2nCY1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_4:0oavra8kgvPuh2nCY1d7","name":"classic-00_testacc3926115512_4","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:51:25.000Z","created":"2026-03-03T16:51:25.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_4_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_4_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/alnvrasy17d4HD3DK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:17 GMT
+                - Tue, 03 Mar 2026 16:51:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.259964416s
+        duration: 1.135991667s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,13 +183,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+                - KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata?kid=S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata?kid=KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,23 +197,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxi0vq9zB3Amw91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8kguKwF3zay1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0
-            MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2
+            NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ
-            g6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys
-            7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6
-            qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV
-            V0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY
-            OGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU
-            tMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI
-            jXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1
-            PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo
-            yk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC
+            tRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192
+            5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC
+            CS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT
+            8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv
+            qJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn
+            lvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq
+            z9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq
+            xLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s
+            9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -222,12 +222,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:27:19 GMT
+                - Tue, 03 Mar 2026 16:51:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.252672542s
+        duration: 1.218972917s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -248,19 +248,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:27:12.000Z","lastUpdated":"2025-12-21T14:27:12.000Z","expiresAt":"2035-12-21T14:27:12.000Z","kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZg6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxVV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPYOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuUtMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVIjXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNoyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:51:25.000Z","lastUpdated":"2026-03-03T16:51:25.000Z","expiresAt":"2036-03-03T16:51:24.000Z","kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkCtRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o1925LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsCCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqvqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZnlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byqz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3BgsqxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:20 GMT
+                - Tue, 03 Mar 2026 16:51:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.343675875s
+        duration: 1.367418375s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -269,7 +269,7 @@ interactions:
         content_length: 1337
         host: classic-00.dne-okta.com
         body: |
-            {"x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0\nMjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ\ng6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys\n7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6\nqisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV\nV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY\nOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU\ntMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI\njXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1\nPJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo\nyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="]}
+            {"x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2\nNTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC\ntRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192\n5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC\nCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT\n8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv\nqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn\nlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq\nz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq\nxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s\n9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="]}
         headers:
             Accept:
                 - application/json
@@ -285,19 +285,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:27:21.000Z","lastUpdated":"2025-12-21T14:27:21.000Z","expiresAt":"2035-12-21T14:27:12.000Z","alg":"RSA","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0\nMjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ\ng6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys\n7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6\nqisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV\nV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY\nOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU\ntMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI\njXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1\nPJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo\nyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:51:33.000Z","lastUpdated":"2026-03-03T16:51:33.000Z","expiresAt":"2036-03-03T16:51:24.000Z","alg":"RSA","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2\nNTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC\ntRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192\n5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC\nCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT\n8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv\nqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn\nlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq\nz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq\nxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s\n9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:21 GMT
+                - Tue, 03 Mar 2026 16:51:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.164293917s
+        duration: 1.081965042s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -310,7 +310,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/0359cdd1-e7a9-425c-9b67-acba8d8727a7
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/572581f4-e3ae-4708-ada6-39a219ead5ff
         method: GET
       response:
         proto: HTTP/2.0
@@ -318,28 +318,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:27:21.000Z","lastUpdated":"2025-12-21T14:27:21.000Z","expiresAt":"2035-12-21T14:27:12.000Z","alg":"RSA","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0\nMjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ\ng6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys\n7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6\nqisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV\nV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY\nOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU\ntMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI\njXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1\nPJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo\nyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:51:33.000Z","lastUpdated":"2026-03-03T16:51:33.000Z","expiresAt":"2036-03-03T16:51:24.000Z","alg":"RSA","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2\nNTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC\ntRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192\n5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC\nCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT\n8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv\nqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn\nlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq\nz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq\nxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s\n9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:22 GMT
+                - Tue, 03 Mar 2026 16:51:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.125396125s
+        duration: 1.047876625s
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 943
+        content_length: 962
         host: classic-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
+            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
@@ -355,19 +355,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:27:24.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:51:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:24 GMT
+                - Tue, 03 Mar 2026 16:51:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.010604459s
+        duration: 1.978538166s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -380,7 +380,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -388,19 +388,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:27:24.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:51:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:26 GMT
+                - Tue, 03 Mar 2026 16:51:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.204353125s
+        duration: 1.251539208s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -412,13 +412,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhplh2UIKJfwp1d7
+                - 0oavra7zw0bAI32iv1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -426,21 +426,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}},{"id":"prmsxhplhlrZxEBVB1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhlrZxEBVB1d7"}}},{"id":"prmsxhplhwAyzpfFf1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhwAyzpfFf1d7"}}},{"id":"prmsxhpli7juFLwnN1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpli7juFLwnN1d7"}}},{"id":"prmsxhpliicAOxNxP1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpliicAOxNxP1d7"}}},{"id":"prmsxhplitMz7mH8C1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplitMz7mH8C1d7"}}},{"id":"prmsxhplj4YPHDKDt1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplj4YPHDKDt1d7"}}},{"id":"prmsxhpljf31QcY6T1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpljf31QcY6T1d7"}}}]'
+        body: '[{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}},{"id":"prmvra7zwjd2bn9zW1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwjd2bn9zW1d7"}}},{"id":"prmvra7zwusHVFFxF1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwusHVFFxF1d7"}}},{"id":"prmvra7zx5OMzLyki1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zx5OMzLyki1d7"}}},{"id":"prmvra7zxg6kmO0lZ1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxg6kmO0lZ1d7"}}},{"id":"prmvra7zxr3GkKkNX1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxr3GkKkNX1d7"}}},{"id":"prmvra7zy2cDHyzWu1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zy2cDHyzWu1d7"}}},{"id":"prmvra7zydruSgU3I1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zydruSgU3I1d7"}}},{"id":"prmvra7zyo6eBzZaI1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zyo6eBzZaI1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:27 GMT
+                - Tue, 03 Mar 2026 16:51:39 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.195002333s
+        duration: 1.1161665s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -453,7 +453,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -461,19 +461,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}}'
+        body: '{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:28 GMT
+                - Tue, 03 Mar 2026 16:51:40 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.101066792s
+        duration: 1.099545042s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -486,7 +486,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -494,19 +494,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi0vqaWfoITbh1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_1:0oasxi0vqaWfoITbh1d7","name":"classic-00_testacc3926115512_1","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:27:13.000Z","created":"2025-12-21T14:27:12.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_1_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/alnsxic9g4M1Q9cPF1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra8kgvPuh2nCY1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_4:0oavra8kgvPuh2nCY1d7","name":"classic-00_testacc3926115512_4","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:51:25.000Z","created":"2026-03-03T16:51:25.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_4_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_4_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/alnvrasy17d4HD3DK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:29 GMT
+                - Tue, 03 Mar 2026 16:51:41 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.103691333s
+        duration: 1.129476709s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -516,13 +516,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+                - KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata?kid=S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata?kid=KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,23 +530,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxi0vq9zB3Amw91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8kguKwF3zay1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0
-            MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2
+            NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ
-            g6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys
-            7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6
-            qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV
-            V0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY
-            OGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU
-            tMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI
-            jXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1
-            PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo
-            yk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC
+            tRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192
+            5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC
+            CS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT
+            8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv
+            qJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn
+            lvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq
+            z9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq
+            xLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s
+            9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -555,12 +555,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:27:30 GMT
+                - Tue, 03 Mar 2026 16:51:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.268310667s
+        duration: 1.288817292s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -573,7 +573,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -581,19 +581,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:27:12.000Z","lastUpdated":"2025-12-21T14:27:12.000Z","expiresAt":"2035-12-21T14:27:12.000Z","kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZg6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxVV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPYOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuUtMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVIjXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNoyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:51:25.000Z","lastUpdated":"2026-03-03T16:51:25.000Z","expiresAt":"2036-03-03T16:51:24.000Z","kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkCtRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o1925LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsCCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqvqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZnlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byqz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3BgsqxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:32 GMT
+                - Tue, 03 Mar 2026 16:51:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.28301825s
+        duration: 1.266930292s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -606,7 +606,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/0359cdd1-e7a9-425c-9b67-acba8d8727a7
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/572581f4-e3ae-4708-ada6-39a219ead5ff
         method: GET
       response:
         proto: HTTP/2.0
@@ -614,19 +614,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:27:21.000Z","lastUpdated":"2025-12-21T14:27:21.000Z","expiresAt":"2035-12-21T14:27:12.000Z","alg":"RSA","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0\nMjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ\ng6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys\n7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6\nqisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV\nV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY\nOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU\ntMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI\njXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1\nPJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo\nyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:51:33.000Z","lastUpdated":"2026-03-03T16:51:33.000Z","expiresAt":"2036-03-03T16:51:24.000Z","alg":"RSA","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2\nNTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC\ntRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192\n5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC\nCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT\n8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv\nqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn\nlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq\nz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq\nxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s\n9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:33 GMT
+                - Tue, 03 Mar 2026 16:51:45 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0746395s
+        duration: 1.069565625s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -639,7 +639,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -647,19 +647,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:27:24.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:51:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:34 GMT
+                - Tue, 03 Mar 2026 16:51:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.081325459s
+        duration: 1.093183917s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -671,13 +671,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhplh2UIKJfwp1d7
+                - 0oavra7zw0bAI32iv1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -685,21 +685,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}},{"id":"prmsxhplhlrZxEBVB1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhlrZxEBVB1d7"}}},{"id":"prmsxhplhwAyzpfFf1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhwAyzpfFf1d7"}}},{"id":"prmsxhpli7juFLwnN1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpli7juFLwnN1d7"}}},{"id":"prmsxhpliicAOxNxP1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpliicAOxNxP1d7"}}},{"id":"prmsxhplitMz7mH8C1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplitMz7mH8C1d7"}}},{"id":"prmsxhplj4YPHDKDt1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplj4YPHDKDt1d7"}}},{"id":"prmsxhpljf31QcY6T1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpljf31QcY6T1d7"}}}]'
+        body: '[{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}},{"id":"prmvra7zwjd2bn9zW1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwjd2bn9zW1d7"}}},{"id":"prmvra7zwusHVFFxF1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwusHVFFxF1d7"}}},{"id":"prmvra7zx5OMzLyki1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zx5OMzLyki1d7"}}},{"id":"prmvra7zxg6kmO0lZ1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxg6kmO0lZ1d7"}}},{"id":"prmvra7zxr3GkKkNX1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxr3GkKkNX1d7"}}},{"id":"prmvra7zy2cDHyzWu1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zy2cDHyzWu1d7"}}},{"id":"prmvra7zydruSgU3I1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zydruSgU3I1d7"}}},{"id":"prmvra7zyo6eBzZaI1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zyo6eBzZaI1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:35 GMT
+                - Tue, 03 Mar 2026 16:51:47 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.121071042s
+        duration: 1.194100083s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -712,7 +712,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -720,19 +720,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}}'
+        body: '{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:36 GMT
+                - Tue, 03 Mar 2026 16:51:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.079016792s
+        duration: 1.125435791s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -745,7 +745,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -753,19 +753,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi0vqaWfoITbh1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_1:0oasxi0vqaWfoITbh1d7","name":"classic-00_testacc3926115512_1","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:27:13.000Z","created":"2025-12-21T14:27:12.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_1_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/alnsxic9g4M1Q9cPF1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra8kgvPuh2nCY1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_4:0oavra8kgvPuh2nCY1d7","name":"classic-00_testacc3926115512_4","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:51:25.000Z","created":"2026-03-03T16:51:25.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_4_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_4_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/alnvrasy17d4HD3DK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:37 GMT
+                - Tue, 03 Mar 2026 16:51:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.103992542s
+        duration: 1.102758167s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -775,13 +775,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+                - KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata?kid=S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata?kid=KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,23 +789,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxi0vq9zB3Amw91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8kguKwF3zay1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0
-            MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2
+            NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ
-            g6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys
-            7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6
-            qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV
-            V0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY
-            OGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU
-            tMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI
-            jXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1
-            PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo
-            yk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC
+            tRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192
+            5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC
+            CS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT
+            8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv
+            qJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn
+            lvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq
+            z9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq
+            xLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s
+            9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -814,12 +814,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:27:39 GMT
+                - Tue, 03 Mar 2026 16:51:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.244218208s
+        duration: 1.270120333s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -832,7 +832,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -840,19 +840,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:27:12.000Z","lastUpdated":"2025-12-21T14:27:12.000Z","expiresAt":"2035-12-21T14:27:12.000Z","kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZg6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxVV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPYOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuUtMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVIjXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNoyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:51:25.000Z","lastUpdated":"2026-03-03T16:51:25.000Z","expiresAt":"2036-03-03T16:51:24.000Z","kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkCtRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o1925LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsCCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqvqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZnlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byqz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3BgsqxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:40 GMT
+                - Tue, 03 Mar 2026 16:51:52 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.250268417s
+        duration: 1.232595542s
     - id: 23
       request:
         proto: HTTP/1.1
@@ -865,7 +865,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/0359cdd1-e7a9-425c-9b67-acba8d8727a7
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/572581f4-e3ae-4708-ada6-39a219ead5ff
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,19 +873,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:27:21.000Z","lastUpdated":"2025-12-21T14:27:21.000Z","expiresAt":"2035-12-21T14:27:12.000Z","alg":"RSA","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0\nMjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ\ng6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys\n7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6\nqisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV\nV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY\nOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU\ntMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI\njXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1\nPJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo\nyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:51:33.000Z","lastUpdated":"2026-03-03T16:51:33.000Z","expiresAt":"2036-03-03T16:51:24.000Z","alg":"RSA","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2\nNTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC\ntRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192\n5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC\nCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT\n8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv\nqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn\nlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq\nz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq\nxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s\n9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:41 GMT
+                - Tue, 03 Mar 2026 16:51:53 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.140817292s
+        duration: 1.057579834s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -898,7 +898,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -906,19 +906,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:27:24.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:51:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:42 GMT
+                - Tue, 03 Mar 2026 16:51:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.103111292s
+        duration: 1.086813s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -930,13 +930,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhplh2UIKJfwp1d7
+                - 0oavra7zw0bAI32iv1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -944,21 +944,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}},{"id":"prmsxhplhlrZxEBVB1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhlrZxEBVB1d7"}}},{"id":"prmsxhplhwAyzpfFf1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhwAyzpfFf1d7"}}},{"id":"prmsxhpli7juFLwnN1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpli7juFLwnN1d7"}}},{"id":"prmsxhpliicAOxNxP1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpliicAOxNxP1d7"}}},{"id":"prmsxhplitMz7mH8C1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplitMz7mH8C1d7"}}},{"id":"prmsxhplj4YPHDKDt1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplj4YPHDKDt1d7"}}},{"id":"prmsxhpljf31QcY6T1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpljf31QcY6T1d7"}}}]'
+        body: '[{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}},{"id":"prmvra7zwjd2bn9zW1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwjd2bn9zW1d7"}}},{"id":"prmvra7zwusHVFFxF1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwusHVFFxF1d7"}}},{"id":"prmvra7zx5OMzLyki1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zx5OMzLyki1d7"}}},{"id":"prmvra7zxg6kmO0lZ1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxg6kmO0lZ1d7"}}},{"id":"prmvra7zxr3GkKkNX1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxr3GkKkNX1d7"}}},{"id":"prmvra7zy2cDHyzWu1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zy2cDHyzWu1d7"}}},{"id":"prmvra7zydruSgU3I1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zydruSgU3I1d7"}}},{"id":"prmvra7zyo6eBzZaI1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zyo6eBzZaI1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:43 GMT
+                - Tue, 03 Mar 2026 16:51:55 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.1027475s
+        duration: 1.136065375s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -971,7 +971,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -979,28 +979,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}}'
+        body: '{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:44 GMT
+                - Tue, 03 Mar 2026 16:51:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.0860445s
+        duration: 1.1044405s
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1046
+        content_length: 1066
         host: classic-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":60,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","issuer":"https://idp.example.com/issuer","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com/test","url":"https://idp.example.com/test"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
+            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":60,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":false},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","issuer":"https://idp.example.com/issuer","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com/test","url":"https://idp.example.com/test"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
@@ -1008,7 +1008,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1016,19 +1016,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":null,"lastUpdated":"2025-12-21T14:27:46.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T16:51:58.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:46 GMT
+                - Tue, 03 Mar 2026 16:51:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.340495334s
+        duration: 1.425419s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1041,7 +1041,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1049,19 +1049,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:27:46.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:51:58.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:47 GMT
+                - Tue, 03 Mar 2026 16:51:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.235137625s
+        duration: 1.063846334s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1073,13 +1073,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhplh2UIKJfwp1d7
+                - 0oavra7zw0bAI32iv1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1087,21 +1087,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}},{"id":"prmsxhplhlrZxEBVB1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhlrZxEBVB1d7"}}},{"id":"prmsxhplhwAyzpfFf1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhwAyzpfFf1d7"}}},{"id":"prmsxhpli7juFLwnN1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpli7juFLwnN1d7"}}},{"id":"prmsxhpliicAOxNxP1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpliicAOxNxP1d7"}}},{"id":"prmsxhplitMz7mH8C1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplitMz7mH8C1d7"}}},{"id":"prmsxhplj4YPHDKDt1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplj4YPHDKDt1d7"}}},{"id":"prmsxhpljf31QcY6T1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpljf31QcY6T1d7"}}}]'
+        body: '[{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}},{"id":"prmvra7zwjd2bn9zW1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwjd2bn9zW1d7"}}},{"id":"prmvra7zwusHVFFxF1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwusHVFFxF1d7"}}},{"id":"prmvra7zx5OMzLyki1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zx5OMzLyki1d7"}}},{"id":"prmvra7zxg6kmO0lZ1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxg6kmO0lZ1d7"}}},{"id":"prmvra7zxr3GkKkNX1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxr3GkKkNX1d7"}}},{"id":"prmvra7zy2cDHyzWu1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zy2cDHyzWu1d7"}}},{"id":"prmvra7zydruSgU3I1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zydruSgU3I1d7"}}},{"id":"prmvra7zyo6eBzZaI1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zyo6eBzZaI1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:48 GMT
+                - Tue, 03 Mar 2026 16:52:00 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.128427959s
+        duration: 1.161390917s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1114,7 +1114,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1122,19 +1122,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}}'
+        body: '{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:49 GMT
+                - Tue, 03 Mar 2026 16:52:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.123046958s
+        duration: 1.061686416s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1147,7 +1147,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1155,19 +1155,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxi0vqaWfoITbh1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_1:0oasxi0vqaWfoITbh1d7","name":"classic-00_testacc3926115512_1","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:27:13.000Z","created":"2025-12-21T14:27:12.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_1_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_1_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_1/0oasxi0vqaWfoITbh1d7/alnsxic9g4M1Q9cPF1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra8kgvPuh2nCY1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:classic-00_testacc3926115512_4:0oavra8kgvPuh2nCY1d7","name":"classic-00_testacc3926115512_4","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:51:25.000Z","created":"2026-03-03T16:51:25.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"classic-00_testacc3926115512_4_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://classic-00-admin.dne-okta.com/app/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"classic-00_testacc3926115512_4_link","href":"https://classic-00.dne-okta.com/home/classic-00_testacc3926115512_4/0oavra8kgvPuh2nCY1d7/alnvrasy17d4HD3DK1d7","type":"text/html"}],"profileEnrollment":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://classic-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/users"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:51 GMT
+                - Tue, 03 Mar 2026 16:52:03 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.167689708s
+        duration: 1.201798041s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1177,13 +1177,13 @@ interactions:
         host: classic-00.dne-okta.com
         form:
             kid:
-                - S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+                - KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/sso/saml/metadata?kid=S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/sso/saml/metadata?kid=KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA
         method: GET
       response:
         proto: HTTP/2.0
@@ -1191,23 +1191,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxi0vq9zB3Amw91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8kguKwF3zay1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0
-            MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2
+            NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ
-            g6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys
-            7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6
-            qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV
-            V0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY
-            OGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU
-            tMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI
-            jXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1
-            PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo
-            yk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_1/exksxi0vq9zB3Amw91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC
+            tRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192
+            5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC
+            CS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT
+            8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv
+            qJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn
+            lvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq
+            z9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq
+            xLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s
+            9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://classic-00.dne-okta.com/app/classic-00_testacc3926115512_4/exkvra8kguKwF3zay1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -1216,12 +1216,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:27:52 GMT
+                - Tue, 03 Mar 2026 16:52:04 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.389452042s
+        duration: 1.106308833s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1234,7 +1234,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/credentials/keys
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -1242,19 +1242,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:27:12.000Z","lastUpdated":"2025-12-21T14:27:12.000Z","expiresAt":"2035-12-21T14:27:12.000Z","kid":"S_olLEOwab59BwQphLTCu--PCkslT57nJ10w0jJ8EVM","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0MjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZg6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6qisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxVV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPYOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuUtMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVIjXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1PJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNoyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:51:25.000Z","lastUpdated":"2026-03-03T16:51:25.000Z","expiresAt":"2036-03-03T16:51:24.000Z","kid":"KdBRDOdso7VVim9tgZOSWjuW92vexgf71Iqd03Y5RvA","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2NTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkCtRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o1925LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsCCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqvqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZnlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byqz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3BgsqxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:53 GMT
+                - Tue, 03 Mar 2026 16:52:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.335526834s
+        duration: 1.224091625s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1267,7 +1267,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/0359cdd1-e7a9-425c-9b67-acba8d8727a7
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/572581f4-e3ae-4708-ada6-39a219ead5ff
         method: GET
       response:
         proto: HTTP/2.0
@@ -1275,19 +1275,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:27:21.000Z","lastUpdated":"2025-12-21T14:27:21.000Z","expiresAt":"2035-12-21T14:27:12.000Z","alg":"RSA","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBTqe4MA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjYxMloXDTM1MTIyMTE0\nMjcxMlowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8lRxN/HsXKu24Wnj8IBsBdEVf6LvU3jCZ\ng6eQsPXBoV1KC+3wsSVHCGzW35DJBf9mvbzlPh0GmDSg7HmctwdQvU93f+NrcaNhQadTxToL4+ys\n7Ca9BpZIHIRkVtka5U+4ag7ai1kBQD074aHuZkAeCyue4Lh7CcxaIrnmD4oit4Ll4Brs3GfUiVl6\nqisxrAE+I3FJplZIdzbjMRtnC8nK5p9shOUyZxTzgUvb4JJ65NTdLDrcmI6XWZBK8CmvgVUhRJxV\nV0s91l4yQ+QNxkab/SrpJeHxiTZQH3Zu8rj+QO3PpjbSqN3zD/CPh7I7wvLJXgkgz5QiKnAxjdPY\nOGO/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGcvj/uMt1kYurlMEIpoBwoB6ouAAafjkhfM8TuU\ntMo5puRPpg82iKOXAJHmXnLl0eIgvStDOpe0ExdoR1V5v6SdI94fUUe3M3hfHt2QRLjaV6EUQyVI\njXAbN+M/byy3mav0bvMLKN+jHn2pw1jG8+1DnsZaNKHhN3b001LCBwoh91KfQ0ZfnOeUFZ6hk0j1\nPJEA+S5d/kLLgscxuG//pjyAGSN9YmbbS1OGA9Jk0ilPXwzIlhtCMRrltd8zi8ZFH3jW50soYzNo\nyk98wqdKgwrSxFjNj5ZdfYNOrroYn0VhHPUVktiU1TuCV2lkwaE6/CvcN6F8Pt0izVZgQpgKsAE="],"x5t#S256":"z9b01IdQ992PWASB9K_zedLrEl44_gao6by9KPiVjww","e":"AQAB","n":"vJUcTfx7FyrtuFp4_CAbAXRFX-i71N4wmYOnkLD1waFdSgvt8LElRwhs1t-QyQX_Zr285T4dBpg0oOx5nLcHUL1Pd3_ja3GjYUGnU8U6C-PsrOwmvQaWSByEZFbZGuVPuGoO2otZAUA9O-Gh7mZAHgsrnuC4ewnMWiK55g-KIreC5eAa7Nxn1IlZeqorMawBPiNxSaZWSHc24zEbZwvJyuafbITlMmcU84FL2-CSeuTU3Sw63JiOl1mQSvApr4FVIUScVVdLPdZeMkPkDcZGm_0q6SXh8Yk2UB92bvK4_kDtz6Y20qjd8w_wj4eyO8LyyV4JIM-UIipwMY3T2Dhjvw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:51:33.000Z","lastUpdated":"2026-03-03T16:51:33.000Z","expiresAt":"2036-03-03T16:51:24.000Z","alg":"RSA","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0nI7MMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NTAyNVoXDTM2MDMwMzE2\nNTEyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC1P+TO9NDzn5okiterI56ixZT4PmHYcbkC\ntRNB5qtjxVxwpZwO6u1Vmurqs0r3MWrNS8zdbUClQufcnQoHAgpRuFynYbe1BNvH/KYjol63o192\n5LZRzv+7MGq7WaaSeXxLGw8KRs/flsPFtAVyCAKnTJoLw1OYmmqGFNcpSn4XwhEk0WOej6+MnXsC\nCS94M2M2gqAwJhSCcKyV4hA6Vl+MkaUSfdbPO36RvdeETLoxNQTuFF+VX4X40ADKPwXCaf00ZOtT\n8BFW4TV4fvW2fkPiDOM5uzDrChhrYIH1ol7Je47CIdA7z3ICJPGwu452xoRepP9VPK/tvulYEuqv\nqJdrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHYo6teDkbaKo3eWqRD7Ui3zTXSz2KZiT/dkJsZn\nlvpP8SCfiZPsOviLGJfRd9Vi/pnmrL74bQhrISwxVBUhBjJrAA66St+QvVv03kEQlH5U85x+7Byq\nz9321SLvAigJGDlhzXbvCMXIEa+0ntzgExxElcy62nbstzHzNndWs0B1PVe5SrEYrGxuMMm3Bgsq\nxLUFNu7gGUF5dEDHvH0jqwW/ie2zyqr/kgj7pwGLofhlVbCGb9ZrGcPu3jOexrxspuAo0Tm+RF7s\n9xy3DDUQnczVSrD7I0coib2//gaQ1PvrfZigIMQoKmkd+2LQj3SkBjuPkK/JKdgMznhBmHm2m/Q="],"x5t#S256":"kFAxkKX6N4P-ekXjunghp7fbsNrO2pZZnJvkeP5dSyI","e":"AQAB","n":"tT_kzvTQ85-aJIrXqyOeosWU-D5h2HG5ArUTQearY8VccKWcDurtVZrq6rNK9zFqzUvM3W1ApULn3J0KBwIKUbhcp2G3tQTbx_ymI6Jet6NfduS2Uc7_uzBqu1mmknl8SxsPCkbP35bDxbQFcggCp0yaC8NTmJpqhhTXKUp-F8IRJNFjno-vjJ17AgkveDNjNoKgMCYUgnCsleIQOlZfjJGlEn3Wzzt-kb3XhEy6MTUE7hRflV-F-NAAyj8Fwmn9NGTrU_ARVuE1eH71tn5D4gzjObsw6woYa2CB9aJeyXuOwiHQO89yAiTxsLuOdsaEXqT_VTyv7b7pWBLqr6iXaw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:55 GMT
+                - Tue, 03 Mar 2026 16:52:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.107753416s
+        duration: 1.122690917s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1300,7 +1300,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1308,19 +1308,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:27:46.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:51:58.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:56 GMT
+                - Tue, 03 Mar 2026 16:52:07 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.077844042s
+        duration: 1.213468958s
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1332,13 +1332,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhplh2UIKJfwp1d7
+                - 0oavra7zw0bAI32iv1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1346,21 +1346,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}},{"id":"prmsxhplhlrZxEBVB1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhlrZxEBVB1d7"}}},{"id":"prmsxhplhwAyzpfFf1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhwAyzpfFf1d7"}}},{"id":"prmsxhpli7juFLwnN1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpli7juFLwnN1d7"}}},{"id":"prmsxhpliicAOxNxP1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpliicAOxNxP1d7"}}},{"id":"prmsxhplitMz7mH8C1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplitMz7mH8C1d7"}}},{"id":"prmsxhplj4YPHDKDt1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplj4YPHDKDt1d7"}}},{"id":"prmsxhpljf31QcY6T1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpljf31QcY6T1d7"}}}]'
+        body: '[{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}},{"id":"prmvra7zwjd2bn9zW1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwjd2bn9zW1d7"}}},{"id":"prmvra7zwusHVFFxF1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwusHVFFxF1d7"}}},{"id":"prmvra7zx5OMzLyki1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zx5OMzLyki1d7"}}},{"id":"prmvra7zxg6kmO0lZ1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxg6kmO0lZ1d7"}}},{"id":"prmvra7zxr3GkKkNX1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxr3GkKkNX1d7"}}},{"id":"prmvra7zy2cDHyzWu1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zy2cDHyzWu1d7"}}},{"id":"prmvra7zydruSgU3I1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zydruSgU3I1d7"}}},{"id":"prmvra7zyo6eBzZaI1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zyo6eBzZaI1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:57 GMT
+                - Tue, 03 Mar 2026 16:52:09 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.169092209s
+        duration: 1.252926083s
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1373,7 +1373,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1381,19 +1381,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}}'
+        body: '{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:58 GMT
+                - Tue, 03 Mar 2026 16:52:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.122434s
+        duration: 1.102067584s
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1406,7 +1406,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1414,19 +1414,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:27:46.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:51:58.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:27:59 GMT
+                - Tue, 03 Mar 2026 16:52:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.101805542s
+        duration: 1.08997125s
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1438,13 +1438,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhplh2UIKJfwp1d7
+                - 0oavra7zw0bAI32iv1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavra7zw0bAI32iv1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1452,21 +1452,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}},{"id":"prmsxhplhlrZxEBVB1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhlrZxEBVB1d7"}}},{"id":"prmsxhplhwAyzpfFf1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhwAyzpfFf1d7"}}},{"id":"prmsxhpli7juFLwnN1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpli7juFLwnN1d7"}}},{"id":"prmsxhpliicAOxNxP1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpliicAOxNxP1d7"}}},{"id":"prmsxhplitMz7mH8C1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplitMz7mH8C1d7"}}},{"id":"prmsxhplj4YPHDKDt1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplj4YPHDKDt1d7"}}},{"id":"prmsxhpljf31QcY6T1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhpljf31QcY6T1d7"}}}]'
+        body: '[{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}},{"id":"prmvra7zwjd2bn9zW1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwjd2bn9zW1d7"}}},{"id":"prmvra7zwusHVFFxF1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zwusHVFFxF1d7"}}},{"id":"prmvra7zx5OMzLyki1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zx5OMzLyki1d7"}}},{"id":"prmvra7zxg6kmO0lZ1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxg6kmO0lZ1d7"}}},{"id":"prmvra7zxr3GkKkNX1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zxr3GkKkNX1d7"}}},{"id":"prmvra7zy2cDHyzWu1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zy2cDHyzWu1d7"}}},{"id":"prmvra7zydruSgU3I1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zydruSgU3I1d7"}}},{"id":"prmvra7zyo6eBzZaI1d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zyo6eBzZaI1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:00 GMT
+                - Tue, 03 Mar 2026 16:52:12 GMT
             Link:
                 - <https://classic-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.151949708s
+        duration: 1.136441375s
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1479,7 +1479,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7
+        url: https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1487,19 +1487,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhplhaTAI39Xx1d7","source":{"id":"0oasxhplh2UIKJfwp1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oasxhplh2UIKJfwp1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhplh2UIKJfwp1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmsxhplhaTAI39Xx1d7"}}}'
+        body: '{"id":"prmvra7zw8ez79q301d7","source":{"id":"0oavra7zw0bAI32iv1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/apps/0oavra7zw0bAI32iv1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/apps/0oavra7zw0bAI32iv1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/mappings/prmvra7zw8ez79q301d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:02 GMT
+                - Tue, 03 Mar 2026 16:52:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.188728667s
+        duration: 1.101614042s
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1512,7 +1512,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1520,19 +1520,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhplh2UIKJfwp1d7","name":"testAcc_3926115512","status":"INACTIVE","created":"2025-12-21T14:27:24.000Z","lastUpdated":"2025-12-21T14:28:03.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spzkybhcajytlqwsukcs","kid":"0359cdd1-e7a9-425c-9b67-acba8d8727a7","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oasxhplh2UIKJfwp1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavra7zw0bAI32iv1d7","name":"testAcc_3926115512","status":"INACTIVE","created":"2026-03-03T16:51:36.000Z","lastUpdated":"2026-03-03T16:52:15.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppqhmxoxblfiloxoszk","kid":"572581f4-e3ae-4708-ada6-39a219ead5ff","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://classic-00.dne-okta.com/sso/saml2/0oavra7zw0bAI32iv1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:03 GMT
+                - Tue, 03 Mar 2026 16:52:15 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.227013875s
+        duration: 1.257885s
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1545,7 +1545,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/0oasxhplh2UIKJfwp1d7
+        url: https://classic-00.dne-okta.com/api/v1/idps/0oavra7zw0bAI32iv1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1557,12 +1557,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:28:05 GMT
+                - Tue, 03 Mar 2026 16:52:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.6631s
+        duration: 1.799364417s
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/0359cdd1-e7a9-425c-9b67-acba8d8727a7
+        url: https://classic-00.dne-okta.com/api/v1/idps/credentials/keys/572581f4-e3ae-4708-ada6-39a219ead5ff
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1587,12 +1587,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:28:06 GMT
+                - Tue, 03 Mar 2026 16:52:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.240094917s
+        duration: 1.209465958s
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1605,7 +1605,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7/lifecycle/deactivate
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1620,12 +1620,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:07 GMT
+                - Tue, 03 Mar 2026 16:52:19 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.261753916s
+        duration: 1.090542916s
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1638,7 +1638,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://classic-00.dne-okta.com/api/v1/apps/0oasxi0vqaWfoITbh1d7
+        url: https://classic-00.dne-okta.com/api/v1/apps/0oavra8kgvPuh2nCY1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1650,9 +1650,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:28:09 GMT
+                - Tue, 03 Mar 2026 16:52:21 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.570646667s
+        duration: 1.62425675s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaIdpSaml_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaIdpSaml_crud/oie-00.yaml
@@ -28,19 +28,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhz2x2CNv0xmn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_2:0oasxhz2x2CNv0xmn1d7","name":"oie-00_testacc3926115512_2","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:28:25.000Z","created":"2025-12-21T14:28:24.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/alnsxie3t5lO9IJGg1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra886aLMeP9141d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_3:0oavra886aLMeP9141d7","name":"oie-00_testacc3926115512_3","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:50:05.000Z","created":"2026-03-03T16:50:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_3_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_3_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/alnvrar0kgdqMQnLJ1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:25 GMT
+                - Tue, 03 Mar 2026 16:50:05 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.530252875s
+        duration: 2.119863917s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -67,12 +67,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:26 GMT
+                - Tue, 03 Mar 2026 16:50:06 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.123472917s
+        duration: 1.048974334s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -96,21 +96,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
+        body: '[{"id":"rstnkw1sg2fWHAvjK1d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg2fWHAvjK1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sg9IQmPCLu1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sg9IQmPCLu1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgcakRr6vG1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgcakRr6vG1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkw1sgxfqkDUtx1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2025-06-26T15:51:39.000Z","lastUpdated":"2025-06-26T15:51:39.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstnkwe1vlzSvyOpb1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2025-06-26T15:51:41.000Z","lastUpdated":"2025-06-26T15:51:41.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkwe1vlzSvyOpb1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rstpbfm3a3IBq00o11d7","status":"ACTIVE","name":"app","priority":1,"system":false,"conditions":null,"created":"2025-08-20T15:15:14.000Z","lastUpdated":"2025-11-05T16:55:28.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstpbfm3a3IBq00o11d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstptcolp9oveKe3d1d7","status":"ACTIVE","name":"tf-test","priority":1,"system":false,"conditions":null,"created":"2025-09-05T03:40:53.000Z","lastUpdated":"2025-09-05T03:40:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstptcolp9oveKe3d1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstqx747x9rjXYwjj1d7","status":"ACTIVE","name":"OKTA-1010693-1","priority":1,"system":false,"conditions":null,"created":"2025-10-13T08:06:10.000Z","lastUpdated":"2025-10-13T08:06:10.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstqx747x9rjXYwjj1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrdletj1K80Nggt1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2025-10-29T10:04:13.000Z","lastUpdated":"2025-10-29T10:04:13.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrdletj1K80Nggt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrjnmxgxO1EDrOd1d7","status":"ACTIVE","name":"dhiwakar_example","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-04T08:56:28.000Z","lastUpdated":"2025-11-06T09:39:15.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrjnmxgxO1EDrOd1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrm0wvxsAZerwOW1d7","status":"ACTIVE","name":"dhiwakar_example_002","description":"Authentication Policy to be used on my app.","priority":1,"system":false,"conditions":null,"created":"2025-11-06T09:53:07.000Z","lastUpdated":"2025-11-06T09:53:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrm0wvxsAZerwOW1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstrpm0angvCFmYaN1d7","status":"ACTIVE","name":"TF - AMichaels Test-34","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2025-11-10T08:48:58.000Z","lastUpdated":"2025-11-12T20:20:55.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstrpm0angvCFmYaN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsts3b7i5nGuq6FII1d7","status":"ACTIVE","name":"Case:02502653","priority":1,"system":false,"conditions":null,"created":"2025-11-24T11:56:51.000Z","lastUpdated":"2025-11-24T11:56:51.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsts3b7i5nGuq6FII1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstsfz8upwQL3U1wr1d7","status":"ACTIVE","name":"xxx","priority":1,"system":false,"conditions":null,"created":"2025-12-07T08:20:41.000Z","lastUpdated":"2025-12-07T08:20:41.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstsfz8upwQL3U1wr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttgu86y5cqPXYVT1d7","status":"ACTIVE","name":"Case-OKTA-1059814-1","priority":1,"system":false,"conditions":null,"created":"2026-01-05T13:32:57.000Z","lastUpdated":"2026-01-05T13:32:57.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttgu86y5cqPXYVT1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttnr1lke47WiZr71d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T03:07:20.000Z","lastUpdated":"2026-01-09T03:07:20.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttnr1lke47WiZr71d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:27 GMT
+                - Tue, 03 Mar 2026 16:50:07 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.15334175s
+        duration: 1.11974575s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,7 +123,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/policies/rstnkw1sgxfqkDUtx1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/policies/rstnkw1sgxfqkDUtx1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -135,12 +135,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:28:29 GMT
+                - Tue, 03 Mar 2026 16:50:08 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.194043125s
+        duration: 1.212483833s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -161,19 +161,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhz2x2CNv0xmn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_2:0oasxhz2x2CNv0xmn1d7","name":"oie-00_testacc3926115512_2","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:28:25.000Z","created":"2025-12-21T14:28:24.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/alnsxie3t5lO9IJGg1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra886aLMeP9141d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_3:0oavra886aLMeP9141d7","name":"oie-00_testacc3926115512_3","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:50:05.000Z","created":"2026-03-03T16:50:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_3_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_3_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/alnvrar0kgdqMQnLJ1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:30 GMT
+                - Tue, 03 Mar 2026 16:50:10 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.281895625s
+        duration: 1.224792166s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -183,13 +183,13 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+                - ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata?kid=fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata?kid=ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         method: GET
       response:
         proto: HTTP/2.0
@@ -197,23 +197,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxhz2x1AIT70X91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8869C8ZL0PE1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0
-            MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2
+            NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC
-            qAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y
-            dQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c
-            9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT
-            7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN
-            +NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F
-            NiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl
-            vGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei
-            Em73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum
-            y2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB
+            jgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM
+            bZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy
+            rMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT
+            9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda
+            DaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237
+            BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if
+            AbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x
+            oSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no
+            D55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -222,12 +222,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:28:31 GMT
+                - Tue, 03 Mar 2026 16:50:11 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.319903084s
+        duration: 1.241942875s
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,7 +240,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -248,19 +248,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:28:24.000Z","lastUpdated":"2025-12-21T14:28:24.000Z","expiresAt":"2035-12-21T14:28:24.000Z","kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzCqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82ydQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+FNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJlvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3EiEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxumy2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:50:04.000Z","lastUpdated":"2026-03-03T16:50:04.000Z","expiresAt":"2036-03-03T16:50:04.000Z","kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCBjgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDMbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4IacyrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbdaDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8ifAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0xoSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38noD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:32 GMT
+                - Tue, 03 Mar 2026 16:50:12 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.31334575s
+        duration: 1.24098425s
     - id: 7
       request:
         proto: HTTP/1.1
@@ -269,7 +269,7 @@ interactions:
         content_length: 1337
         host: oie-00.dne-okta.com
         body: |
-            {"x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0\nMjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC\nqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y\ndQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c\n9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT\n7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN\n+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F\nNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl\nvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei\nEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum\ny2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="]}
+            {"x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2\nNTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB\njgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM\nbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy\nrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT\n9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda\nDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237\nBVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if\nAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x\noSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no\nD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="]}
         headers:
             Accept:
                 - application/json
@@ -285,19 +285,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:28:34.000Z","lastUpdated":"2025-12-21T14:28:34.000Z","expiresAt":"2035-12-21T14:28:24.000Z","alg":"RSA","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0\nMjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC\nqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y\ndQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c\n9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT\n7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN\n+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F\nNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl\nvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei\nEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum\ny2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:50:13.000Z","lastUpdated":"2026-03-03T16:50:13.000Z","expiresAt":"2036-03-03T16:50:04.000Z","alg":"RSA","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2\nNTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB\njgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM\nbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy\nrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT\n9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda\nDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237\nBVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if\nAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x\noSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no\nD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:34 GMT
+                - Tue, 03 Mar 2026 16:50:13 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.19198425s
+        duration: 1.121866792s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -310,7 +310,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/ada4234c-a18a-4fca-8b9f-ce95f523a4bd
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/42089b9e-eb70-4f9c-b57a-21a1a62817dc
         method: GET
       response:
         proto: HTTP/2.0
@@ -318,28 +318,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:28:34.000Z","lastUpdated":"2025-12-21T14:28:34.000Z","expiresAt":"2035-12-21T14:28:24.000Z","alg":"RSA","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0\nMjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC\nqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y\ndQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c\n9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT\n7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN\n+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F\nNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl\nvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei\nEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum\ny2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:50:13.000Z","lastUpdated":"2026-03-03T16:50:13.000Z","expiresAt":"2036-03-03T16:50:04.000Z","alg":"RSA","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2\nNTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB\njgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM\nbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy\nrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT\n9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda\nDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237\nBVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if\nAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x\noSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no\nD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:35 GMT
+                - Tue, 03 Mar 2026 16:50:14 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.222143833s
+        duration: 1.098315375s
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 943
+        content_length: 962
         host: oie-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
+            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":true},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
@@ -355,19 +355,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:28:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:37 GMT
+                - Tue, 03 Mar 2026 16:50:17 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 2.142175792s
+        duration: 2.375227834s
     - id: 10
       request:
         proto: HTTP/1.1
@@ -380,7 +380,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -388,19 +388,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:28:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:38 GMT
+                - Tue, 03 Mar 2026 16:50:18 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.229128125s
+        duration: 1.20416925s
     - id: 11
       request:
         proto: HTTP/1.1
@@ -412,13 +412,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhkndxVEt6Dtq1d7
+                - 0oavraar3uzIOoiYU1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -426,21 +426,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}},{"id":"prmsxhkneg6ob0kRf1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkneg6ob0kRf1d7"}}},{"id":"prmsxhknerILu0JZc1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknerILu0JZc1d7"}}},{"id":"prmsxhknf2tq3Rm841d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknf2tq3Rm841d7"}}},{"id":"prmsxhknfdE66mKWV1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfdE66mKWV1d7"}}},{"id":"prmsxhknfoJHrLblg1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfoJHrLblg1d7"}}},{"id":"prmsxhknfziHZG6PZ1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfziHZG6PZ1d7"}}},{"id":"prmsxhknga75AT0qD1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknga75AT0qD1d7"}}}]'
+        body: '[{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}},{"id":"prmvraar4d3o1RL9p1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4d3o1RL9p1d7"}}},{"id":"prmvraar4oA4deJs91d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4oA4deJs91d7"}}},{"id":"prmvraar4zqNXXBr11d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4zqNXXBr11d7"}}},{"id":"prmvraar5a9b7U8rv1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5a9b7U8rv1d7"}}},{"id":"prmvraar5lmDZo0ui1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5lmDZo0ui1d7"}}},{"id":"prmvraar5wmxlL4on1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5wmxlL4on1d7"}}},{"id":"prmvraar67mCbjgRZ1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar67mCbjgRZ1d7"}}},{"id":"prmvraar6iIMiPw7e1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar6iIMiPw7e1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:39 GMT
+                - Tue, 03 Mar 2026 16:50:19 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.127452625s
+        duration: 1.263062041s
     - id: 12
       request:
         proto: HTTP/1.1
@@ -453,7 +453,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -461,19 +461,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}}'
+        body: '{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:41 GMT
+                - Tue, 03 Mar 2026 16:50:20 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.09670775s
+        duration: 1.074009875s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -486,7 +486,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -494,19 +494,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhz2x2CNv0xmn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_2:0oasxhz2x2CNv0xmn1d7","name":"oie-00_testacc3926115512_2","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:28:25.000Z","created":"2025-12-21T14:28:24.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/alnsxie3t5lO9IJGg1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra886aLMeP9141d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_3:0oavra886aLMeP9141d7","name":"oie-00_testacc3926115512_3","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:50:05.000Z","created":"2026-03-03T16:50:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_3_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_3_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/alnvrar0kgdqMQnLJ1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:42 GMT
+                - Tue, 03 Mar 2026 16:50:22 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.174234708s
+        duration: 1.130108958s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -516,13 +516,13 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+                - ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata?kid=fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata?kid=ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         method: GET
       response:
         proto: HTTP/2.0
@@ -530,23 +530,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxhz2x1AIT70X91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8869C8ZL0PE1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0
-            MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2
+            NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC
-            qAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y
-            dQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c
-            9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT
-            7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN
-            +NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F
-            NiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl
-            vGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei
-            Em73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum
-            y2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB
+            jgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM
+            bZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy
+            rMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT
+            9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda
+            DaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237
+            BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if
+            AbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x
+            oSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no
+            D55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -555,12 +555,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:28:43 GMT
+                - Tue, 03 Mar 2026 16:50:23 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.257271917s
+        duration: 1.270713375s
     - id: 15
       request:
         proto: HTTP/1.1
@@ -573,7 +573,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -581,19 +581,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:28:24.000Z","lastUpdated":"2025-12-21T14:28:24.000Z","expiresAt":"2035-12-21T14:28:24.000Z","kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzCqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82ydQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+FNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJlvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3EiEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxumy2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:50:04.000Z","lastUpdated":"2026-03-03T16:50:04.000Z","expiresAt":"2036-03-03T16:50:04.000Z","kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCBjgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDMbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4IacyrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbdaDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8ifAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0xoSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38noD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:44 GMT
+                - Tue, 03 Mar 2026 16:50:24 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.184952291s
+        duration: 1.324361666s
     - id: 16
       request:
         proto: HTTP/1.1
@@ -606,7 +606,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/ada4234c-a18a-4fca-8b9f-ce95f523a4bd
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/42089b9e-eb70-4f9c-b57a-21a1a62817dc
         method: GET
       response:
         proto: HTTP/2.0
@@ -614,19 +614,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:28:34.000Z","lastUpdated":"2025-12-21T14:28:34.000Z","expiresAt":"2035-12-21T14:28:24.000Z","alg":"RSA","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0\nMjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC\nqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y\ndQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c\n9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT\n7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN\n+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F\nNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl\nvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei\nEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum\ny2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:50:13.000Z","lastUpdated":"2026-03-03T16:50:13.000Z","expiresAt":"2036-03-03T16:50:04.000Z","alg":"RSA","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2\nNTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB\njgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM\nbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy\nrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT\n9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda\nDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237\nBVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if\nAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x\noSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no\nD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:45 GMT
+                - Tue, 03 Mar 2026 16:50:25 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.215428s
+        duration: 1.061858458s
     - id: 17
       request:
         proto: HTTP/1.1
@@ -639,7 +639,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -647,19 +647,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:28:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:47 GMT
+                - Tue, 03 Mar 2026 16:50:26 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.118654167s
+        duration: 1.058227208s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -671,13 +671,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhkndxVEt6Dtq1d7
+                - 0oavraar3uzIOoiYU1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -685,21 +685,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}},{"id":"prmsxhkneg6ob0kRf1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkneg6ob0kRf1d7"}}},{"id":"prmsxhknerILu0JZc1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknerILu0JZc1d7"}}},{"id":"prmsxhknf2tq3Rm841d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknf2tq3Rm841d7"}}},{"id":"prmsxhknfdE66mKWV1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfdE66mKWV1d7"}}},{"id":"prmsxhknfoJHrLblg1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfoJHrLblg1d7"}}},{"id":"prmsxhknfziHZG6PZ1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfziHZG6PZ1d7"}}},{"id":"prmsxhknga75AT0qD1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknga75AT0qD1d7"}}}]'
+        body: '[{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}},{"id":"prmvraar4d3o1RL9p1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4d3o1RL9p1d7"}}},{"id":"prmvraar4oA4deJs91d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4oA4deJs91d7"}}},{"id":"prmvraar4zqNXXBr11d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4zqNXXBr11d7"}}},{"id":"prmvraar5a9b7U8rv1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5a9b7U8rv1d7"}}},{"id":"prmvraar5lmDZo0ui1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5lmDZo0ui1d7"}}},{"id":"prmvraar5wmxlL4on1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5wmxlL4on1d7"}}},{"id":"prmvraar67mCbjgRZ1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar67mCbjgRZ1d7"}}},{"id":"prmvraar6iIMiPw7e1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar6iIMiPw7e1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:48 GMT
+                - Tue, 03 Mar 2026 16:50:28 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.119109291s
+        duration: 1.204079875s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -712,7 +712,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -720,19 +720,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}}'
+        body: '{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:49 GMT
+                - Tue, 03 Mar 2026 16:50:29 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.2316815s
+        duration: 1.14626125s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -745,7 +745,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -753,19 +753,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhz2x2CNv0xmn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_2:0oasxhz2x2CNv0xmn1d7","name":"oie-00_testacc3926115512_2","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:28:25.000Z","created":"2025-12-21T14:28:24.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/alnsxie3t5lO9IJGg1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra886aLMeP9141d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_3:0oavra886aLMeP9141d7","name":"oie-00_testacc3926115512_3","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:50:05.000Z","created":"2026-03-03T16:50:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_3_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_3_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/alnvrar0kgdqMQnLJ1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:50 GMT
+                - Tue, 03 Mar 2026 16:50:30 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.183532917s
+        duration: 1.124038833s
     - id: 21
       request:
         proto: HTTP/1.1
@@ -775,13 +775,13 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+                - ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata?kid=fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata?kid=ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         method: GET
       response:
         proto: HTTP/2.0
@@ -789,23 +789,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxhz2x1AIT70X91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8869C8ZL0PE1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0
-            MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2
+            NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC
-            qAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y
-            dQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c
-            9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT
-            7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN
-            +NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F
-            NiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl
-            vGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei
-            Em73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum
-            y2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB
+            jgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM
+            bZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy
+            rMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT
+            9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda
+            DaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237
+            BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if
+            AbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x
+            oSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no
+            D55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -814,12 +814,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:28:52 GMT
+                - Tue, 03 Mar 2026 16:50:31 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.247220333s
+        duration: 1.333208917s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -832,7 +832,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -840,19 +840,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:28:24.000Z","lastUpdated":"2025-12-21T14:28:24.000Z","expiresAt":"2035-12-21T14:28:24.000Z","kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzCqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82ydQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+FNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJlvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3EiEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxumy2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:50:04.000Z","lastUpdated":"2026-03-03T16:50:04.000Z","expiresAt":"2036-03-03T16:50:04.000Z","kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCBjgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDMbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4IacyrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbdaDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8ifAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0xoSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38noD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:53 GMT
+                - Tue, 03 Mar 2026 16:50:32 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.282737917s
+        duration: 1.057977417s
     - id: 23
       request:
         proto: HTTP/1.1
@@ -865,7 +865,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/ada4234c-a18a-4fca-8b9f-ce95f523a4bd
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/42089b9e-eb70-4f9c-b57a-21a1a62817dc
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,19 +873,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:28:34.000Z","lastUpdated":"2025-12-21T14:28:34.000Z","expiresAt":"2035-12-21T14:28:24.000Z","alg":"RSA","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0\nMjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC\nqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y\ndQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c\n9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT\n7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN\n+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F\nNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl\nvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei\nEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum\ny2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:50:13.000Z","lastUpdated":"2026-03-03T16:50:13.000Z","expiresAt":"2036-03-03T16:50:04.000Z","alg":"RSA","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2\nNTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB\njgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM\nbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy\nrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT\n9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda\nDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237\nBVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if\nAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x\noSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no\nD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:54 GMT
+                - Tue, 03 Mar 2026 16:50:33 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.116182125s
+        duration: 1.090560125s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -898,7 +898,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -906,19 +906,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:28:36.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":true},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":true,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:55 GMT
+                - Tue, 03 Mar 2026 16:50:35 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.106487583s
+        duration: 1.062301625s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -930,13 +930,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhkndxVEt6Dtq1d7
+                - 0oavraar3uzIOoiYU1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -944,21 +944,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}},{"id":"prmsxhkneg6ob0kRf1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkneg6ob0kRf1d7"}}},{"id":"prmsxhknerILu0JZc1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknerILu0JZc1d7"}}},{"id":"prmsxhknf2tq3Rm841d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknf2tq3Rm841d7"}}},{"id":"prmsxhknfdE66mKWV1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfdE66mKWV1d7"}}},{"id":"prmsxhknfoJHrLblg1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfoJHrLblg1d7"}}},{"id":"prmsxhknfziHZG6PZ1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfziHZG6PZ1d7"}}},{"id":"prmsxhknga75AT0qD1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknga75AT0qD1d7"}}}]'
+        body: '[{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}},{"id":"prmvraar4d3o1RL9p1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4d3o1RL9p1d7"}}},{"id":"prmvraar4oA4deJs91d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4oA4deJs91d7"}}},{"id":"prmvraar4zqNXXBr11d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4zqNXXBr11d7"}}},{"id":"prmvraar5a9b7U8rv1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5a9b7U8rv1d7"}}},{"id":"prmvraar5lmDZo0ui1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5lmDZo0ui1d7"}}},{"id":"prmvraar5wmxlL4on1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5wmxlL4on1d7"}}},{"id":"prmvraar67mCbjgRZ1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar67mCbjgRZ1d7"}}},{"id":"prmvraar6iIMiPw7e1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar6iIMiPw7e1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:56 GMT
+                - Tue, 03 Mar 2026 16:50:36 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.167635292s
+        duration: 1.112527208s
     - id: 26
       request:
         proto: HTTP/1.1
@@ -971,7 +971,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -979,28 +979,28 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}}'
+        body: '{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:58 GMT
+                - Tue, 03 Mar 2026 16:50:37 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.200471416s
+        duration: 1.100489875s
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1046
+        content_length: 1066
         host: oie-00.dne-okta.com
         body: |
-            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":60,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","issuer":"https://idp.example.com/issuer","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com/test","url":"https://idp.example.com/test"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
+            {"issuerMode":"ORG_URL","name":"testAcc_3926115512","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":60,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}},"trustClaims":false},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"credentials":{"trust":{"audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","issuer":"https://idp.example.com/issuer","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com/test","url":"https://idp.example.com/test"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
         headers:
             Accept:
                 - application/json
@@ -1008,7 +1008,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1016,19 +1016,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":null,"lastUpdated":"2025-12-21T14:28:59.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":null,"lastUpdated":"2026-03-03T16:50:38.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:28:59 GMT
+                - Tue, 03 Mar 2026 16:50:38 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.433725375s
+        duration: 1.375906625s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1041,7 +1041,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1049,19 +1049,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:28:59.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:38.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:00 GMT
+                - Tue, 03 Mar 2026 16:50:39 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.124080542s
+        duration: 1.094138166s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1073,13 +1073,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhkndxVEt6Dtq1d7
+                - 0oavraar3uzIOoiYU1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1087,21 +1087,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}},{"id":"prmsxhkneg6ob0kRf1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkneg6ob0kRf1d7"}}},{"id":"prmsxhknerILu0JZc1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknerILu0JZc1d7"}}},{"id":"prmsxhknf2tq3Rm841d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknf2tq3Rm841d7"}}},{"id":"prmsxhknfdE66mKWV1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfdE66mKWV1d7"}}},{"id":"prmsxhknfoJHrLblg1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfoJHrLblg1d7"}}},{"id":"prmsxhknfziHZG6PZ1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfziHZG6PZ1d7"}}},{"id":"prmsxhknga75AT0qD1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknga75AT0qD1d7"}}}]'
+        body: '[{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}},{"id":"prmvraar4d3o1RL9p1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4d3o1RL9p1d7"}}},{"id":"prmvraar4oA4deJs91d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4oA4deJs91d7"}}},{"id":"prmvraar4zqNXXBr11d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4zqNXXBr11d7"}}},{"id":"prmvraar5a9b7U8rv1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5a9b7U8rv1d7"}}},{"id":"prmvraar5lmDZo0ui1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5lmDZo0ui1d7"}}},{"id":"prmvraar5wmxlL4on1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5wmxlL4on1d7"}}},{"id":"prmvraar67mCbjgRZ1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar67mCbjgRZ1d7"}}},{"id":"prmvraar6iIMiPw7e1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar6iIMiPw7e1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:01 GMT
+                - Tue, 03 Mar 2026 16:50:41 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.12980375s
+        duration: 1.117030875s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1114,7 +1114,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1122,19 +1122,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}}'
+        body: '{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:03 GMT
+                - Tue, 03 Mar 2026 16:50:42 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.118112042s
+        duration: 1.162592583s
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1147,7 +1147,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1155,19 +1155,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhz2x2CNv0xmn1d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_2:0oasxhz2x2CNv0xmn1d7","name":"oie-00_testacc3926115512_2","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2025-12-21T14:28:25.000Z","created":"2025-12-21T14:28:24.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_2/0oasxhz2x2CNv0xmn1d7/alnsxie3t5lO9IJGg1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/lifecycle/deactivate"}}}'
+        body: '{"id":"0oavra886aLMeP9141d7","orn":"orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oie-00_testacc3926115512_3:0oavra886aLMeP9141d7","name":"oie-00_testacc3926115512_3","label":"testAcc_3926115512","status":"ACTIVE","lastUpdated":"2026-03-03T16:50:05.000Z","created":"2026-03-03T16:50:04.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3926115512_3_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":"","ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3926115512_3_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3926115512_3/0oavra886aLMeP9141d7/alnvrar0kgdqMQnLJ1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgzCwhJaUs1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstnkw1sgxfqkDUtx1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/lifecycle/deactivate"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:04 GMT
+                - Tue, 03 Mar 2026 16:50:43 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.133494792s
+        duration: 1.098101417s
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1177,13 +1177,13 @@ interactions:
         host: oie-00.dne-okta.com
         form:
             kid:
-                - fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+                - ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         headers:
             Accept:
                 - application/xml
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/sso/saml/metadata?kid=fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/sso/saml/metadata?kid=ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk
         method: GET
       response:
         proto: HTTP/2.0
@@ -1191,23 +1191,23 @@ interactions:
         proto_minor: 0
         content_length: 2363
         body: |-
-            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exksxhz2x1AIT70X91d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkvra8869C8ZL0PE1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG
             A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
             MBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2
-            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0
-            MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
+            MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2
+            NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g
             RnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa
             ZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w
-            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC
-            qAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y
-            dQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c
-            9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT
-            7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN
-            +NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F
-            NiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl
-            vGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei
-            Em73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum
-            y2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_2/exksxhz2x1AIT70X91d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+            ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB
+            jgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM
+            bZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy
+            rMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT
+            9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda
+            DaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237
+            BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if
+            AbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x
+            oSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no
+            D55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3926115512_3/exkvra8869C8ZL0PE1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -1216,12 +1216,12 @@ interactions:
             Content-Type:
                 - application/xml;charset=ISO-8859-1
             Date:
-                - Sun, 21 Dec 2025 14:29:05 GMT
+                - Tue, 03 Mar 2026 16:50:44 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.269657417s
+        duration: 1.275413042s
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1234,7 +1234,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/credentials/keys
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/credentials/keys
         method: GET
       response:
         proto: HTTP/2.0
@@ -1242,19 +1242,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"kty":"RSA","created":"2025-12-21T14:28:24.000Z","lastUpdated":"2025-12-21T14:28:24.000Z","expiresAt":"2035-12-21T14:28:24.000Z","kid":"fTYuF5eQcvs7VbtPw_AdvnE-9_wdwEyCzaMrUNPs_h4","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0MjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzCqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82ydQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+FNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJlvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3EiEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxumy2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}]'
+        body: '[{"kty":"RSA","created":"2026-03-03T16:50:04.000Z","lastUpdated":"2026-03-03T16:50:04.000Z","expiresAt":"2036-03-03T16:50:04.000Z","kid":"ZL4u-6mmQ_Y05EitHWcHWpi6cPlEDOTdDVr8Kh1-5Rk","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2NTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwaZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCBjgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDMbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4IacyrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbdaDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237BVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8ifAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0xoSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38noD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:06 GMT
+                - Tue, 03 Mar 2026 16:50:46 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.339503542s
+        duration: 1.280486333s
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1267,7 +1267,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/ada4234c-a18a-4fca-8b9f-ce95f523a4bd
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/42089b9e-eb70-4f9c-b57a-21a1a62817dc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1275,19 +1275,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"kty":"RSA","created":"2025-12-21T14:28:34.000Z","lastUpdated":"2025-12-21T14:28:34.000Z","expiresAt":"2035-12-21T14:28:24.000Z","alg":"RSA","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZtBT8GxMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI1MTIyMTE0MjcyNFoXDTM1MTIyMTE0\nMjgyNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCrJuJUEWq6TaRbU5UXgONuMAVXxpTJbUzC\nqAPCkUaiwJyiJhNrXPwlomjkkNYQgASVc4M9ME85OV9xskAioKAJIwEU16oUjIlQjayoaOsjt82y\ndQ7hQF0m1+him4IWZcZ5RUPTYVu0P+RbV1R6nKoeGPDLmmK/CF2LKXLgyjQ1790IvMveB+q1BC8c\n9HD8Bl0A7Mfz12XB87npMhAwRmYxXQDvc2+O+8AZ63fTgHJvp3ev+pk8SL5+GY/3K5lkGE+N5zvT\n7UoCUsL9EijbEtZRgxcUzflUa5fP3eQ4KI8FOz7K9ATd3pGPxH6ximSkwRhv7TpPPaKuRDgcsnaN\n+NRvAgMBAAEwDQYJKoZIhvcNAQELBQADggEBACkLenEg127zsZyFLgyKS1xw4eUV/TENjHp1Pt+F\nNiaVtzvsrGOTn89Y3fGXzSaxilZSSOauqhfcl5ykYLtkE0SFimU8E8Z1+J1VA+r3aRKLzlKkeeJl\nvGyZar4KNsNrIaGvL4lQsqiv6l6jZcnqnk7gJNNnaGptnJ/DGpKeYQ7iqOB5Jyy1pZ0ppoYcS3Ei\nEm73BxDTK8mkLZUO+Z4XfxvXub/WXoOhrM31+VuJgNlFSHAYEmnk8QrclDv4AELUJyDvTpE+Vxum\ny2WCf+5g2/kMqm12Pja8kIOn7aGxIRDfycvE6rlT7pVKwU5G3X8vfU/djfuFNlP8Oyf2qV1mY+0="],"x5t#S256":"DyWioexO5qWXx82n7AOI3ErkXVQvHHtoCAphP6QRbMg","e":"AQAB","n":"qybiVBFquk2kW1OVF4DjbjAFV8aUyW1MwqgDwpFGosCcoiYTa1z8JaJo5JDWEIAElXODPTBPOTlfcbJAIqCgCSMBFNeqFIyJUI2sqGjrI7fNsnUO4UBdJtfoYpuCFmXGeUVD02FbtD_kW1dUepyqHhjwy5pivwhdiyly4Mo0Ne_dCLzL3gfqtQQvHPRw_AZdAOzH89dlwfO56TIQMEZmMV0A73NvjvvAGet304Byb6d3r_qZPEi-fhmP9yuZZBhPjec70-1KAlLC_RIo2xLWUYMXFM35VGuXz93kOCiPBTs-yvQE3d6Rj8R-sYpkpMEYb-06Tz2irkQ4HLJ2jfjUbw"}'
+        body: '{"kty":"RSA","created":"2026-03-03T16:50:13.000Z","lastUpdated":"2026-03-03T16:50:13.000Z","expiresAt":"2036-03-03T16:50:04.000Z","alg":"RSA","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","use":"sig","x5c":["MIIDxDCCAqygAwIBAgIGAZy0m1WlMA0GCSqGSIb3DQEBCwUAMIGiMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIzAhBgNVBAMMGmRjcC10ZXN0aW5nLW9pZy0yMDI1LTA2LTI2\nMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI2MDMwMzE2NDkwNFoXDTM2MDMwMzE2\nNTAwNFowgaIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\nRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEjMCEGA1UEAwwa\nZGNwLXRlc3Rpbmctb2lnLTIwMjUtMDYtMjYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20w\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4Fq/0YLkmgw8b6EMtxREpiURB1IxXTpCB\njgIDlA3DdplO6HlratwcVHebHil6rNIZqHyv9JwzX9gZMN64bGAzwLz0dCyl3liiGhH456UzEIDM\nbZkovGtZ+ndmbO/73y/mltJncKsxPgLm7qunqdionA4P1t4fIDZjFoCYUZ4+fi7XPCns79L4Iacy\nrMknPyJADXkRqZ1eGOWMwaRfDGwdtH92CH0LwwPZnPAt3jrZujUESAD84ChO/DeKuDwpS5RSgbxT\n9gjHF7WEJk+5EO1md3UkBMpvPRd1RX+Mco0nmL/NT2SAl5iopo0ZUidJ5IwzCXpmk/z4jTufUbda\nDaCTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADlNb3xsXSi71vtM41yf0wyGR5TpT5/wJfVR1237\nBVEzxXLdbvHV5Q9KrYtsIILzu5WGA2M/CVCpH/xI/pY+mQBZrkPm6yO1f3DGjHgdjgsMCGOQh8if\nAbbXiOcVfv1p2Qzs5V48z7yhjIL+WLJW5zJ7UMDWnZuwYKBxLkH8M/AE8Yxiw5Z+o6SNhiTnJO0x\noSJ+/R6AFBfAnkpkuztDoN5N8v2ZsnNHUViJxdxo/43qhbjhrc2qyAHLMm63cM6iJ8CYkdjh38no\nD55oK+hUWBo+zp4grEnyJv69wP8bMKpjuYQV92FmJ2vCVuDRfRPYcJd73b1//Wz9xAK+y1k0IrI="],"x5t#S256":"b0aH9LEDU6FqmAibHuSH_DkCQBNPg-g8pVPA2LEUuyk","e":"AQAB","n":"uBav9GC5JoMPG-hDLcURKYlEQdSMV06QgY4CA5QNw3aZTuh5a2rcHFR3mx4peqzSGah8r_ScM1_YGTDeuGxgM8C89HQspd5YohoR-OelMxCAzG2ZKLxrWfp3Zmzv-98v5pbSZ3CrMT4C5u6rp6nYqJwOD9beHyA2YxaAmFGePn4u1zwp7O_S-CGnMqzJJz8iQA15EamdXhjljMGkXwxsHbR_dgh9C8MD2ZzwLd462bo1BEgA_OAoTvw3irg8KUuUUoG8U_YIxxe1hCZPuRDtZnd1JATKbz0XdUV_jHKNJ5i_zU9kgJeYqKaNGVInSeSMMwl6ZpP8-I07n1G3Wg2gkw"}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:08 GMT
+                - Tue, 03 Mar 2026 16:50:47 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.065759083s
+        duration: 1.051422375s
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1300,7 +1300,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1308,19 +1308,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:28:59.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:38.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:09 GMT
+                - Tue, 03 Mar 2026 16:50:48 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.108897667s
+        duration: 1.15154775s
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1332,13 +1332,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhkndxVEt6Dtq1d7
+                - 0oavraar3uzIOoiYU1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1346,21 +1346,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}},{"id":"prmsxhkneg6ob0kRf1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkneg6ob0kRf1d7"}}},{"id":"prmsxhknerILu0JZc1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknerILu0JZc1d7"}}},{"id":"prmsxhknf2tq3Rm841d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknf2tq3Rm841d7"}}},{"id":"prmsxhknfdE66mKWV1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfdE66mKWV1d7"}}},{"id":"prmsxhknfoJHrLblg1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfoJHrLblg1d7"}}},{"id":"prmsxhknfziHZG6PZ1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfziHZG6PZ1d7"}}},{"id":"prmsxhknga75AT0qD1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknga75AT0qD1d7"}}}]'
+        body: '[{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}},{"id":"prmvraar4d3o1RL9p1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4d3o1RL9p1d7"}}},{"id":"prmvraar4oA4deJs91d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4oA4deJs91d7"}}},{"id":"prmvraar4zqNXXBr11d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4zqNXXBr11d7"}}},{"id":"prmvraar5a9b7U8rv1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5a9b7U8rv1d7"}}},{"id":"prmvraar5lmDZo0ui1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5lmDZo0ui1d7"}}},{"id":"prmvraar5wmxlL4on1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5wmxlL4on1d7"}}},{"id":"prmvraar67mCbjgRZ1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar67mCbjgRZ1d7"}}},{"id":"prmvraar6iIMiPw7e1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar6iIMiPw7e1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:10 GMT
+                - Tue, 03 Mar 2026 16:50:49 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.136713875s
+        duration: 1.131211667s
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1373,7 +1373,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1381,19 +1381,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}}'
+        body: '{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:11 GMT
+                - Tue, 03 Mar 2026 16:50:50 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.137035583s
+        duration: 1.182518625s
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1406,7 +1406,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1414,19 +1414,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:28:59.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"ACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:38.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:12 GMT
+                - Tue, 03 Mar 2026 16:50:51 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.070032958s
+        duration: 1.134350708s
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1438,13 +1438,13 @@ interactions:
             limit:
                 - "200"
             sourceId:
-                - 0oasxhkndxVEt6Dtq1d7
+                - 0oavraar3uzIOoiYU1d7
         headers:
             Accept:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oavraar3uzIOoiYU1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1452,21 +1452,21 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '[{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}},{"id":"prmsxhkneg6ob0kRf1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkneg6ob0kRf1d7"}}},{"id":"prmsxhknerILu0JZc1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknerILu0JZc1d7"}}},{"id":"prmsxhknf2tq3Rm841d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknf2tq3Rm841d7"}}},{"id":"prmsxhknfdE66mKWV1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfdE66mKWV1d7"}}},{"id":"prmsxhknfoJHrLblg1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfoJHrLblg1d7"}}},{"id":"prmsxhknfziHZG6PZ1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknfziHZG6PZ1d7"}}},{"id":"prmsxhknga75AT0qD1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhknga75AT0qD1d7"}}}]'
+        body: '[{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}},{"id":"prmvraar4d3o1RL9p1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi4uwusluHu4nz1d7","name":"python_sdk_aAaewb","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi4uwusluHu4nz1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi4uwusluHu4nz1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4d3o1RL9p1d7"}}},{"id":"prmvraar4oA4deJs91d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5161q2sER2PB1d7","name":"python_sdk_XfloX","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5161q2sER2PB1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5161q2sER2PB1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4oA4deJs91d7"}}},{"id":"prmvraar4zqNXXBr11d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi54hjauytDuO11d7","name":"python_sdk_zEVAT","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi54hjauytDuO11d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi54hjauytDuO11d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar4zqNXXBr11d7"}}},{"id":"prmvraar5a9b7U8rv1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi57o8eZpQCEbJ1d7","name":"python_sdk_cRuLD","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi57o8eZpQCEbJ1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi57o8eZpQCEbJ1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5a9b7U8rv1d7"}}},{"id":"prmvraar5lmDZo0ui1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5as0w2iwlwJx1d7","name":"python_sdk_akIKx","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5as0w2iwlwJx1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5as0w2iwlwJx1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5lmDZo0ui1d7"}}},{"id":"prmvraar5wmxlL4on1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyqi5dz28AZXBD5h1d7","name":"python_sdk_JWXbL","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyqi5dz28AZXBD5h1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscqi5dz28AZXBD5h1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar5wmxlL4on1d7"}}},{"id":"prmvraar67mCbjgRZ1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otysrzz1n69gnJOOD1d7","name":"t","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otysrzz1n69gnJOOD1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscsrzz1n69gnJOOD1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar67mCbjgRZ1d7"}}},{"id":"prmvraar6iIMiPw7e1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otyvovl06nsgdLpY21d7","name":"testAcc_987182423","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otyvovl06nsgdLpY21d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscvovl06nsgdLpY21d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar6iIMiPw7e1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:14 GMT
+                - Tue, 03 Mar 2026 16:50:53 GMT
             Link:
                 - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.244442834s
+        duration: 1.238836209s
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1479,7 +1479,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -1487,19 +1487,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"prmsxhkne5rOxgYES1d7","source":{"id":"0oasxhkndxVEt6Dtq1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oasxhkndxVEt6Dtq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oasxhkndxVEt6Dtq1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmsxhkne5rOxgYES1d7"}}}'
+        body: '{"id":"prmvraar42EHFmNNz1d7","source":{"id":"0oavraar3uzIOoiYU1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oavraar3uzIOoiYU1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oavraar3uzIOoiYU1d7/default"}}},"target":{"id":"otynkw1sdzpoFCZMq1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmvraar42EHFmNNz1d7"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:15 GMT
+                - Tue, 03 Mar 2026 16:50:54 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.209512917s
+        duration: 1.1854265s
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1512,7 +1512,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1520,19 +1520,19 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"0oasxhkndxVEt6Dtq1d7","name":"testAcc_3926115512","status":"INACTIVE","created":"2025-12-21T14:28:36.000Z","lastUpdated":"2025-12-21T14:29:16.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/spuldtfzayqyyrujktye","kid":"ada4234c-a18a-4fca-8b9f-ce95f523a4bd","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oasxhkndxVEt6Dtq1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
+        body: '{"id":"0oavraar3uzIOoiYU1d7","name":"testAcc_3926115512","status":"INACTIVE","created":"2026-03-03T16:50:16.000Z","lastUpdated":"2026-03-03T16:50:55.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com/test","binding":"HTTP-POST","destination":"https://idp.example.com/test"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"RESPONSE"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com/issuer","audience":"https://www.okta.com/saml2/service-provider/sppexbihsgjbarimpljv","kid":"42089b9e-eb70-4f9c-b57a-21a1a62817dc","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"b-aWcq9q5sjB_wfWfazE-KJC4wRL5bDSuySCSVIOqFo"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":60,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oavraar3uzIOoiYU1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:16 GMT
+                - Tue, 03 Mar 2026 16:50:55 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.228993708s
+        duration: 1.127863417s
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1545,7 +1545,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/0oasxhkndxVEt6Dtq1d7
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oavraar3uzIOoiYU1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1557,12 +1557,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:29:18 GMT
+                - Tue, 03 Mar 2026 16:50:57 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.600020334s
+        duration: 1.587598208s
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1575,7 +1575,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/ada4234c-a18a-4fca-8b9f-ce95f523a4bd
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/42089b9e-eb70-4f9c-b57a-21a1a62817dc
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1587,12 +1587,12 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:29:19 GMT
+                - Tue, 03 Mar 2026 16:50:58 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.098424541s
+        duration: 1.1430925s
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1605,7 +1605,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7/lifecycle/deactivate
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7/lifecycle/deactivate
         method: POST
       response:
         proto: HTTP/2.0
@@ -1620,12 +1620,12 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Sun, 21 Dec 2025 14:29:20 GMT
+                - Tue, 03 Mar 2026 16:50:59 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
-        duration: 1.129223792s
+        duration: 1.164539917s
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1638,7 +1638,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/apps/0oasxhz2x2CNv0xmn1d7
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oavra886aLMeP9141d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1650,9 +1650,9 @@ interactions:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Date:
-                - Sun, 21 Dec 2025 14:29:22 GMT
+                - Tue, 03 Mar 2026 16:51:01 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 1.824052209s
+        duration: 1.81603675s


### PR DESCRIPTION
**Description**
Adds support for the trust_claims attribute on SAML and OIDC Identity Provider resources and data sources. This attribute controls whether to trust authentication claims from the IdP, mapping to the trustClaims field in the Okta Identity Provider Policy API.
