### PR TITLE
Fix okta_app_oauth creation failure with OAuth 2.0 auth

### DIFF
--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -517,6 +517,10 @@ func setAppOauthGroupsClaim(ctx context.Context, d *schema.ResourceData, meta in
 	apiSupplement := getAPISupplementFromMetadata(meta)
 	appID := d.Id()
 	if !ok {
+		c, ok2 := meta.(*config.Config)
+		if ok2 && c.IsOAuth20Auth() {
+			return nil
+		}
 		gc := &sdk.AppOauthGroupClaim{
 			Name:      "",
 			Value:     "",


### PR DESCRIPTION
Fixes #2705

App OAuth groups claim logic doesn't apply to OAuth 2.0 auth. Added an early return when using that auth method to prevent the invalid session error.