### PR TITLE
fix: extract structured error details from Okta SDK API errors

### DIFF
--- a/okta/services/idaas/data_source_okta_log_stream.go
+++ b/okta/services/idaas/data_source_okta_log_stream.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -117,7 +118,7 @@ func (d *logStreamDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to get log stream",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/data_source_okta_push_group.go
+++ b/okta/services/idaas/data_source_okta_push_group.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 type pushGroupDataSourceModel struct {
@@ -93,14 +94,14 @@ func (r *pushGroupDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if state.ID.ValueString() != "" {
 		groupPushMapping, _, err = r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.GetGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Execute()
 		if err != nil {
-			resp.Diagnostics.AddError("failed to read push group mapping: ", err.Error())
+			resp.Diagnostics.AddError("failed to read push group mapping: ", utils.ErrorDetail_V6(err))
 			return
 		}
 	} else {
 		err := retry.RetryContext(ctx, 3*time.Second, func() *retry.RetryError {
 			groupPushMappings, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.ListGroupPushMappings(ctx, state.AppId.ValueString()).SourceGroupId(state.SourceGroupId.ValueString()).Execute()
 			if err != nil {
-				resp.Diagnostics.AddError("failed to list push group mappings: ", err.Error())
+				resp.Diagnostics.AddError("failed to list push group mappings: ", utils.ErrorDetail_V6(err))
 				return retry.NonRetryableError(err)
 			}
 			if len(groupPushMappings) == 0 {

--- a/okta/services/idaas/data_source_okta_push_groups.go
+++ b/okta/services/idaas/data_source_okta_push_groups.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var pushGroupsDataSourceObjectAttrs = map[string]attr.Type{
@@ -80,7 +81,7 @@ func (r *pushGroupsDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	for {
 		mappings, response, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.ListGroupPushMappings(ctx, state.AppId.ValueString()).After(cursor).Execute()
 		if err != nil {
-			resp.Diagnostics.AddError("failed to read push group mapping: ", err.Error())
+			resp.Diagnostics.AddError("failed to read push group mapping: ", utils.ErrorDetail_V6(err))
 			return
 		}
 		groupPushMappings = append(groupPushMappings, mappings...)

--- a/okta/services/idaas/resource_okta_agent_pool_update.go
+++ b/okta/services/idaas/resource_okta_agent_pool_update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -210,7 +211,7 @@ func (r *agentPoolUpdateResource) Create(ctx context.Context, req resource.Creat
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating agent pool update",
-			fmt.Sprintf("Could not create agent pool update: %s", err.Error()),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -234,8 +235,8 @@ func (r *agentPoolUpdateResource) Read(ctx context.Context, req resource.ReadReq
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading agent pool update",
-			fmt.Sprintf("Could not read agent pool update %s: %s", state.ID.ValueString(), err.Error()),
+			fmt.Sprintf("Error reading agent pool update %s", state.ID.ValueString()),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -262,8 +263,8 @@ func (r *agentPoolUpdateResource) Update(ctx context.Context, req resource.Updat
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error updating agent pool update",
-			fmt.Sprintf("Could not update agent pool update %s: %s", state.ID.ValueString(), err.Error()),
+			fmt.Sprintf("Error updating agent pool update %s", state.ID.ValueString()),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -287,8 +288,8 @@ func (r *agentPoolUpdateResource) Delete(ctx context.Context, req resource.Delet
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error deleting agent pool update",
-			fmt.Sprintf("Could not delete agent pool update %s: %s", state.ID.ValueString(), err.Error()),
+			fmt.Sprintf("Error deleting agent pool update %s", state.ID.ValueString()),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_api_service_integration.go
+++ b/okta/services/idaas/resource_okta_api_service_integration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -95,7 +96,7 @@ func (r *apiServiceIntegrationResource) Create(ctx context.Context, req resource
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create api service integration",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -119,7 +120,7 @@ func (r *apiServiceIntegrationResource) Read(ctx context.Context, req resource.R
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create group owner for group "+data.Type.ValueString()+" for group owner user id: ",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -145,7 +146,7 @@ func (r *apiServiceIntegrationResource) Delete(ctx context.Context, req resource
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete API Service Integration",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_api_token.go
+++ b/okta/services/idaas/resource_okta_api_token.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -131,7 +132,7 @@ func (r *apiTokenResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"error in getting API token",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -155,7 +156,7 @@ func (r *apiTokenResource) Update(ctx context.Context, req resource.UpdateReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error in upserting API token",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -174,7 +175,7 @@ func (r *apiTokenResource) Delete(ctx context.Context, req resource.DeleteReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"error in revoking API token",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_app_access_policy_assignment.go
+++ b/okta/services/idaas/resource_okta_app_access_policy_assignment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -87,7 +88,7 @@ func (r *appAccessPolicyAssignmentResource) Create(ctx context.Context, req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("create failed to find app %q for policy assignment", plan.AppID.ValueString()),
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -106,7 +107,7 @@ func (r *appAccessPolicyAssignmentResource) Create(ctx context.Context, req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("couldn't assign policy %q to app %q", policyID, appID),
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -138,7 +139,7 @@ func (r *appAccessPolicyAssignmentResource) Read(ctx context.Context, req resour
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("read failed to find app %q for policy assignment", state.ID.ValueString()),
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -197,7 +198,7 @@ func (r *appAccessPolicyAssignmentResource) Update(ctx context.Context, req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("update failed to find app %q for policy assignment", state.AppID.ValueString()),
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -209,7 +210,7 @@ func (r *appAccessPolicyAssignmentResource) Update(ctx context.Context, req reso
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("couldn't re-assign policy %q to app %q", plan.PolicyID.ValueString(), appID),
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}

--- a/okta/services/idaas/resource_okta_app_connection.go
+++ b/okta/services/idaas/resource_okta_app_connection.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -157,7 +158,7 @@ func (r *appConnections) Create(ctx context.Context, req resource.CreateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating App Connection",
-			"Could not create app connection for application ID "+data.ID.ValueString()+": "+err.Error(),
+			"Could not create app connection for application ID "+data.ID.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -175,7 +176,7 @@ func (r *appConnections) Create(ctx context.Context, req resource.CreateRequest,
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Activating App Connection",
-				"Could not create app connection for application ID "+data.ID.ValueString()+": "+err.Error(),
+				"Could not create app connection for application ID "+data.ID.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -257,7 +258,7 @@ func (r *appConnections) Read(ctx context.Context, req resource.ReadRequest, res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading App Connection",
-			"Could not read app connection for application ID "+data.ID.ValueString()+": "+err.Error(),
+			"Could not read app connection for application ID "+data.ID.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -323,7 +324,7 @@ func (r *appConnections) Update(ctx context.Context, req resource.UpdateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating App Connection",
-			"Could not update app connection for application ID "+data.ID.ValueString()+": "+err.Error(),
+			"Could not update app connection for application ID "+data.ID.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -341,7 +342,7 @@ func (r *appConnections) Update(ctx context.Context, req resource.UpdateRequest,
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Activating App Connection",
-				"Could not create app connection for application ID "+data.ID.ValueString()+": "+err.Error(),
+				"Could not create app connection for application ID "+data.ID.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -352,7 +353,7 @@ func (r *appConnections) Update(ctx context.Context, req resource.UpdateRequest,
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Deactivating App Connection",
-				"Could not deactivate app connection for application ID "+data.ID.ValueString()+": "+err.Error(),
+				"Could not deactivate app connection for application ID "+data.ID.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}

--- a/okta/services/idaas/resource_okta_app_features.go
+++ b/okta/services/idaas/resource_okta_app_features.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -337,7 +338,7 @@ func (r *appFeatures) Create(ctx context.Context, req resource.CreateRequest, re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating app features",
-			"Could not create app feature, unexpected error: "+err.Error(),
+			"Could not create app feature, unexpected error: "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -599,7 +600,7 @@ func (r *appFeatures) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading app features",
-			"Could not read app feature, unexpected error: "+err.Error(),
+			"Could not read app feature, unexpected error: "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -628,7 +629,7 @@ func (r *appFeatures) Update(ctx context.Context, req resource.UpdateRequest, re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating app features",
-			"Could not update app feature, unexpected error: "+err.Error(),
+			"Could not update app feature, unexpected error: "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_app_federated_claim.go
+++ b/okta/services/idaas/resource_okta_app_federated_claim.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -91,7 +92,7 @@ func (r *appFederatedClaim) Create(ctx context.Context, req resource.CreateReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating app federated claim",
-			"Could not create app federated claim, unexpected error: "+err.Error(),
+			"Could not create app federated claim, unexpected error: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -123,7 +124,7 @@ func (r *appFederatedClaim) Read(ctx context.Context, req resource.ReadRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading app federated claim",
-			"Could not read app federated claim, unexpected error: "+err.Error(),
+			"Could not read app federated claim, unexpected error: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -151,7 +152,7 @@ func (r *appFederatedClaim) Update(ctx context.Context, req resource.UpdateReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating app federated claim",
-			"Could not update app federated claim, unexpected error: "+err.Error(),
+			"Could not update app federated claim, unexpected error: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -173,7 +174,7 @@ func (r *appFederatedClaim) Delete(ctx context.Context, req resource.DeleteReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting app federated claim",
-			"Could not delete app federated claim, unexpected error: "+err.Error(),
+			"Could not delete app federated claim, unexpected error: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_brand.go
+++ b/okta/services/idaas/resource_okta_brand.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -146,7 +147,7 @@ func (r *brandResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create brand",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -164,7 +165,7 @@ func (r *brandResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update brand",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -173,7 +174,7 @@ func (r *brandResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read brand",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -203,7 +204,7 @@ func (r *brandResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"failed to get list brand",
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}
@@ -218,7 +219,7 @@ func (r *brandResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"failed to read brand",
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}
@@ -246,7 +247,7 @@ func (r *brandResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete brand",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -267,7 +268,7 @@ func (r *brandResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"failed to get list brand",
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}
@@ -282,7 +283,7 @@ func (r *brandResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"failed to read brand",
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}
@@ -301,7 +302,7 @@ func (r *brandResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update brand",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -310,7 +311,7 @@ func (r *brandResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read brand",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_device.go
+++ b/okta/services/idaas/resource_okta_device.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -86,7 +87,7 @@ func (r *devicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Device",
-			"Could not read Device with Id "+data.Id.ValueString()+": "+err.Error(),
+			"Could not read Device with Id "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -115,7 +116,7 @@ func (r *devicesResource) Update(ctx context.Context, req resource.UpdateRequest
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Activating Device",
-				"Could not activate device with Id "+state.Id.ValueString()+": "+err.Error(),
+				"Could not activate device with Id "+state.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -124,7 +125,7 @@ func (r *devicesResource) Update(ctx context.Context, req resource.UpdateRequest
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Deactivating Device",
-				"Could not deactivate device with Id "+state.Id.ValueString()+": "+err.Error(),
+				"Could not deactivate device with Id "+state.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -133,7 +134,7 @@ func (r *devicesResource) Update(ctx context.Context, req resource.UpdateRequest
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Suspending Device",
-				"Could not suspend device with Id "+state.Id.ValueString()+": "+err.Error(),
+				"Could not suspend device with Id "+state.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -142,7 +143,7 @@ func (r *devicesResource) Update(ctx context.Context, req resource.UpdateRequest
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error unsuspending the Device",
-				"Could not unsuspend device with Id "+state.Id.ValueString()+": "+err.Error(),
+				"Could not unsuspend device with Id "+state.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -152,7 +153,7 @@ func (r *devicesResource) Update(ctx context.Context, req resource.UpdateRequest
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Device",
-			"Could not read Device with Id "+data.Id.ValueString()+": "+err.Error(),
+			"Could not read Device with Id "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -177,7 +178,7 @@ func (r *devicesResource) Delete(ctx context.Context, req resource.DeleteRequest
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting Device",
-			"Could not delete device with Id "+data.Id.ValueString()+": "+err.Error(),
+			"Could not delete device with Id "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_device_assurance_policy_android_os.go
+++ b/okta/services/idaas/resource_okta_device_assurance_policy_android_os.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -182,7 +183,7 @@ func (r *policyDeviceAssuranceAndroidResource) Create(ctx context.Context, req r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -209,7 +210,7 @@ func (r *policyDeviceAssuranceAndroidResource) Read(ctx context.Context, req res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -236,7 +237,7 @@ func (r *policyDeviceAssuranceAndroidResource) Delete(ctx context.Context, req r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -262,7 +263,7 @@ func (r *policyDeviceAssuranceAndroidResource) Update(ctx context.Context, req r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_device_assurance_policy_chromeos_os.go
+++ b/okta/services/idaas/resource_okta_device_assurance_policy_chromeos_os.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -180,7 +181,7 @@ func (r *policyDeviceAssuranceChromeOSResource) Create(ctx context.Context, req 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -207,7 +208,7 @@ func (r *policyDeviceAssuranceChromeOSResource) Read(ctx context.Context, req re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -234,7 +235,7 @@ func (r *policyDeviceAssuranceChromeOSResource) Delete(ctx context.Context, req 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -260,7 +261,7 @@ func (r *policyDeviceAssuranceChromeOSResource) Update(ctx context.Context, req 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_device_assurance_policy_ios_os.go
+++ b/okta/services/idaas/resource_okta_device_assurance_policy_ios_os.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -145,7 +146,7 @@ func (r *policyDeviceAssuranceIOSResource) Create(ctx context.Context, req resou
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -172,7 +173,7 @@ func (r *policyDeviceAssuranceIOSResource) Read(ctx context.Context, req resourc
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -199,7 +200,7 @@ func (r *policyDeviceAssuranceIOSResource) Delete(ctx context.Context, req resou
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -225,7 +226,7 @@ func (r *policyDeviceAssuranceIOSResource) Update(ctx context.Context, req resou
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_device_assurance_policy_macos_os.go
+++ b/okta/services/idaas/resource_okta_device_assurance_policy_macos_os.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -203,7 +204,7 @@ func (r *policyDeviceAssuranceMacOSResource) Create(ctx context.Context, req res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -230,7 +231,7 @@ func (r *policyDeviceAssuranceMacOSResource) Read(ctx context.Context, req resou
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -257,7 +258,7 @@ func (r *policyDeviceAssuranceMacOSResource) Delete(ctx context.Context, req res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -283,7 +284,7 @@ func (r *policyDeviceAssuranceMacOSResource) Update(ctx context.Context, req res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_device_assurance_policy_windows_os.go
+++ b/okta/services/idaas/resource_okta_device_assurance_policy_windows_os.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -233,7 +234,7 @@ func (r *policyDeviceAssuranceWindowsResource) Create(ctx context.Context, req r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -260,7 +261,7 @@ func (r *policyDeviceAssuranceWindowsResource) Read(ctx context.Context, req res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -287,7 +288,7 @@ func (r *policyDeviceAssuranceWindowsResource) Delete(ctx context.Context, req r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -313,7 +314,7 @@ func (r *policyDeviceAssuranceWindowsResource) Update(ctx context.Context, req r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update device assurance",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_email_template_settings.go
+++ b/okta/services/idaas/resource_okta_email_template_settings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -84,7 +85,7 @@ func (r *emailTemplateSettingsResource) Create(ctx context.Context, req resource
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update email template settings",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -108,7 +109,7 @@ func (r *emailTemplateSettingsResource) Read(ctx context.Context, req resource.R
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read email template settings",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -138,7 +139,7 @@ func (r *emailTemplateSettingsResource) Update(ctx context.Context, req resource
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update email template settings",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_group_owner.go
+++ b/okta/services/idaas/resource_okta_group_owner.go
@@ -137,7 +137,7 @@ func (r *groupOwnerResource) Create(ctx context.Context, req resource.CreateRequ
 				state.Type.ValueString(),
 				state.GroupID.ValueString(),
 			),
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -174,7 +174,7 @@ func (r *groupOwnerResource) Read(ctx context.Context, req resource.ReadRequest,
 		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error retrieving the list of owners for okta_group '%s'", state.GroupID.ValueString()),
-			fmt.Sprintf("Error returned: %s", err.Error()),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -217,8 +217,12 @@ func (r *groupOwnerResource) Delete(ctx context.Context, req resource.DeleteRequ
 			return
 		}
 		resp.Diagnostics.AddError(
-			"failed to delete group owner "+state.ID.ValueString()+" from group",
-			err.Error(),
+			fmt.Sprintf(
+				"failed to delete okta_group_owner '%s' from okta_group '%s'",
+				state.ID.ValueString(),
+				state.GroupID.ValueString(),
+			),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_hook_key.go
+++ b/okta/services/idaas/resource_okta_hook_key.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -117,7 +118,7 @@ func (r *hookKey) Create(ctx context.Context, req resource.CreateRequest, resp *
 	keyRequest.SetName(data.Name.ValueString())
 	hookKey, _, err := hookKeyRequest.KeyRequest(keyRequest).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error creating hook key", "Could not create hook key, unexpected error: "+err.Error())
+		resp.Diagnostics.AddError("Error creating hook key", "Could not create hook key, unexpected error: "+utils.ErrorDetail_V5(err))
 		return
 	}
 
@@ -135,7 +136,7 @@ func (r *hookKey) Read(ctx context.Context, req resource.ReadRequest, resp *reso
 
 	hookKey, _, err := r.OktaIDaaSClient.OktaSDKClientV5().HookKeyAPI.GetHookKey(ctx, data.Id.ValueString()).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading hook key", "Could not read hook key, unexpected error: "+err.Error())
+		resp.Diagnostics.AddError("Error reading hook key", "Could not read hook key, unexpected error: "+utils.ErrorDetail_V5(err))
 		return
 	}
 	applyHookKeyToState(&data, hookKey)
@@ -155,7 +156,7 @@ func (r *hookKey) Update(ctx context.Context, req resource.UpdateRequest, resp *
 	updateKeyRequest.SetName(data.Name.ValueString())
 	hookKey, _, err := updateHookKeyRequest.KeyRequest(updateKeyRequest).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error replacing hook key", "Could not replace hook key, unexpected error: "+err.Error())
+		resp.Diagnostics.AddError("Error replacing hook key", "Could not replace hook key, unexpected error: "+utils.ErrorDetail_V5(err))
 		return
 	}
 
@@ -174,7 +175,7 @@ func (r *hookKey) Delete(ctx context.Context, req resource.DeleteRequest, resp *
 	deleteHookKeyRequest := r.OktaIDaaSClient.OktaSDKClientV5().HookKeyAPI.DeleteHookKey(ctx, data.Id.ValueString())
 	_, err := deleteHookKeyRequest.Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error deleting hook key", "Could not delete  hook key, unexpected error: "+err.Error())
+		resp.Diagnostics.AddError("Error deleting hook key", "Could not delete  hook key, unexpected error: "+utils.ErrorDetail_V5(err))
 		return
 	}
 }

--- a/okta/services/idaas/resource_okta_log_stream.go
+++ b/okta/services/idaas/resource_okta_log_stream.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/okta/okta-sdk-golang/v4/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -206,7 +207,7 @@ func (r *logStreamResource) Create(ctx context.Context, req resource.CreateReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create log stream",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -230,7 +231,7 @@ func (r *logStreamResource) Create(ctx context.Context, req resource.CreateReque
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"failed to activate log stream",
-					err.Error(),
+					utils.ErrorDetail_V4(err),
 				)
 				return
 			}
@@ -241,7 +242,7 @@ func (r *logStreamResource) Create(ctx context.Context, req resource.CreateReque
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"failed to deactivate log stream",
-					err.Error(),
+					utils.ErrorDetail_V4(err),
 				)
 				return
 			}
@@ -267,7 +268,7 @@ func (r *logStreamResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to get log stream",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -304,7 +305,7 @@ func (r *logStreamResource) Update(ctx context.Context, req resource.UpdateReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to replace log stream",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -328,7 +329,7 @@ func (r *logStreamResource) Update(ctx context.Context, req resource.UpdateReque
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"failed to activate log stream",
-					err.Error(),
+					utils.ErrorDetail_V4(err),
 				)
 				return
 			}
@@ -339,7 +340,7 @@ func (r *logStreamResource) Update(ctx context.Context, req resource.UpdateReque
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"failed to deactivate log stream",
-					err.Error(),
+					utils.ErrorDetail_V4(err),
 				)
 				return
 			}
@@ -366,7 +367,7 @@ func (r *logStreamResource) Delete(ctx context.Context, req resource.DeleteReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to deactivate log stream",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -374,7 +375,7 @@ func (r *logStreamResource) Delete(ctx context.Context, req resource.DeleteReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to delete log stream",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_post_auth_session_policy_rule.go
+++ b/okta/services/idaas/resource_okta_post_auth_session_policy_rule.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 
 	fwdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
@@ -174,7 +175,7 @@ func (r *postAuthSessionPolicyRuleResource) Update(ctx context.Context, req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update post auth session policy rule",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -186,7 +187,7 @@ func (r *postAuthSessionPolicyRuleResource) Update(ctx context.Context, req reso
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"failed to activate post auth session policy rule",
-					err.Error(),
+					utils.ErrorDetail_V6(err),
 				)
 				return
 			}
@@ -195,7 +196,7 @@ func (r *postAuthSessionPolicyRuleResource) Update(ctx context.Context, req reso
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"failed to deactivate post auth session policy rule",
-					err.Error(),
+					utils.ErrorDetail_V6(err),
 				)
 				return
 			}
@@ -253,7 +254,7 @@ func (r *postAuthSessionPolicyRuleResource) readPostAuthSessionPolicyRule(ctx co
 	if err != nil {
 		diags.AddError(
 			"failed to get post auth session policy rule",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_principal_rate_limits.go
+++ b/okta/services/idaas/resource_okta_principal_rate_limits.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	tfpath "github.com/hashicorp/terraform-plugin-framework/path"
@@ -132,7 +133,7 @@ func (r *principalRateLimits) Create(ctx context.Context, req resource.CreateReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to get principal rate limit",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -149,7 +150,7 @@ func (r *principalRateLimits) Create(ctx context.Context, req resource.CreateReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update principal rate limit",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -175,7 +176,7 @@ func (r *principalRateLimits) Read(ctx context.Context, req resource.ReadRequest
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read principal rate limit",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -201,7 +202,7 @@ func (r *principalRateLimits) Update(ctx context.Context, req resource.UpdateReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update principal rate limit",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -227,7 +228,7 @@ func (r *principalRateLimits) Delete(ctx context.Context, req resource.DeleteReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update principal rate limit",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_push_group.go
+++ b/okta/services/idaas/resource_okta_push_group.go
@@ -175,7 +175,7 @@ func (r *pushGroupResource) Create(ctx context.Context, req resource.CreateReque
 	if data.TargetGroupName.ValueString() == "" && data.TargetGroupId.ValueString() == "" {
 		sourceGroup, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupAPI.GetGroup(ctx, data.SourceGroupId.ValueString()).Execute()
 		if err != nil {
-			resp.Diagnostics.AddError("Error creating Okta Push Group ", err.Error())
+			resp.Diagnostics.AddError("Error creating Okta Push Group ", utils.ErrorDetail_V6(err))
 			return
 		}
 		if sourceGroup.Profile.OktaActiveDirectoryGroupProfile != nil {
@@ -193,7 +193,7 @@ func (r *pushGroupResource) Create(ctx context.Context, req resource.CreateReque
 
 	groupPushMapping, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.CreateGroupPushMapping(ctx, data.AppId.ValueString()).Body(request).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error creating Okta Push Group ", err.Error())
+		resp.Diagnostics.AddError("Error creating Okta Push Group ", utils.ErrorDetail_V6(err))
 		return
 	}
 
@@ -217,7 +217,7 @@ func (r *pushGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	groupPushMapping, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.GetGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading Okta push group mapping ", err.Error())
+		resp.Diagnostics.AddError("Error reading Okta push group mapping ", utils.ErrorDetail_V6(err))
 		return
 	}
 
@@ -253,7 +253,7 @@ func (r *pushGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		Status: state.Status.ValueString(),
 	}).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("failed to update push group mapping: ", err.Error())
+		resp.Diagnostics.AddError("failed to update push group mapping: ", utils.ErrorDetail_V6(err))
 		return
 	}
 
@@ -285,14 +285,14 @@ func (r *pushGroupResource) Delete(ctx context.Context, req resource.DeleteReque
 			Status: "INACTIVE",
 		}).Execute()
 		if err != nil {
-			resp.Diagnostics.AddError("failed to delete push group mapping: ", err.Error())
+			resp.Diagnostics.AddError("failed to delete push group mapping: ", utils.ErrorDetail_V6(err))
 			return
 		}
 	}
 
 	_, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.DeleteGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).DeleteTargetGroup(state.DeleteTargetGroupOnDestroy.ValueBool()).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("failed to delete push group mapping: ", err.Error())
+		resp.Diagnostics.AddError("failed to delete push group mapping: ", utils.ErrorDetail_V6(err))
 		return
 	}
 }

--- a/okta/services/idaas/resource_okta_rate_limit_admin_notification_settings.go
+++ b/okta/services/idaas/resource_okta_rate_limit_admin_notification_settings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -96,7 +97,7 @@ func (r *rateLimitAdminNotificationSettingsResource) Read(ctx context.Context, r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read rate limit admin notification settings",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -123,7 +124,7 @@ func (r *rateLimitAdminNotificationSettingsResource) Update(ctx context.Context,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update rate limit admin notification settings",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_rate_limit_warning_threshold_percentage.go
+++ b/okta/services/idaas/resource_okta_rate_limit_warning_threshold_percentage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -73,7 +74,7 @@ func (r *rateLimitWarningThresholdPercentage) Create(ctx context.Context, req re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to read rate limit warning threshold percentage",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -101,7 +102,7 @@ func (r *rateLimitWarningThresholdPercentage) Read(ctx context.Context, req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update rate limit warning threshold percentage",
-			err.Error(),
+			utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_realm.go
+++ b/okta/services/idaas/resource_okta_realm.go
@@ -16,6 +16,7 @@ import (
 
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 type realmModel struct {
@@ -88,7 +89,7 @@ func (r *realmResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	responseRealm, _, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.CreateRealm(ctx).Body(*createRealmRequest).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error creating Okta realm ", err.Error())
+		resp.Diagnostics.AddError("Error creating Okta realm ", utils.ErrorDetail_V5(err))
 		return
 	}
 	responseRealm.Profile.SetRealmType(data.RealmType.String()) // realm type isn't returned as part of the response, we need to set it manually.
@@ -113,7 +114,7 @@ func (r *realmResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	realm, _, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.GetRealm(ctx, state.ID.ValueString()).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading Okta realm ", err.Error())
+		resp.Diagnostics.AddError("Error reading Okta realm ", utils.ErrorDetail_V5(err))
 		return
 	}
 
@@ -146,7 +147,7 @@ func (r *realmResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	realm, _, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.ReplaceRealm(ctx, state.ID.ValueString()).Body(*updateRealmRequest).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("failed to update realm: ", err.Error())
+		resp.Diagnostics.AddError("failed to update realm: ", utils.ErrorDetail_V5(err))
 		return
 	}
 	realm.Profile.SetRealmType(state.RealmType.String()) // realm type isn't returned as part of the response, we need to set it manually.
@@ -172,7 +173,7 @@ func (r *realmResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	_, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAPI.DeleteRealm(ctx, state.ID.ValueString()).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("failed to delete realm: ", err.Error())
+		resp.Diagnostics.AddError("failed to delete realm: ", utils.ErrorDetail_V5(err))
 		return
 	}
 }

--- a/okta/services/idaas/resource_okta_realm_assignment.go
+++ b/okta/services/idaas/resource_okta_realm_assignment.go
@@ -131,10 +131,10 @@ func (r *realmAssignmentResource) Create(ctx context.Context, req resource.Creat
 		body, ioErr := io.ReadAll(response.Body)
 		defer response.Body.Close()
 		if ioErr != nil {
-			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			resp.Diagnostics.AddError(utils.ErrorDetail_V5(err), "failed to read response body")
 			return
 		}
-		resp.Diagnostics.AddError("failed to create realm assignment:"+err.Error(), string(body))
+		resp.Diagnostics.AddError("failed to create realm assignment:"+utils.ErrorDetail_V5(err), string(body))
 		return
 	}
 
@@ -144,10 +144,10 @@ func (r *realmAssignmentResource) Create(ctx context.Context, req resource.Creat
 			body, ioErr := io.ReadAll(response.Body)
 			defer response.Body.Close()
 			if ioErr != nil {
-				resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+				resp.Diagnostics.AddError(utils.ErrorDetail_V5(err), "failed to read response body")
 				return
 			}
-			resp.Diagnostics.AddError("failed to activate realm assignment:"+err.Error(), string(body))
+			resp.Diagnostics.AddError("failed to activate realm assignment:"+utils.ErrorDetail_V5(err), string(body))
 			return
 		}
 		realmAssignment.Status = utils.StringPtr("ACTIVE")
@@ -173,7 +173,7 @@ func (r *realmAssignmentResource) Read(ctx context.Context, req resource.ReadReq
 
 	realmAssignment, _, err := r.config.OktaIDaaSClient.OktaSDKClientV5().RealmAssignmentAPI.GetRealmAssignment(ctx, state.ID.ValueString()).Execute()
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Error getting realm assignment with id: %v", state.ID.ValueString()), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Error getting realm assignment with id: %v", state.ID.ValueString()), utils.ErrorDetail_V5(err))
 		return
 	}
 
@@ -205,10 +205,10 @@ func (r *realmAssignmentResource) Update(ctx context.Context, req resource.Updat
 		body, ioErr := io.ReadAll(response.Body)
 		defer response.Body.Close()
 		if ioErr != nil {
-			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			resp.Diagnostics.AddError(utils.ErrorDetail_V5(err), "failed to read response body")
 			return
 		}
-		resp.Diagnostics.AddError("failed to deactivate realm assignment before updating:"+err.Error(), string(body))
+		resp.Diagnostics.AddError("failed to deactivate realm assignment before updating:"+utils.ErrorDetail_V5(err), string(body))
 		return
 	}
 
@@ -234,10 +234,10 @@ func (r *realmAssignmentResource) Update(ctx context.Context, req resource.Updat
 		body, ioErr := io.ReadAll(response.Body)
 		defer response.Body.Close()
 		if ioErr != nil {
-			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			resp.Diagnostics.AddError(utils.ErrorDetail_V5(err), "failed to read response body")
 			return
 		}
-		resp.Diagnostics.AddError("failed to update realm assignment:"+err.Error(), string(body))
+		resp.Diagnostics.AddError("failed to update realm assignment:"+utils.ErrorDetail_V5(err), string(body))
 
 		return
 	}
@@ -248,10 +248,10 @@ func (r *realmAssignmentResource) Update(ctx context.Context, req resource.Updat
 			body, ioErr := io.ReadAll(response.Body)
 			defer response.Body.Close()
 			if ioErr != nil {
-				resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+				resp.Diagnostics.AddError(utils.ErrorDetail_V5(err), "failed to read response body")
 				return
 			}
-			resp.Diagnostics.AddError("failed to activate realm assignment:"+err.Error(), string(body))
+			resp.Diagnostics.AddError("failed to activate realm assignment:"+utils.ErrorDetail_V5(err), string(body))
 			return
 		}
 		realmAssignment.Status = utils.StringPtr("ACTIVE")
@@ -280,10 +280,10 @@ func (r *realmAssignmentResource) Delete(ctx context.Context, req resource.Delet
 		body, ioErr := io.ReadAll(response.Body)
 		defer response.Body.Close()
 		if ioErr != nil {
-			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			resp.Diagnostics.AddError(utils.ErrorDetail_V5(err), "failed to read response body")
 			return
 		}
-		resp.Diagnostics.AddError("failed to deactivate realm assignment before deletion:"+err.Error(), string(body))
+		resp.Diagnostics.AddError("failed to deactivate realm assignment before deletion:"+utils.ErrorDetail_V5(err), string(body))
 		return
 	}
 
@@ -292,10 +292,10 @@ func (r *realmAssignmentResource) Delete(ctx context.Context, req resource.Delet
 		body, ioErr := io.ReadAll(response.Body)
 		defer response.Body.Close()
 		if ioErr != nil {
-			resp.Diagnostics.AddError(err.Error(), "failed to read response body")
+			resp.Diagnostics.AddError(utils.ErrorDetail_V5(err), "failed to read response body")
 			return
 		}
-		resp.Diagnostics.AddError("failed to delete realm assignment:"+err.Error(), string(body))
+		resp.Diagnostics.AddError("failed to delete realm assignment:"+utils.ErrorDetail_V5(err), string(body))
 		return
 	}
 }

--- a/okta/services/idaas/resource_okta_security_events_provider.go
+++ b/okta/services/idaas/resource_okta_security_events_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v5okta "github.com/okta/okta-sdk-golang/v5/okta"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -71,7 +72,7 @@ func (r *securityEventsProviderResource) Create(ctx context.Context, req resourc
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Activating Security Events Provider",
-				"Could not activate Security Events Provider ID "+data.Id.ValueString()+": "+err.Error(),
+				"Could not activate Security Events Provider ID "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -81,7 +82,7 @@ func (r *securityEventsProviderResource) Create(ctx context.Context, req resourc
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Deactivating Security Events Provider",
-				"Could not deactivate Security Events Provider ID "+data.Id.ValueString()+": "+err.Error(),
+				"Could not deactivate Security Events Provider ID "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -108,7 +109,7 @@ func (r *securityEventsProviderResource) Read(ctx context.Context, request resou
 	if err != nil {
 		response.Diagnostics.AddError(
 			"Error Reading Security Events Provider",
-			"Could not read Security Events Provider ID "+data.Id.ValueString()+": "+err.Error(),
+			"Could not read Security Events Provider ID "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -136,7 +137,7 @@ func (r *securityEventsProviderResource) Update(ctx context.Context, req resourc
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Security Events Provider",
-			"Could not update Security Events Provider ID "+data.Id.ValueString()+": "+err.Error(),
+			"Could not update Security Events Provider ID "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}
@@ -148,7 +149,7 @@ func (r *securityEventsProviderResource) Update(ctx context.Context, req resourc
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Activating Security Events Provider",
-				"Could not activate Security Events Provider ID "+data.Id.ValueString()+": "+err.Error(),
+				"Could not activate Security Events Provider ID "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -158,7 +159,7 @@ func (r *securityEventsProviderResource) Update(ctx context.Context, req resourc
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Deactivating Security Events Provider",
-				"Could not deactivate Security Events Provider ID "+data.Id.ValueString()+": "+err.Error(),
+				"Could not deactivate Security Events Provider ID "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 			)
 			return
 		}
@@ -186,7 +187,7 @@ func (r *securityEventsProviderResource) Delete(ctx context.Context, request res
 	if err != nil {
 		response.Diagnostics.AddError(
 			"Error Deleting Security Events Provider",
-			"Could not delete Security Events Provider ID "+data.Id.ValueString()+": "+err.Error(),
+			"Could not delete Security Events Provider ID "+data.Id.ValueString()+": "+utils.ErrorDetail_V5(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_trusted_server.go
+++ b/okta/services/idaas/resource_okta_trusted_server.go
@@ -88,7 +88,7 @@ func (r *trustedServerResource) Create(ctx context.Context, req resource.CreateR
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to create trusted servers",
-			err.Error(),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -116,7 +116,7 @@ func (r *trustedServerResource) Read(ctx context.Context, req resource.ReadReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error retrieving list trusted server",
-			fmt.Sprintf("Error returned: %s", err.Error()),
+			utils.ErrorDetail_V4(err),
 		)
 		return
 	}
@@ -150,7 +150,7 @@ func (r *trustedServerResource) Delete(ctx context.Context, req resource.DeleteR
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("failed to delete trusted server %v", trustedServerID),
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}
@@ -190,7 +190,7 @@ func (r *trustedServerResource) Update(ctx context.Context, req resource.UpdateR
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"failed to update trusted servers",
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}
@@ -201,7 +201,7 @@ func (r *trustedServerResource) Update(ctx context.Context, req resource.UpdateR
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("failed to delete trusted server %v", trustedServerID),
-				err.Error(),
+				utils.ErrorDetail_V4(err),
 			)
 			return
 		}

--- a/okta/services/idaas/resource_okta_ui_schema.go
+++ b/okta/services/idaas/resource_okta_ui_schema.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 )
 
 var (
@@ -136,7 +137,7 @@ func (r *uiSchemaResource) Create(ctx context.Context, req resource.CreateReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating UISchema",
-			"Could not create UISchema, unexpected error: "+err.Error(),
+			"Could not create UISchema, unexpected error: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -203,7 +204,7 @@ func (r *uiSchemaResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading UISchema",
-			"Could not read UISchema, unexpected error: "+err.Error(),
+			"Could not read UISchema, unexpected error: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -232,7 +233,7 @@ func (r *uiSchemaResource) Update(ctx context.Context, req resource.UpdateReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating UISchema",
-			"An error occurred while updating the UISchema: "+err.Error(),
+			"An error occurred while updating the UISchema: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -260,7 +261,7 @@ func (r *uiSchemaResource) Delete(ctx context.Context, req resource.DeleteReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting UISchema",
-			"Could not delete UISchema, unexpected error: "+err.Error(),
+			"Could not delete UISchema, unexpected error: "+utils.ErrorDetail_V6(err),
 		)
 		return
 	}

--- a/okta/services/idaas/resource_okta_user_risk.go
+++ b/okta/services/idaas/resource_okta_user_risk.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/terraform-provider-okta/okta/config"
+	"github.com/okta/terraform-provider-okta/okta/utils"
 
 	fwdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
@@ -94,7 +95,7 @@ func (r *userRiskResource) Create(ctx context.Context, req resource.CreateReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to set user risk",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -147,7 +148,7 @@ func (r *userRiskResource) Update(ctx context.Context, req resource.UpdateReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to update user risk",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -187,7 +188,7 @@ func (r *userRiskResource) ImportState(ctx context.Context, req resource.ImportS
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"failed to get user risk",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}
@@ -217,7 +218,7 @@ func (r *userRiskResource) readUserRisk(ctx context.Context, state *userRiskReso
 	if err != nil {
 		diags.AddError(
 			"failed to get user risk",
-			err.Error(),
+			utils.ErrorDetail_V6(err),
 		)
 		return
 	}

--- a/okta/utils/utils.go
+++ b/okta/utils/utils.go
@@ -545,6 +545,104 @@ func ResponseErr_V3(resp *okta.APIResponse, err error) error {
 	return nil
 }
 
+// ErrorDetail_V4 extracts the error summary, error code, error ID, and causes
+// from an Okta V4 SDK GenericOpenAPIError. Falls back to err.Error() when the
+// structured model is unavailable.
+func ErrorDetail_V4(err error) string {
+	var oae okta.GenericOpenAPIError
+	if errors.As(err, &oae) {
+		if m := oae.Model(); m != nil {
+			if oe, ok := m.(okta.Error); ok {
+				return formatOktaError(oe.GetErrorSummary(), oe.GetErrorCode(), oe.GetErrorId(), oktaErrorCauseSummaries(oe.GetErrorCauses()))
+			}
+		}
+	}
+	return err.Error()
+}
+
+// ErrorDetail_V5 extracts the error summary, error code, error ID, and causes
+// from an Okta V5 SDK GenericOpenAPIError. Falls back to err.Error() when the
+// structured model is unavailable.
+func ErrorDetail_V5(err error) string {
+	var oae v5okta.GenericOpenAPIError
+	if errors.As(err, &oae) {
+		if m := oae.Model(); m != nil {
+			if oe, ok := m.(v5okta.Error); ok {
+				return formatOktaError(oe.GetErrorSummary(), oe.GetErrorCode(), oe.GetErrorId(), v5ErrorCauseSummaries(oe.GetErrorCauses()))
+			}
+		}
+	}
+	return err.Error()
+}
+
+// ErrorDetail_V6 extracts the error summary, error code, error ID, and causes
+// from an Okta V6 SDK GenericOpenAPIError. Falls back to err.Error() when the
+// structured model is unavailable.
+func ErrorDetail_V6(err error) string {
+	var oae v6okta.GenericOpenAPIError
+	if errors.As(err, &oae) {
+		if m := oae.Model(); m != nil {
+			if oe, ok := m.(v6okta.Error); ok {
+				return formatOktaError(oe.GetErrorSummary(), oe.GetErrorCode(), oe.GetErrorId(), v6ErrorCauseSummaries(oe.GetErrorCauses()))
+			}
+		}
+	}
+	return err.Error()
+}
+
+// formatOktaError builds a human-readable error string from Okta API error
+// fields. This is shared across all SDK version helpers.
+func formatOktaError(summary, code, id string, causes []string) string {
+	if summary == "" {
+		return "unknown error"
+	}
+	msg := summary
+	var meta []string
+	if code != "" {
+		meta = append(meta, fmt.Sprintf("errorCode: %s", code))
+	}
+	if id != "" {
+		meta = append(meta, fmt.Sprintf("errorId: %s", id))
+	}
+	if len(meta) > 0 {
+		msg = fmt.Sprintf("%s (%s)", msg, strings.Join(meta, ", "))
+	}
+	if len(causes) > 0 {
+		msg = fmt.Sprintf("%s. Causes: %s", msg, strings.Join(causes, ", "))
+	}
+	return msg
+}
+
+func oktaErrorCauseSummaries(causes []okta.ErrorErrorCausesInner) []string {
+	out := make([]string, 0, len(causes))
+	for _, c := range causes {
+		if s := c.GetErrorSummary(); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func v5ErrorCauseSummaries(causes []v5okta.ErrorCause) []string {
+	out := make([]string, 0, len(causes))
+	for _, c := range causes {
+		if s := c.GetErrorSummary(); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func v6ErrorCauseSummaries(causes []v6okta.ErrorCause) []string {
+	out := make([]string, 0, len(causes))
+	for _, c := range causes {
+		if s := c.GetErrorSummary(); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // TODO switch to responseErr when migration complete
 func ResponseErr_V5(resp *v5okta.APIResponse, err error) error {
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `ErrorDetail_V4`, `ErrorDetail_V5`, and `ErrorDetail_V6` utility functions that unpack
`GenericOpenAPIError` models to surface the error summary, error code, error ID, and error causes from Okta
API responses
- Update ~147 `AddError` call sites across idaas resources and data sources to use the appropriate helper instead of bare `err.Error()`
- No logic changes — strictly an error message improvement

## Problem

The v4/v5/v6 Okta SDKs wrap API errors as `GenericOpenAPIError` where `Error()` only returns the HTTP status text (e.g. `"400 Bad Request"`), discarding the structured error details from the response body. This makes it difficult for Terraform users to diagnose terraform plan/appy failures that result from API errors.

**Before:**
```
Error: failed to update/assign group owner

  400 Bad Request
```

**After:**
```
Error: failed to update/assign okta_group_owner with id 'abc123' and type 'USER' to okta_group 'def456'

  Api validation failed (errorCode: E0000001, errorId: oae123abc).
  Causes: Provided owner is already assigned to this group
```
