### PR TITLE
fix(request_condition): inconsistent result after apply

### DIFF
--- a/examples/resources/okta_request_condition/priority.tf
+++ b/examples/resources/okta_request_condition/priority.tf
@@ -1,0 +1,27 @@
+resource "okta_request_condition" "priority_first" {
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "priority-first"
+  priority             = 1
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+}
+
+resource "okta_request_condition" "priority_second" {
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "priority-second"
+  priority             = 2
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+
+  depends_on = [okta_request_condition.priority_first]
+}

--- a/examples/resources/okta_request_condition/priority_non_sequential.tf
+++ b/examples/resources/okta_request_condition/priority_non_sequential.tf
@@ -1,0 +1,27 @@
+resource "okta_request_condition" "priority_first" {
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "priority-first"
+  priority             = 1
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+}
+
+resource "okta_request_condition" "priority_second" {
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "priority-second"
+  priority             = 100
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+
+  depends_on = [okta_request_condition.priority_first]
+}

--- a/examples/resources/okta_request_condition/priority_updated.tf
+++ b/examples/resources/okta_request_condition/priority_updated.tf
@@ -1,0 +1,27 @@
+resource "okta_request_condition" "priority_first" {
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "priority-first"
+  priority             = 2
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+}
+
+resource "okta_request_condition" "priority_second" {
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "priority-second"
+  priority             = 1
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+
+  depends_on = [okta_request_condition.priority_first]
+}

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -233,6 +234,13 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	if !plannedPriority.IsNull() && !plannedPriority.IsUnknown() {
+		if !data.Priority.Equal(plannedPriority) {
+			resp.Diagnostics.AddWarning(
+				"Priority reassigned by API",
+				fmt.Sprintf("Requested priority %s was reassigned to %s by the server. "+
+					"Run terraform plan to reconcile.", plannedPriority, data.Priority),
+			)
+		}
 		data.Priority = plannedPriority
 	}
 
@@ -335,6 +343,13 @@ func (r *requestConditionResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	if !plannedPriority.IsNull() && !plannedPriority.IsUnknown() {
+		if !data.Priority.Equal(plannedPriority) {
+			resp.Diagnostics.AddWarning(
+				"Priority reassigned by API",
+				fmt.Sprintf("Requested priority %s was reassigned to %s by the server. "+
+					"Run terraform plan to reconcile.", plannedPriority, data.Priority),
+			)
+		}
 		data.Priority = plannedPriority
 	}
 

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -218,9 +218,22 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 		}
 	}
 
+	// Preserve the planned priority before applying API response to state.
+	// The API may silently reassign priorities (e.g., when another condition
+	// collides), but the create response still echoes back the requested value.
+	// Other conditions' priorities may shift, causing a post-apply refresh to
+	// read back a different priority than planned. By preserving the planned
+	// value here, we avoid "inconsistent result after apply" errors. Any
+	// server-side reassignment will surface as drift on the next plan via Read.
+	plannedPriority := data.Priority
+
 	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &data, requestConditionResp)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !plannedPriority.IsNull() && !plannedPriority.IsUnknown() {
+		data.Priority = plannedPriority
 	}
 
 	// Save Data into Terraform state
@@ -313,9 +326,16 @@ func (r *requestConditionResource) Update(ctx context.Context, req resource.Upda
 		}
 	}
 
+	// Preserve the planned priority — see Create for rationale.
+	plannedPriority := data.Priority
+
 	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &data, updatedRequestCondition)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !plannedPriority.IsNull() && !plannedPriority.IsUnknown() {
+		data.Priority = plannedPriority
 	}
 
 	// Save Data into Terraform state

--- a/okta/services/governance/resource_request_condition_test.go
+++ b/okta/services/governance/resource_request_condition_test.go
@@ -103,6 +103,78 @@ func TestAccRequestConditionResource_Status(t *testing.T) {
 	})
 }
 
+// TestAccRequestConditionResource_Priority verifies that creating two conditions
+// with explicit priorities does not cause "inconsistent result after apply" errors
+// when the API silently reassigns priorities. It also swaps priorities in a second
+// step to exercise the Update path.
+func TestAccRequestConditionResource_Priority(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceRequestCondition, t.Name())
+	config := mgr.GetFixtures("priority.tf", t)
+	updatedConfig := mgr.GetFixtures("priority_updated.tf", t)
+	firstName := fmt.Sprintf("%s.priority_first", resources.OktaGovernanceRequestCondition)
+	secondName := fmt.Sprintf("%s.priority_second", resources.OktaGovernanceRequestCondition)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkRequestConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(firstName, "name", "priority-first"),
+					resource.TestCheckResourceAttr(firstName, "priority", "1"),
+					resource.TestCheckResourceAttr(secondName, "name", "priority-second"),
+					resource.TestCheckResourceAttr(secondName, "priority", "2"),
+				),
+			},
+			{
+				Config:             mgr.ConfigReplace(updatedConfig),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(firstName, "name", "priority-first"),
+					resource.TestCheckResourceAttr(firstName, "priority", "2"),
+					resource.TestCheckResourceAttr(secondName, "name", "priority-second"),
+					resource.TestCheckResourceAttr(secondName, "priority", "1"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccRequestConditionResource_PriorityNonSequential verifies that creating
+// a condition with a non-sequential priority (e.g., 100 when only 2 conditions
+// exist) does not cause "inconsistent result after apply" errors. This hits the
+// Create code path directly — the API is likely to normalize the priority down
+// to the actual position, which is the most common trigger for the bug.
+func TestAccRequestConditionResource_PriorityNonSequential(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceRequestCondition, t.Name())
+	config := mgr.GetFixtures("priority_non_sequential.tf", t)
+	firstName := fmt.Sprintf("%s.priority_first", resources.OktaGovernanceRequestCondition)
+	secondName := fmt.Sprintf("%s.priority_second", resources.OktaGovernanceRequestCondition)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkRequestConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(firstName, "name", "priority-first"),
+					resource.TestCheckResourceAttr(firstName, "priority", "1"),
+					resource.TestCheckResourceAttr(secondName, "name", "priority-second"),
+					resource.TestCheckResourceAttr(secondName, "priority", "100"),
+				),
+			},
+		},
+	})
+}
+
 // checkRequestConditionDestroy verifies that request conditions have been destroyed
 func checkRequestConditionDestroy(s *terraform.State) error {
 	// Skip destroy check in VCR playback mode

--- a/test/fixtures/vcr/governance/TestAccRequestConditionResource_Priority/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccRequestConditionResource_Priority/oie-00.yaml
@@ -1,0 +1,378 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 177
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","priority":1,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 538
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","id":"rco197a8dwl5rHpsl1d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:00Z","lastUpdated":"2026-03-19T06:09:00Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "538"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:00 GMT
+            Location:
+                - https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 2.170498292s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 178
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","priority":2,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 539
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","id":"rco19790njEib7R031d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:02Z","lastUpdated":"2026-03-19T06:09:02Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7","hints":{}}},"status":"INACTIVE","priority":1}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "539"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:02 GMT
+            Location:
+                - https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.624026792s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","id":"rco197a8dwl5rHpsl1d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:00Z","lastUpdated":"2026-03-19T06:09:00Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:03 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.161239458s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","id":"rco19790njEib7R031d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:02Z","lastUpdated":"2026-03-19T06:09:02Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7","hints":{}}},"status":"INACTIVE","priority":1}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:04 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 693.468916ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","id":"rco197a8dwl5rHpsl1d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:00Z","lastUpdated":"2026-03-19T06:09:00Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 876.9955ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","id":"rco19790njEib7R031d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:02Z","lastUpdated":"2026-03-19T06:09:02Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7","hints":{}}},"status":"INACTIVE","priority":1}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 694.16675ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 177
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","priority":2,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","id":"rco197a8dwl5rHpsl1d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:00Z","lastUpdated":"2026-03-19T06:09:08Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7","hints":{}}},"status":"INACTIVE","priority":1}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:08 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.089650125s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","id":"rco197a8dwl5rHpsl1d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:00Z","lastUpdated":"2026-03-19T06:09:08Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7","hints":{}}},"status":"INACTIVE","priority":1}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:09 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 727.545208ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","id":"rco19790njEib7R031d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:02Z","lastUpdated":"2026-03-19T06:09:02Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:10 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 724.279625ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790njEib7R031d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 19 Mar 2026 06:09:12 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 843.157625ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8dwl5rHpsl1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 19 Mar 2026 06:09:13 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 832.733917ms

--- a/test/fixtures/vcr/governance/TestAccRequestConditionResource_PriorityNonSequential/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccRequestConditionResource_PriorityNonSequential/oie-00.yaml
@@ -1,0 +1,209 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 177
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","priority":1,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 538
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","id":"rco19790nwUD0YJBs1d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:30Z","lastUpdated":"2026-03-19T06:09:30Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790nwUD0YJBs1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "538"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:30 GMT
+            Location:
+                - https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790nwUD0YJBs1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.363355167s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 180
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","priority":100,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 539
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","id":"rco197a8eaYcl1MC61d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:31Z","lastUpdated":"2026-03-19T06:09:31Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8eaYcl1MC61d7","hints":{}}},"status":"INACTIVE","priority":1}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "539"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:31 GMT
+            Location:
+                - https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8eaYcl1MC61d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.152398375s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790nwUD0YJBs1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-first","id":"rco19790nwUD0YJBs1d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:30Z","lastUpdated":"2026-03-19T06:09:30Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790nwUD0YJBs1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 720.665042ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8eaYcl1MC61d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"69251ae704a4d0a7fcdb870f","name":"priority-second","id":"rco197a8eaYcl1MC61d7","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-03-19T06:09:31Z","lastUpdated":"2026-03-19T06:09:31Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8eaYcl1MC61d7","hints":{}}},"status":"INACTIVE","priority":1}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 19 Mar 2026 06:09:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 729.996292ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco197a8eaYcl1MC61d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 19 Mar 2026 06:09:35 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 823.21425ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oasp3g29b1hqkcYE1d7/request-conditions/rco19790nwUD0YJBs1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 19 Mar 2026 06:09:36 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 817.516ms


### PR DESCRIPTION
- Fixes `"Provider produced inconsistent result after apply"` error on `okta_request_condition.priority` when the Okta API computes the `priority` value
  - `Create` & `Update`: stores the user's planned priority value in state
  - `Read` continues to use the API response so server-side changes surface as drift on the next `terraform plan` run