### PR TITLE
fix(docs): update fallback templates for tfplugindocs v0.17+

### DIFF
--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-{{ printf "{{tffile %q}}" .ExampleFile }}
+{{ tffile .ExampleFile }}
 
 {{- end }}
 
@@ -24,6 +24,6 @@ description: |-
 
 Import is supported using the following syntax:
 
-{{ printf "{{codefile \"shell\" %q}}" .ImportFile }}
+{{ codefile "shell" .ImportFile }}
 
 {{- end }}

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-{{ printf "{{tffile %q}}" .ExampleFile }}
+{{ tffile .ExampleFile }}
 
 {{- end }}
 
@@ -24,6 +24,6 @@ description: |-
 
 Import is supported using the following syntax:
 
-{{ printf "{{codefile \"shell\" %q}}" .ImportFile }}
+{{ codefile "shell" .ImportFile }}
 
 {{- end }}


### PR DESCRIPTION
### Summary
- Replace `printf`-based template indirection with direct `tffile` and `codefile` calls in
    `data-sources.md.tmpl` and `resources.md.tmpl`
- tfplugindocs v0.17.0 changed how template functions are rendered, making `printf`-wrapped
    calls like `{{printf "{{tffile %q}}" .ExampleFile}}` no longer works. The migration
    path documented in the [v0.17.0 changelog](https://github.com/hashicorp/terraform-plugin-docs/blob/main/CHANGELOG.md)
    is to call `tffile` and `codefile` directly.