### PR TITLE
fix: restore limit=10000 for q-based searches in okta_groups datasour…

### DIFF
--- a/okta/services/idaas/data_source_okta_groups.go
+++ b/okta/services/idaas/data_source_okta_groups.go
@@ -106,7 +106,7 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if q, ok := d.GetOk("q"); ok {
 		qp.Limit = 10000 // keeping this here to avoid potentially changing datasource ID generation behavior
-		apiRequest = apiRequest.Q(q.(string))
+		apiRequest = apiRequest.Q(q.(string)).Limit(10000)
 		qp.Q = q.(string)
 	}
 

--- a/okta/services/idaas/data_source_okta_groups_unit_test.go
+++ b/okta/services/idaas/data_source_okta_groups_unit_test.go
@@ -1,0 +1,124 @@
+package idaas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	oktav4 "github.com/okta/okta-sdk-golang/v4/okta"
+	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
+	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
+	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/sdk"
+)
+
+type testIDaaSClient struct {
+	v5Client *v5okta.APIClient
+}
+
+func (m *testIDaaSClient) OktaSDKClientV6() *v6okta.APIClient        { return nil }
+func (m *testIDaaSClient) OktaSDKClientV5() *v5okta.APIClient         { return m.v5Client }
+func (m *testIDaaSClient) OktaSDKClientV3() *oktav4.APIClient         { return nil }
+func (m *testIDaaSClient) OktaSDKClientV2() *sdk.Client               { return nil }
+func (m *testIDaaSClient) OktaSDKSupplementClient() *sdk.APISupplement { return nil }
+
+// newTestV5Client creates a V5 API client pointed at the given test server.
+// We patch cfg.Host after creation because the V5 SDK's NewConfiguration
+// calls url.Hostname() which strips the port.
+func newTestV5Client(t *testing.T, serverURL string) *v5okta.APIClient {
+	v5Cfg, err := v5okta.NewConfiguration(
+		v5okta.WithOrgUrl(serverURL),
+		v5okta.WithToken("test-token"),
+		v5okta.WithAuthorizationMode("SSWS"),
+		v5okta.WithTestingDisableHttpsCheck(true),
+		v5okta.WithCache(false),
+	)
+	if err != nil {
+		t.Fatalf("creating V5 config: %v", err)
+	}
+	purl, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parsing server URL: %v", err)
+	}
+	v5Cfg.Host = purl.Host
+	return v5okta.NewAPIClient(v5Cfg)
+}
+
+func newTestMeta(t *testing.T, serverURL string) *config.Config {
+	meta := &config.Config{}
+	meta.SetIdaasAPIClient(&testIDaaSClient{v5Client: newTestV5Client(t, serverURL)})
+	return meta
+}
+
+func makeGroupJSON(id, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   id,
+		"type": "OKTA_GROUP",
+		"profile": map[string]interface{}{
+			"name":        name,
+			"description": "test group",
+		},
+	}
+}
+
+// https://github.com/okta/terraform-provider-okta/issues/2673
+func TestDataSourceGroupsRead_QParameterLimit(t *testing.T) {
+	var mu sync.Mutex
+	var receivedLimit string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		receivedLimit = r.URL.Query().Get("limit")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]interface{}{})
+	}))
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, dataSourceGroups().Schema, map[string]interface{}{
+		"q": "aws-",
+	})
+	diags := dataSourceGroupsRead(context.Background(), d, newTestMeta(t, server.URL))
+	if diags.HasError() {
+		t.Fatalf("dataSourceGroupsRead returned errors: %v", diags)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if receivedLimit != "10000" {
+		t.Fatalf("q-based search should send limit=10000 to Okta API, but sent limit=%s", receivedLimit)
+	}
+}
+
+func TestDataSourceGroupsRead_QParameterReturnsAllGroups(t *testing.T) {
+	const totalGroups = 300
+	allGroups := make([]map[string]interface{}, totalGroups)
+	for i := range allGroups {
+		allGroups[i] = makeGroupJSON(fmt.Sprintf("group-%03d", i), fmt.Sprintf("aws-group-%03d", i))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(allGroups)
+	}))
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, dataSourceGroups().Schema, map[string]interface{}{
+		"q": "aws-",
+	})
+	diags := dataSourceGroupsRead(context.Background(), d, newTestMeta(t, server.URL))
+	if diags.HasError() {
+		t.Fatalf("dataSourceGroupsRead returned errors: %v", diags)
+	}
+
+	groups := d.Get("groups").([]interface{})
+	if len(groups) != totalGroups {
+		t.Fatalf("expected %d groups, got %d", totalGroups, len(groups))
+	}
+}


### PR DESCRIPTION
PR #2281 refactored the groups datasource from the old SDK to V5, but accidentally decoupled the q-parameter limit override from the actual API request. The line `qp.Limit = 10000` was preserved for datasource ID generation only, while apiRequest.Limit() stayed at the default 200.

This caused users with >200 groups matching a q-filter to silently receive truncated results, since the Okta API does not reliably return Link: next headers for q-based searches at the default page size.