### PR TITLE
fixes issues causing failure of creation of OAuth application

### DIFF
--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -514,8 +514,18 @@ func resourceAppOAuthCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func setAppOauthGroupsClaim(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	raw, ok := d.GetOk("groups_claim")
+	// Log deprecation warning
+	logger(meta).Warn("groups_claim is deprecated and will be removed in a future version. Please use Authorization Server Claims (okta_auth_server_claim) or app profile configuration instead.")
+
+	c := meta.(*config.Config)
+	if c.IsOAuth20Auth() {
+		logger(meta).Warn("setting groups_claim disabled with OAuth 2.0 API authentication")
+		return nil
+	}
+
 	apiSupplement := getAPISupplementFromMetadata(meta)
 	appID := d.Id()
+
 	if !ok {
 		gc := &sdk.AppOauthGroupClaim{
 			Name:      "",
@@ -536,15 +546,6 @@ func setAppOauthGroupsClaim(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return fmt.Errorf("failed to update groups claim for an OAuth application: %v", err)
 		}
-		return nil
-	}
-
-	// Log deprecation warning
-	logger(meta).Warn("groups_claim is deprecated and will be removed in a future version. Please use Authorization Server Claims (okta_auth_server_claim) or app profile configuration instead.")
-
-	c := meta.(*config.Config)
-	if c.IsOAuth20Auth() {
-		logger(meta).Warn("setting groups_claim disabled with OAuth 2.0 API authentication")
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #2705 

Problem: The IsOAuth20Auth() check was placed after the code path that handles empty groups_claim, so the internal API was called regardless of authentication method.

The Fix
Move the IsOAuth20Auth() check to the beginning of the function, before any API calls.

<img width="921" height="157" alt="Screenshot 2026-03-08 at 7 51 53 PM" src="https://github.com/user-attachments/assets/3bf11231-bfee-4f9f-ad17-b915a33b42c0" />
