### PR TITLE
GH-1834 | okta_event_hook_verification Not Re-Verifying After an Update

### DIFF
--- a/docs/resources/event_hook_verification.md
+++ b/docs/resources/event_hook_verification.md
@@ -46,5 +46,6 @@ resource "okta_event_hook_verification" "example" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `verification_status` (String) The verification status of the event hook.
 
 

--- a/examples/resources/okta_event_hook_verification/basic.tf
+++ b/examples/resources/okta_event_hook_verification/basic.tf
@@ -1,0 +1,23 @@
+resource "okta_event_hook" "example" {
+  name = "testAcc_replace_with_uuid"
+  events = [
+    "user.lifecycle.create",
+    "user.lifecycle.delete.initiated",
+  ]
+
+  channel = {
+    type    = "HTTP"
+    version = "1.0.0"
+    uri     = "https://eoj5lz4z8m0m1jk.m.pipedream.net"
+  }
+
+  auth = {
+    type  = "HEADER"
+    key   = "Authorization"
+    value = "value"
+  }
+}
+
+resource "okta_event_hook_verification" "user_assigned" {
+  event_hook_id = okta_event_hook.example.id
+}

--- a/examples/resources/okta_event_hook_verification/basic_updated.tf
+++ b/examples/resources/okta_event_hook_verification/basic_updated.tf
@@ -1,0 +1,23 @@
+resource "okta_event_hook" "example" {
+  name = "testAcc_replace_with_uuid"
+  events = [
+    "user.lifecycle.create",
+    "user.lifecycle.delete.initiated",
+  ]
+
+  channel = {
+    type    = "HTTP"
+    version = "1.0.0"
+    uri     = "https://eo4afyqp3adkxpk.m.pipedream.net"
+  }
+
+  auth = {
+    type  = "HEADER"
+    key   = "Authorization"
+    value = "value"
+  }
+}
+
+resource "okta_event_hook_verification" "user_assigned" {
+  event_hook_id = okta_event_hook.example.id
+}

--- a/okta/services/idaas/resource_okta_event_hook_verification.go
+++ b/okta/services/idaas/resource_okta_event_hook_verification.go
@@ -11,26 +11,64 @@ import (
 func resourceEventHookVerification() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceEventHookVerificationCreate,
-		ReadContext:   utils.ResourceFuncNoOp,
+		ReadContext:   resourceEventHookVerificationRead,
+		UpdateContext: resourceEventHookVerificationUpdate,
 		DeleteContext: utils.ResourceFuncNoOp,
 		Importer:      nil,
 		Description:   "Verifies the Event Hook. The resource won't be created unless the URI provided in the event hook returns a valid JSON object with verification. See [Event Hooks](https://developer.okta.com/docs/concepts/event-hooks/#one-time-verification-request) documentation for details.",
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			// When the API reports the hook as UNVERIFIED, force a planned diff so that
+			// UpdateContext is invoked on the next apply to re-trigger verification.
+			if d.Id() != "" && d.Get("verification_status").(string) == "UNVERIFIED" {
+				return d.SetNew("verification_status", "VERIFIED")
+			}
+			return nil
+		},
 		Schema: map[string]*schema.Schema{
 			"event_hook_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Event hook ID",
+			},
+			"verification_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Verification status of the Event hook",
 			},
 		},
 	}
 }
 
 func resourceEventHookVerificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	_, _, err := getOktaClientFromMetadata(meta).EventHook.VerifyEventHook(ctx, d.Get("event_hook_id").(string))
+	hook, _, err := getOktaV6ClientFromMetadata(meta).EventHookAPI.VerifyEventHook(ctx, d.Get("event_hook_id").(string)).Execute()
 	if err != nil {
 		return diag.Errorf("failed to verify event hook sender: %v", err)
 	}
 	d.SetId(d.Get("event_hook_id").(string))
+	_ = d.Set("verification_status", hook.VerificationStatus)
+	return nil
+}
+
+func resourceEventHookVerificationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	hook, resp, err := getOktaV6ClientFromMetadata(meta).EventHookAPI.GetEventHook(ctx, d.Id()).Execute()
+	if err := utils.SuppressErrorOn404_V6(resp, err); err != nil {
+		return diag.Errorf("failed to get event hook: %v", err)
+	}
+	if hook == nil {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(d.Get("event_hook_id").(string))
+	_ = d.Set("verification_status", hook.VerificationStatus)
+	return nil
+}
+
+func resourceEventHookVerificationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	hook, _, err := getOktaV6ClientFromMetadata(meta).EventHookAPI.VerifyEventHook(ctx, d.Get("event_hook_id").(string)).Execute()
+	if err != nil {
+		return diag.Errorf("failed to verify event hook sender: %v", err)
+	}
+	d.SetId(d.Get("event_hook_id").(string))
+	_ = d.Set("verification_status", hook.VerificationStatus)
 	return nil
 }

--- a/okta/services/idaas/resource_okta_event_hook_verification_test.go
+++ b/okta/services/idaas/resource_okta_event_hook_verification_test.go
@@ -1,0 +1,50 @@
+package idaas_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+)
+
+func TestAccResourceOktaEventHookVerification_crud(t *testing.T) {
+	resourceName := "okta_event_hook_verification.user_assigned"
+	mgr := newFixtureManager("resources", resources.OktaIDaaSEventHookVerification, t.Name())
+	config := mgr.GetFixtures("basic.tf", t)
+	updatedConfig := mgr.GetFixtures("basic_updated.tf", t)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "verification_status", "VERIFIED"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "verification_status", "VERIFIED"),
+				),
+				// After apply, ReadContext fetches UNVERIFIED from the API and
+				// CustomizeDiff forces the plan to VERIFIED, so a non-empty plan
+				// is expected on the post-step refresh.
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// ReadContext fetches the hook and sets verification_status=UNVERIFIED
+				// in state (e.g. the hook was reset externally between applies).
+				// CustomizeDiff then detects UNVERIFIED and calls
+				// d.SetNew("verification_status", "VERIFIED"), so the plan must show ...
+				Config:             updatedConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true, // ... at least one change — Terraform will schedule an Update to re-verify.
+			},
+		},
+	})
+}

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaEventHookVerification_crud/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaEventHookVerification_crud/classic-00.yaml
@@ -1,0 +1,569 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 319
+        host: classic-00.dne-okta.com
+        body: |
+            {"channel":{"config":{"authScheme":{"key":"Authorization","type":"HEADER","value":"value"},"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net"},"type":"HTTP","version":"1.0.0"},"events":{"items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"type":"EVENT_TYPE"},"name":"testAcc_1243360674","status":"ACTIVE"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:26.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:26 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.289895542s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:26.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:27 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.281363875s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:29.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:29 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.655677417s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:29.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:30 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.189541208s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:29.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:31 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.204085167s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:29.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.26194875s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:29.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:34 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.067621833s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 319
+        host: classic-00.dne-okta.com
+        body: |
+            {"channel":{"config":{"authScheme":{"key":"Authorization","type":"HEADER","value":"value"},"uri":"https://eo4afyqp3adkxpk.m.pipedream.net"},"type":"HTTP","version":"1.0.0"},"events":{"items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"type":"EVENT_TYPE"},"name":"testAcc_1243360674","status":"ACTIVE"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:29.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:35 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.237298958s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:35.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.310036291s
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:35.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:38 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.308081708s
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:35.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:39 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.338988542s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:35.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:41 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.18963025s
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:35.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:42 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.214268334s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:35.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.2764865s
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:35.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"verify":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:45 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.249896334s
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6a8dxbXhXSJp1d7","status":"INACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:48:26.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:46.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"activate":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7"},"delete":{"href":"https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7","hints":{"allow":["DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:46 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.05567975s
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/eventHooks/whowc6a8dxbXhXSJp1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 16 Mar 2026 03:48:47 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.25420425s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaEventHookVerification_crud/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaEventHookVerification_crud/oie-00.yaml
@@ -1,0 +1,569 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 319
+        host: oie-00.dne-okta.com
+        body: |
+            {"channel":{"config":{"authScheme":{"key":"Authorization","type":"HEADER","value":"value"},"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net"},"type":"HTTP","version":"1.0.0"},"events":{"items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"type":"EVENT_TYPE"},"name":"testAcc_1243360674","status":"ACTIVE"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:47.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:47 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.295364041s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:47.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.229580833s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:50.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:50 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.977459791s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:50.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:51 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.257698958s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:50.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:53 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.254015s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:50.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:54 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.255447292s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"VERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:50.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eoj5lz4z8m0m1jk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:55 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.206975583s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 319
+        host: oie-00.dne-okta.com
+        body: |
+            {"channel":{"config":{"authScheme":{"key":"Authorization","type":"HEADER","value":"value"},"uri":"https://eo4afyqp3adkxpk.m.pipedream.net"},"type":"HTTP","version":"1.0.0"},"events":{"items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"type":"EVENT_TYPE"},"name":"testAcc_1243360674","status":"ACTIVE"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:50.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:57 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.238863167s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:57.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:58 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.232071417s
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:57.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:47:59 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.444429375s
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:57.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.375691833s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:57.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:02 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.269453292s
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:57.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:04 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.227283042s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:57.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:05 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.202717s
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"ACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:47:57.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/verify","hints":{"allow":["POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.069488292s
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"whowc6euvjq8G2hVP1d7","status":"INACTIVE","verificationStatus":"UNVERIFIED","name":"testAcc_1243360674","description":null,"created":"2026-03-16T03:47:47.000Z","createdBy":"00uonmvbfznIufFS61d7","lastUpdated":"2026-03-16T03:48:07.000Z","events":{"type":"EVENT_TYPE","items":["user.lifecycle.create","user.lifecycle.delete.initiated"],"filter":null},"channel":{"type":"HTTP","version":"1.0.0","config":{"uri":"https://eo4afyqp3adkxpk.m.pipedream.net","headers":[],"method":"POST","authScheme":{"type":"HEADER","key":"Authorization"}}},"_links":{"activate":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7"},"delete":{"href":"https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7","hints":{"allow":["DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 16 Mar 2026 03:48:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.196954334s
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/eventHooks/whowc6euvjq8G2hVP1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 16 Mar 2026 03:48:09 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.24611125s


### PR DESCRIPTION
Fixes https://github.com/okta/terraform-provider-okta/issues/1834

**Problem**
`okta_event_hook_verification` used ReadContext: utils.ResourceFuncNoOp, meaning Terraform never refreshed the verification state from the API. If an event hook's verification status was reset to UNVERIFIED (e.g. the hook URI changed or was externally reset), the provider had no way to detect the drift and would never re-trigger verification on the next terraform apply.

Additionally, event_hook_id was marked ForceNew: true, which would destroy and recreate the resource on any change rather than re-running the verification flow in-place.

**Changes**
resource_okta_event_hook_verification.go

- Added ReadContext — calls GetEventHook and persists verification_status in state, enabling Terraform to detect when the hook has drifted to UNVERIFIED

- Added UpdateContext — re-calls VerifyEventHook when Terraform schedules an update, re-triggering the verification flow

- Added CustomizeDiff — when the refreshed state shows verification_status = "UNVERIFIED", forces a planned diff (UNVERIFIED → VERIFIED) so that UpdateContext is invoked on the next apply

- Added verification_status as a Computed schema attribute so the current status is visible in state and plan output

- Removed ForceNew: true from event_hook_id — changes now trigger an update (re-verification) rather than a destroy/recreate

- Migrated API calls from the v2 SDK to the v6 SDK (EventHookAPI)