### PR TITLE
okta_app_oauth - Adds Support for Network

### DIFF
--- a/docs/data-sources/app_oauth.md
+++ b/docs/data-sources/app_oauth.md
@@ -50,6 +50,7 @@ data "okta_app_oauth" "test" {
 - `login_uri` (String) URI that initiates login.
 - `logo_uri` (String) URI that references a logo for the client.
 - `name` (String) Name of application.
+- `network` (List of Object) Network restrictions for the application client. (see [below for nested schema](#nestedblock--network))
 - `policy_uri` (String) URI to web page providing client policy document.
 - `post_logout_redirect_uris` (Set of String) List of URIs for redirection after logout
 - `redirect_uris` (Set of String) List of URIs for use in the redirect-based flow.
@@ -59,3 +60,11 @@ data "okta_app_oauth" "test" {
 - `wildcard_redirect` (String) Indicates if the client is allowed to use wildcard matching of redirect_uris. Some valid values include: "SUBDOMAIN", "DISABLED".
 
 
+<a id="nestedblock--network"></a>
+### Nested Schema for `network`
+
+Read-Only:
+
+- `connection` (String) The network connection type. Can be `ANYWHERE` or `ZONE`.
+- `exclude` (Set of String) IP zones to exclude when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.
+- `include` (Set of String) IP zones to include when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.

--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -96,6 +96,7 @@ resource "okta_app_oauth" "example" {
 - `login_uri` (String) URI that initiates login.
 - `logo` (String) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 - `logo_uri` (String) URI that references a logo for the client.
+- `network` (Block List, Max: 1) Network restrictions for the application client. (see [below for nested schema](#nestedblock--network))
 - `omit_secret` (Boolean) This tells the provider not manage the client_secret value in state. When this is false (the default), it will cause the auto-generated client_secret to be persisted in the client_secret attribute in state. This also means that every time an update to this app is run, this value is also set on the API. If this changes from false => true, the `client_secret` is dropped from state and the secret at the time of the apply is what remains. If this is ever changes from true => false your app will be recreated, due to the need to regenerate a secret we can store in state.
 - `pkce_required` (Boolean) Require Proof Key for Code Exchange (PKCE) for additional verification key rotation mode. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
 - `policy_uri` (String) URI to web page providing client policy document.
@@ -159,6 +160,19 @@ Optional:
 - `n` (String) RSA Modulus
 - `x` (String) X coordinate of the elliptic curve point
 - `y` (String) Y coordinate of the elliptic curve point
+
+
+<a id="nestedblock--network"></a>
+### Nested Schema for `network`
+
+Required:
+
+- `connection` (String) The network connection type. Can be `ANYWHERE` or `ZONE`.
+
+Optional:
+
+- `exclude` (Set of String) IP zones to exclude when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.
+- `include` (Set of String) IP zones to include when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/examples/resources/okta_app_oauth/basic.tf
+++ b/examples/resources/okta_app_oauth/basic.tf
@@ -15,4 +15,7 @@ resource "okta_app_oauth" "test" {
     value = "aa"
     name  = "bb"
   }
+  network {
+    connection = "ANYWHERE"
+  }
 }

--- a/examples/resources/okta_app_oauth/blank_custom_attributes.tf
+++ b/examples/resources/okta_app_oauth/blank_custom_attributes.tf
@@ -8,4 +8,7 @@ resource "okta_app_oauth" "test" {
   consent_method             = "TRUSTED"
   issuer_mode                = "ORG_URL"
   wildcard_redirect          = "DISABLED"
+  network {
+    connection = "ANYWHERE"
+  }
 }

--- a/examples/resources/okta_app_oauth/custom_attributes.tf
+++ b/examples/resources/okta_app_oauth/custom_attributes.tf
@@ -8,6 +8,9 @@ resource "okta_app_oauth" "test" {
   consent_method             = "TRUSTED"
   issuer_mode                = "ORG_URL"
   wildcard_redirect          = "DISABLED"
+  network {
+    connection = "ANYWHERE"
+  }
 
   profile = <<JSON
   {

--- a/examples/resources/okta_app_oauth/group_for_groups_claim.tf
+++ b/examples/resources/okta_app_oauth/group_for_groups_claim.tf
@@ -19,6 +19,9 @@ resource "okta_app_oauth" "test" {
   consent_method             = "TRUSTED"
   issuer_mode                = "ORG_URL"
   wildcard_redirect          = "DISABLED"
+  network {
+    connection = "ANYWHERE"
+  }
 
   profile = <<JSON
    {

--- a/examples/resources/okta_app_oauth/remove_custom_attributes.tf
+++ b/examples/resources/okta_app_oauth/remove_custom_attributes.tf
@@ -8,4 +8,7 @@ resource "okta_app_oauth" "test" {
   consent_method             = "TRUSTED"
   issuer_mode                = "ORG_URL"
   wildcard_redirect          = "DISABLED"
+  network {
+    connection = "ANYWHERE"
+  }
 }

--- a/examples/resources/okta_app_oauth/updated.tf
+++ b/examples/resources/okta_app_oauth/updated.tf
@@ -13,4 +13,7 @@ resource "okta_app_oauth" "test" {
   participate_slo                      = true
   frontchannel_logout_uri              = "https://*.example.com/logout"
   frontchannel_logout_session_required = true
+  network {
+    connection = "ANYWHERE"
+  }
 }

--- a/okta/services/idaas/data_source_okta_app_oauth.go
+++ b/okta/services/idaas/data_source_okta_app_oauth.go
@@ -154,6 +154,32 @@ func dataSourceAppOauth() *schema.Resource {
 				Computed:    true,
 				Description: "Indicates if the client is allowed to use wildcard matching of redirect_uris. Some valid values include: \"SUBDOMAIN\", \"DISABLED\".",
 			},
+			"network": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Network restrictions for the application client.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"connection": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The network connection type. Can be `ANYWHERE` or `ZONE`.",
+						},
+						"include": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "IP zones to include when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.",
+						},
+						"exclude": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "IP zones to exclude when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.",
+						},
+					},
+				},
+			},
 		}),
 		Description: "Get a OIDC application from Okta.",
 	}
@@ -246,6 +272,17 @@ func dataSourceAppOauthRead(ctx context.Context, d *schema.ResourceData, meta in
 	err = utils.SetNonPrimitives(d, aggMap)
 	if err != nil {
 		return diag.Errorf("failed to set OAuth application properties: %v", err)
+	}
+	if app.Settings.OauthClient != nil && app.Settings.OauthClient.Network != nil {
+		network := app.Settings.OauthClient.Network
+		networkMap := map[string]interface{}{
+			"connection": network.Connection,
+			"include":    utils.ConvertStringSliceToSet(network.Include),
+			"exclude":    utils.ConvertStringSliceToSet(network.Exclude),
+		}
+		if err := utils.SetNonPrimitives(d, map[string]interface{}{"network": []interface{}{networkMap}}); err != nil {
+			return diag.Errorf("failed to set OAuth application network properties: %v", err)
+		}
 	}
 	p, _ := json.Marshal(app.Links)
 	_ = d.Set("links", string(p))

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -424,6 +424,34 @@ other arguments that changed will be applied.`,
 				Optional:    true,
 				Description: "URL reference to JWKS",
 			},
+			"network": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Network restrictions for the application client.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"connection": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The network connection type. Can be `ANYWHERE` or `ZONE`.",
+							ValidateFunc: validation.StringInSlice([]string{"ANYWHERE", "ZONE"}, false),
+						},
+						"include": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "IP zones to include when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.",
+						},
+						"exclude": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "IP zones to exclude when `connection` is `ZONE`. Can be `ALL_IP_ZONES` or specific zone IDs.",
+						},
+					},
+				},
+			},
 		}),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Hour),
@@ -787,6 +815,17 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 		return diag.Errorf("failed to set OAuth application properties: %v", err)
 	}
 
+	if network, ok := oauthClient.GetNetworkOk(); ok && network != nil {
+		networkMap := map[string]interface{}{
+			"connection": network.GetConnection(),
+			"include":    utils.ConvertStringSliceToSet(network.GetInclude()),
+			"exclude":    utils.ConvertStringSliceToSet(network.GetExclude()),
+		}
+		if err := utils.SetNonPrimitives(d, map[string]interface{}{"network": []interface{}{networkMap}}); err != nil {
+			return diag.Errorf("failed to set OAuth application network properties: %v", err)
+		}
+	}
+
 	jwk, ok := oauthClient.GetJwksOk()
 	if ok {
 		jwks := jwk.Keys
@@ -1143,6 +1182,22 @@ func buildAppOAuthV6(d *schema.ResourceData, isNew bool) (v6okta.ListApplication
 			jwks.SetKeys(keyData)
 			oauthClientSettings.SetJwks(*jwks)
 
+		}
+	}
+
+	// Handle network restrictions
+	if networkList, ok := d.GetOk("network"); ok {
+		networkData := networkList.([]interface{})
+		if len(networkData) > 0 {
+			networkMap := networkData[0].(map[string]interface{})
+			network := v6okta.NewOpenIdConnectApplicationNetwork(networkMap["connection"].(string))
+			if include := utils.ConvertInterfaceToStringSet(networkMap["include"]); len(include) > 0 {
+				network.SetInclude(include)
+			}
+			if exclude := utils.ConvertInterfaceToStringSet(networkMap["exclude"]); len(exclude) > 0 {
+				network.SetExclude(exclude)
+			}
+			oauthClientSettings.SetNetwork(*network)
 		}
 	}
 

--- a/sdk/v2_openIdConnectApplicationNetwork.go
+++ b/sdk/v2_openIdConnectApplicationNetwork.go
@@ -1,0 +1,8 @@
+// DO NOT EDIT LOCAL SDK - USE v3 okta-sdk-golang FOR API CALLS THAT DO NOT EXIST IN LOCAL SDK
+package sdk
+
+type OpenIdConnectApplicationNetwork struct {
+	Connection string   `json:"connection"`
+	Exclude    []string `json:"exclude,omitempty"`
+	Include    []string `json:"include,omitempty"`
+}

--- a/sdk/v2_openIdConnectApplicationSettingsClient.go
+++ b/sdk/v2_openIdConnectApplicationSettingsClient.go
@@ -19,4 +19,5 @@ type OpenIdConnectApplicationSettingsClient struct {
 	TosUri                 string                                        `json:"tos_uri,omitempty"`
 	WildcardRedirect       string                                        `json:"wildcard_redirect,omitempty"`
 	JwksUri                string                                        `json:"jwks_uri,omitempty"`
+	Network                *OpenIdConnectApplicationNetwork              `json:"network,omitempty"`
 }


### PR DESCRIPTION
Adds Support for the Network Attribute to `okta_app_oauth`.

`resource_okta_app_oauth.go` uses v6 client
`data_source_okta_app_oauth.go` continues to use v2 client 

examples and docs updated.