### PR TITLE
Fix WebAuthn authenticator validation requiring unnecessary provider fields

### DIFF
--- a/okta/services/idaas/resource_okta_authenticator.go
+++ b/okta/services/idaas/resource_okta_authenticator.go
@@ -318,7 +318,8 @@ func buildAuthenticator(d *schema.ResourceData) (*sdk.Authenticator, error) {
 		Key:  d.Get("key").(string),
 		Name: d.Get("name").(string),
 	}
-	if d.Get("type").(string) == "security_key" {
+	// WebAuthn is a built-in authenticator and doesn't need provider configuration
+	if d.Get("type").(string) == "security_key" && d.Get("key").(string) != "webauthn" {
 		authenticator.Provider = &sdk.AuthenticatorProvider{
 			Type: d.Get("provider_type").(string),
 			Configuration: &sdk.AuthenticatorProviderConfiguration{
@@ -400,8 +401,14 @@ func buildOTP(d *schema.ResourceData) (*sdk.OTP, error) {
 
 func validateAuthenticator(d *schema.ResourceData) error {
 	typ := d.Get("type").(string)
+	key := d.Get("key").(string)
 	if typ == "security_key" {
-		if d.Get("key").(string) != "custom_otp" {
+		// WebAuthn is a built-in authenticator and doesn't need provider configuration
+		if key == "webauthn" {
+			// WebAuthn authenticators don't require provider fields
+			return nil
+		}
+		if key != "custom_otp" {
 			h := d.Get("provider_hostname").(string)
 			_, pok := d.GetOk("provider_auth_port")
 			s := d.Get("provider_shared_secret").(string)
@@ -445,7 +452,8 @@ func establishAuthenticator(authenticator *sdk.Authenticator, d *schema.Resource
 	if authenticator.Provider != nil {
 		_ = d.Set("provider_type", authenticator.Provider.Type)
 
-		if authenticator.Type == "security_key" {
+		// WebAuthn is a built-in authenticator and doesn't have provider configuration
+		if authenticator.Type == "security_key" && authenticator.Key != "webauthn" {
 			_ = d.Set("provider_hostname", authenticator.Provider.Configuration.HostName)
 			if authenticator.Provider.Configuration.AuthPortPtr != nil {
 				_ = d.Set("provider_auth_port", authenticator.Provider.Configuration.AuthPortPtr)

--- a/okta/services/idaas/resource_okta_authenticator_test.go
+++ b/okta/services/idaas/resource_okta_authenticator_test.go
@@ -301,3 +301,52 @@ func TestAccResourceOktaAuthenticator_ExternalIDPCrud(t *testing.T) {
 		},
 	})
 }
+
+// TestAccResourceOktaAuthenticator_WebAuthn_update
+// Tests that WebAuthn authenticators can be updated without requiring
+// on-premises provider configuration fields
+// Fixes: https://github.com/okta/terraform-provider-okta/issues/XXXX
+func TestAccResourceOktaAuthenticator_WebAuthn_update(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.webauthn", resources.OktaIDaaSAuthenticator)
+
+	configInitial := `
+resource "okta_authenticator" "webauthn" {
+  name   = "WebAuthn Test"
+  key    = "webauthn"
+  status = "ACTIVE"
+}`
+
+	configUpdated := `
+resource "okta_authenticator" "webauthn" {
+  name   = "WebAuthn Test Updated"
+  key    = "webauthn"
+  status = "ACTIVE"
+}`
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: configInitial,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "WebAuthn Test"),
+					resource.TestCheckResourceAttr(resourceName, "key", "webauthn"),
+					resource.TestCheckResourceAttr(resourceName, "type", "security_key"),
+					resource.TestCheckResourceAttr(resourceName, "status", idaas.StatusActive),
+				),
+			},
+			{
+				Config: configUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "WebAuthn Test Updated"),
+					resource.TestCheckResourceAttr(resourceName, "key", "webauthn"),
+					resource.TestCheckResourceAttr(resourceName, "type", "security_key"),
+					resource.TestCheckResourceAttr(resourceName, "status", idaas.StatusActive),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Description
Fixes a long-standing bug where the `okta_authenticator` resource incorrectly required on-premises provider configuration fields for WebAuthn authenticators during update operations.

## Problem
WebAuthn authenticators (key: `webauthn`) have type `security_key` in the Okta API, but the Terraform provider's validation logic treated ALL `security_key` authenticators as if they required on-premises MFA provider configuration (hostname, auth port, shared secret, username template).

This caused the following error on any update operation:
```
Error: for authenticator type 'security_key' fields 'provider_hostname',
'provider_auth_port', 'provider_shared_secret' and 'provider_user_name_template'
are required
```

## Solution
Added logic to distinguish between:
- **WebAuthn** (built-in Okta authenticator, no provider config needed)
- **On-premises MFA** (RSA, RADIUS, etc., requires provider config)

Modified three functions in `okta/services/idaas/resource_okta_authenticator.go`:
1. `validateAuthenticator()` - Skip provider field validation for WebAuthn
2. `buildAuthenticator()` - Skip building provider configuration for WebAuthn
3. `establishAuthenticator()` - Skip setting provider state fields for WebAuthn

## Impact
- ✅ WebAuthn authenticators can now be updated via Terraform
- ✅ Status changes (ACTIVE/INACTIVE) work correctly
- ✅ Name and property updates work correctly
- ✅ No breaking changes for existing configurations
- ✅ On-premises MFA authenticators still work as before

## Testing
Tested against Okta Preview environment with provider built from this branch:
- ✅ Initial creation with status ACTIVE - Works
- ✅ Update authenticator name - Works
- ✅ Update authenticator status - Validation passes (API errors if in use by policies, which is correct)
- ✅ No provider fields required for WebAuthn
- ✅ Provider fields still required for on-premises authenticators
- ✅ Added acceptance test: `TestAccResourceOktaAuthenticator_WebAuthn_update`

## Bug History
This bug has existed since at least v3.30.0 (circa 2022-2023) and persists through v6.7.0 (current latest). Tested across multiple versions:
- v3.30.0 ❌
- v4.10.0 ❌
- v6.5.5 ❌
- v6.7.0 ❌
- This fix ✅

## Related Context
This affects any customer using Infrastructure-as-Code to manage WebAuthn/Passkeys (FIDO2) authenticators.

## Checklist
- [x] Code follows existing conventions
- [x] Code formatted with `go fmt`
- [x] Changes are focused on the specific bug fix
- [x] No breaking changes
- [x] Acceptance test added
- [x] Manually tested against live Okta org