### PR TITLE
adds support for require replace when updating a field in campaign resource

### DIFF
--- a/examples/resources/okta_campaign/updated.tf
+++ b/examples/resources/okta_campaign/updated.tf
@@ -1,12 +1,12 @@
 resource "okta_user" "test" {
   first_name = "TestAcc"
-  last_name  = "Smith"
+  last_name  = "Smith-1"
   login      = "testAcc-replace_with_uuid@example.com"
   email      = "testAcc-replace_with_uuid@example.com"
 }
 
 resource "okta_campaign" "test" {
-  name          = "Monthly access review of sales team"
+  name          = "Quarterly access review of sales team"
   description   = "Multi app campaign"
   campaign_type = "RESOURCE"
 

--- a/okta/services/governance/resource_campaign.go
+++ b/okta/services/governance/resource_campaign.go
@@ -14,7 +14,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-governance-sdk-golang/governance"
@@ -188,10 +193,16 @@ func (r *campaignResource) Schema(ctx context.Context, req resource.SchemaReques
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Name of the campaign. Maintain some uniqueness when naming the campaign as it helps to identify and filter for campaigns when needed.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"campaign_tier": schema.StringAttribute{
 				Optional:    true,
 				Description: "Indicates the minimum required SKU to manage the campaign. Values can be `BASIC` and `PREMIUM`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"campaign_type": schema.StringAttribute{
 				Optional:    true,
@@ -200,18 +211,30 @@ func (r *campaignResource) Schema(ctx context.Context, req resource.SchemaReques
 				Validators: []validator.String{
 					stringvalidator.OneOf("RESOURCE", "USER"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
 				Description: "Description about the campaign.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"skip_remediation": schema.BoolAttribute{
 				Optional:    true,
 				Description: "If true, skip remediation when ending the campaign (only applicable if remediationSetting.noResponse=DENY).",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
 			"remediation_settings": schema.SingleNestedBlock{
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"access_approved": schema.StringAttribute{
 						Required:    true,
@@ -255,6 +278,9 @@ func (r *campaignResource) Schema(ctx context.Context, req resource.SchemaReques
 				Description: "Specify the action to be taken after a reviewer makes a decision to APPROVE or REVOKE the access, or if the campaign was CLOSED and there was no response from the reviewer.",
 			},
 			"resource_settings": schema.SingleNestedBlock{
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"type": schema.StringAttribute{
 						Required:    true,
@@ -380,6 +406,9 @@ func (r *campaignResource) Schema(ctx context.Context, req resource.SchemaReques
 				Description: "Resource specific properties.",
 			},
 			"reviewer_settings": schema.SingleNestedBlock{
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"type": schema.StringAttribute{
 						Required:    true,
@@ -496,6 +525,9 @@ func (r *campaignResource) Schema(ctx context.Context, req resource.SchemaReques
 				Description: "Identifies the kind of reviewer for Access Certification.",
 			},
 			"schedule_settings": schema.SingleNestedBlock{
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"start_date": schema.StringAttribute{
 						Required:    true,
@@ -546,6 +578,9 @@ func (r *campaignResource) Schema(ctx context.Context, req resource.SchemaReques
 				Description: "Scheduler specific settings.",
 			},
 			"notification_settings": schema.SingleNestedBlock{
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"notify_reviewer_at_campaign_end": schema.BoolAttribute{
 						Required:    true,
@@ -572,10 +607,16 @@ func (r *campaignResource) Schema(ctx context.Context, req resource.SchemaReques
 						Computed:    true,
 						ElementType: types.Int64Type,
 						Description: "Specifies times (in seconds) to send reminders to reviewers before the campaign closes. Max 3 values. Example: [86400, 172800, 604800]",
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.RequiresReplace(),
+						},
 					},
 				},
 			},
 			"principal_scope_settings": schema.SingleNestedBlock{
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"type": schema.StringAttribute{
 						Required:    true,
@@ -705,7 +746,9 @@ func (r *campaignResource) Update(ctx context.Context, req resource.UpdateReques
 
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
-		"No other fields other than launch_campaign and end_campaign are updatable for this resource. Terraform will retain the existing state.",
+		"The okta_campaign resource does not support in-place updates. All attributes require replacement. "+
+			"If you see this error, ensure all campaign attributes have 'requires replacement' plan modifiers, "+
+			"or destroy and re-create the resource manually.",
 	)
 }
 

--- a/okta/services/governance/resource_campaign.go
+++ b/okta/services/governance/resource_campaign.go
@@ -747,8 +747,7 @@ func (r *campaignResource) Update(ctx context.Context, req resource.UpdateReques
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
 		"The okta_campaign resource does not support in-place updates. All attributes require replacement. "+
-			"If you see this error, ensure all campaign attributes have 'requires replacement' plan modifiers, "+
-			"or destroy and re-create the resource manually.",
+			"If you see this error, please destroy the resource and re-create it again.",
 	)
 }
 

--- a/okta/services/governance/resource_campaign_test.go
+++ b/okta/services/governance/resource_campaign_test.go
@@ -33,3 +33,55 @@ func TestAccCampaignResource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccCampaignResource_requiresReplace verifies that mutating any attribute
+// that cannot be updated in-place (e.g. name) causes Terraform to destroy and
+// re-create the campaign instead of attempting an in-place update that the API
+// would reject. The test captures the resource ID after the initial create and
+// asserts it differs after the attribute change, confirming a replace occurred.
+func TestAccCampaignResource_requiresReplace(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceCampaign, t.Name())
+	config := mgr.GetFixtures("basic.tf", t)
+	updatedConfig := mgr.GetFixtures("updated.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaGovernanceCampaign)
+
+	var idBeforeReplace string
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create the campaign and capture its ID.
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Monthly access review of sales team"),
+					resource.TestCheckResourceAttr(resourceName, "campaign_type", "RESOURCE"),
+					resource.TestCheckResourceAttrWith(resourceName, "id", func(id string) error {
+						idBeforeReplace = id
+						return nil
+					}),
+				),
+			},
+			{
+				// Step 2: change `name` — a RequiresReplace attribute.
+				// Terraform must destroy the old campaign and create a new one
+				// rather than attempting an unsupported in-place update.
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Quarterly access review of sales team"),
+					resource.TestCheckResourceAttr(resourceName, "campaign_type", "RESOURCE"),
+					// The resource ID must differ, proving a replace (destroy+create) occurred.
+					resource.TestCheckResourceAttrWith(resourceName, "id", func(id string) error {
+						if id == idBeforeReplace {
+							return fmt.Errorf("expected campaign ID to change after replace, but it remained %q", id)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}

--- a/test/fixtures/vcr/governance/TestAccCampaignResource_requiresReplace/classic-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccCampaignResource_requiresReplace/classic-00.yaml
@@ -1,0 +1,242 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1241
+        host: classic-00.dne-okta.com
+        body: |
+            {"campaignType":"RESOURCE","description":"Multi app campaign","name":"Monthly access review of sales team","notificationSettings":{"notifyReviewPeriodEnd":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewerWhenOverdue":false,"notifyReviewerWhenReviewAssigned":false},"principalScopeSettings":{"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false,"type":"USERS"},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"resourceSettings":{"excludedResources":[],"includeAdminRoles":false,"includeEntitlements":false,"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"onlyIncludeOutOfPolicyEntitlements":false,"targetResources":[{"includeAllEntitlementsAndBundles":false,"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION"}],"type":"APPLICATION"},"reviewerSettings":{"bulkDecisionDisabled":true,"justificationRequired":true,"reassignmentDisabled":false,"reviewerId":"00uwvhlav3r3WdCqy1d7","selfReviewDisabled":true,"type":"USER"},"scheduleSettings":{"durationInDays":21,"recurrence":{"interval":""},"startDate":"2026-10-04T13:43:40Z","timeZone":"America/Vancouver","type":"ONE_OFF"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/governance/api/v1/campaigns
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2257
+        body: '{"_links":{"launchCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7/launch","hints":{}},"endCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7/end","hints":{}},"reviews":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpofRP3iLew1d7%22","hints":{}},"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7","hints":{}}},"id":"ici19ncpofRP3iLew1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:52:09Z","lastUpdated":"2026-03-29T13:52:09Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Monthly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhlav3r3WdCqy1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2257"
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:52:09 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.489965625s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"_links":{"launchCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7/launch","hints":{}},"endCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7/end","hints":{}},"reviews":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpofRP3iLew1d7%22","hints":{}},"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7","hints":{}}},"id":"ici19ncpofRP3iLew1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:52:09Z","lastUpdated":"2026-03-29T13:52:09Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Monthly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhlav3r3WdCqy1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:52:12 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.115534584s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"_links":{"launchCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7/launch","hints":{}},"endCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7/end","hints":{}},"reviews":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpofRP3iLew1d7%22","hints":{}},"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7","hints":{}}},"id":"ici19ncpofRP3iLew1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:52:09Z","lastUpdated":"2026-03-29T13:52:09Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Monthly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhlav3r3WdCqy1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:52:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.128477s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpofRP3iLew1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Sun, 29 Mar 2026 13:52:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.129748209s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1243
+        host: classic-00.dne-okta.com
+        body: |
+            {"campaignType":"RESOURCE","description":"Multi app campaign","name":"Quarterly access review of sales team","notificationSettings":{"notifyReviewPeriodEnd":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewerWhenOverdue":false,"notifyReviewerWhenReviewAssigned":false},"principalScopeSettings":{"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false,"type":"USERS"},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"resourceSettings":{"excludedResources":[],"includeAdminRoles":false,"includeEntitlements":false,"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"onlyIncludeOutOfPolicyEntitlements":false,"targetResources":[{"includeAllEntitlementsAndBundles":false,"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION"}],"type":"APPLICATION"},"reviewerSettings":{"bulkDecisionDisabled":true,"justificationRequired":true,"reassignmentDisabled":false,"reviewerId":"00uwvhlav3r3WdCqy1d7","selfReviewDisabled":true,"type":"USER"},"scheduleSettings":{"durationInDays":21,"recurrence":{"interval":""},"startDate":"2026-10-04T13:43:40Z","timeZone":"America/Vancouver","type":"ONE_OFF"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/governance/api/v1/campaigns
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2259
+        body: '{"_links":{"launchCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7/launch","hints":{}},"endCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7/end","hints":{}},"reviews":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpoiwfMzv6N1d7%22","hints":{}},"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7","hints":{}}},"id":"ici19ncpoiwfMzv6N1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:52:19Z","lastUpdated":"2026-03-29T13:52:19Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Quarterly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhlav3r3WdCqy1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2259"
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:52:19 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.273237708s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"_links":{"launchCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7/launch","hints":{}},"endCampaign":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7/end","hints":{}},"reviews":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpoiwfMzv6N1d7%22","hints":{}},"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7","hints":{}}},"id":"ici19ncpoiwfMzv6N1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:52:19Z","lastUpdated":"2026-03-29T13:52:19Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Quarterly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhlav3r3WdCqy1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:52:22 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.097174625s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpoiwfMzv6N1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Sun, 29 Mar 2026 13:52:23 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.154911083s

--- a/test/fixtures/vcr/governance/TestAccCampaignResource_requiresReplace/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccCampaignResource_requiresReplace/oie-00.yaml
@@ -1,0 +1,242 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1241
+        host: oie-00.dne-okta.com
+        body: |
+            {"campaignType":"RESOURCE","description":"Multi app campaign","name":"Monthly access review of sales team","notificationSettings":{"notifyReviewPeriodEnd":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewerWhenOverdue":false,"notifyReviewerWhenReviewAssigned":false},"principalScopeSettings":{"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false,"type":"USERS"},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"resourceSettings":{"excludedResources":[],"includeAdminRoles":false,"includeEntitlements":false,"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"onlyIncludeOutOfPolicyEntitlements":false,"targetResources":[{"includeAllEntitlementsAndBundles":false,"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION"}],"type":"APPLICATION"},"reviewerSettings":{"bulkDecisionDisabled":true,"justificationRequired":true,"reassignmentDisabled":false,"reviewerId":"00uwvhe0y85W3Iq6x1d7","selfReviewDisabled":true,"type":"USER"},"scheduleSettings":{"durationInDays":21,"recurrence":{"interval":""},"startDate":"2026-10-04T13:43:40Z","timeZone":"America/Vancouver","type":"ONE_OFF"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/campaigns
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2257
+        body: '{"_links":{"launchCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7/launch","hints":{}},"endCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7/end","hints":{}},"reviews":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpoc2PQjvPQ1d7%22","hints":{}},"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7","hints":{}}},"id":"ici19ncpoc2PQjvPQ1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:51:30Z","lastUpdated":"2026-03-29T13:51:30Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Monthly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhe0y85W3Iq6x1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2257"
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:51:30 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.316400833s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"_links":{"launchCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7/launch","hints":{}},"endCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7/end","hints":{}},"reviews":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpoc2PQjvPQ1d7%22","hints":{}},"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7","hints":{}}},"id":"ici19ncpoc2PQjvPQ1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:51:30Z","lastUpdated":"2026-03-29T13:51:30Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Monthly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhe0y85W3Iq6x1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:51:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.122616958s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"_links":{"launchCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7/launch","hints":{}},"endCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7/end","hints":{}},"reviews":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19ncpoc2PQjvPQ1d7%22","hints":{}},"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7","hints":{}}},"id":"ici19ncpoc2PQjvPQ1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:51:30Z","lastUpdated":"2026-03-29T13:51:30Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Monthly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhe0y85W3Iq6x1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:51:35 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.135623667s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/campaigns/ici19ncpoc2PQjvPQ1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Sun, 29 Mar 2026 13:51:37 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.163720083s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1243
+        host: oie-00.dne-okta.com
+        body: |
+            {"campaignType":"RESOURCE","description":"Multi app campaign","name":"Quarterly access review of sales team","notificationSettings":{"notifyReviewPeriodEnd":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewerWhenOverdue":false,"notifyReviewerWhenReviewAssigned":false},"principalScopeSettings":{"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false,"type":"USERS"},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"resourceSettings":{"excludedResources":[],"includeAdminRoles":false,"includeEntitlements":false,"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"onlyIncludeOutOfPolicyEntitlements":false,"targetResources":[{"includeAllEntitlementsAndBundles":false,"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION"}],"type":"APPLICATION"},"reviewerSettings":{"bulkDecisionDisabled":true,"justificationRequired":true,"reassignmentDisabled":false,"reviewerId":"00uwvhe0y85W3Iq6x1d7","selfReviewDisabled":true,"type":"USER"},"scheduleSettings":{"durationInDays":21,"recurrence":{"interval":""},"startDate":"2026-10-04T13:43:40Z","timeZone":"America/Vancouver","type":"ONE_OFF"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/campaigns
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2259
+        body: '{"_links":{"launchCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7/launch","hints":{}},"endCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7/end","hints":{}},"reviews":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19nco40ikyCZ3K1d7%22","hints":{}},"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7","hints":{}}},"id":"ici19nco40ikyCZ3K1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:51:41Z","lastUpdated":"2026-03-29T13:51:41Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Quarterly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhe0y85W3Iq6x1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2259"
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:51:41 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.301590958s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"_links":{"launchCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7/launch","hints":{}},"endCampaign":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7/end","hints":{}},"reviews":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/reviews?filter=campaignId%20eq%20%22ici19nco40ikyCZ3K1d7%22","hints":{}},"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7","hints":{}}},"id":"ici19nco40ikyCZ3K1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-03-29T13:51:41Z","lastUpdated":"2026-03-29T13:51:41Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","name":"Quarterly access review of sales team","description":"Multi app campaign","campaignType":"RESOURCE","scheduleSettings":{"type":"ONE_OFF","startDate":"2026-10-04T06:43:40-07:00","durationInDays":21,"timeZone":"America/Vancouver","endDate":"2026-10-25T06:43:40-07:00"},"resourceSettings":{"type":"APPLICATION","targetTypes":["APPLICATION"],"targetResources":[{"resourceId":"0oaws4am895IZbn6Q1d7","resourceType":"APPLICATION","includeAllEntitlementsAndBundles":false,"includeBundlesHavingSameEntitlementValues":false,"includeAllAppServiceAccounts":false}],"excludedResources":[],"individuallyAssignedAppsOnly":false,"individuallyAssignedGroupsOnly":false,"includeEntitlements":false,"onlyIncludeOutOfPolicyEntitlements":false,"includeAdminRoles":false,"includeAllOktaServiceAccounts":false},"principalScopeSettings":{"type":"USERS","excludedUserIds":[],"userIds":[],"groupIds":[],"includeOnlyActiveUsers":false,"onlyIncludeUsersWithSODConflicts":false},"reviewerSettings":{"type":"USER","reviewerId":"00uwvhe0y85W3Iq6x1d7","selfReviewDisabled":true,"justificationRequired":true,"bulkDecisionDisabled":true,"reassignmentDisabled":false},"notificationSettings":{"notifyReviewerWhenReviewAssigned":false,"notifyReviewerAtCampaignEnd":false,"notifyReviewerWhenOverdue":false,"notifyReviewerDuringMidpointOfReview":false,"notifyReviewPeriodEnd":false},"remediationSettings":{"accessApproved":"NO_ACTION","accessRevoked":"NO_ACTION","noResponse":"NO_ACTION"},"status":"SCHEDULED"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 29 Mar 2026 13:51:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.08217575s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/campaigns/ici19nco40ikyCZ3K1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Sun, 29 Mar 2026 13:51:45 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.193828333s


### PR DESCRIPTION
fixes #2527 , fixes #2738
The PR adds functionality to force replacement of the resource i.e destroy and recreate the resource with the updated fields.