### PR TITLE
feat: delegate_appointments resource & dataSource

### DIFF
--- a/examples/data-sources/okta_delegate_appointments/data-source.tf
+++ b/examples/data-sources/okta_delegate_appointments/data-source.tf
@@ -1,0 +1,5 @@
+data "okta_delegate_appointments" "all" {}
+
+data "okta_delegate_appointments" "by_principal" {
+  principal_id = "00ub0oNGTSWTBKOLGLNR"
+}

--- a/examples/data-sources/okta_delegate_appointments/datasource.tf
+++ b/examples/data-sources/okta_delegate_appointments/datasource.tf
@@ -1,0 +1,31 @@
+resource "okta_user" "delegator" {
+  first_name = "TestAcc"
+  last_name  = "Delegator"
+  login      = "testAcc-delegator-replace_with_uuid@example.com"
+  email      = "testAcc-delegator-replace_with_uuid@example.com"
+}
+
+resource "okta_user" "delegate1" {
+  first_name = "TestAcc"
+  last_name  = "Delegate1"
+  login      = "testAcc-delegate1-replace_with_uuid@example.com"
+  email      = "testAcc-delegate1-replace_with_uuid@example.com"
+}
+
+resource "okta_delegate_appointments" "test" {
+  principal_id = okta_user.delegator.id
+
+  appointments {
+    delegate_id = okta_user.delegate1.id
+    note        = "Test appointment for data source"
+  }
+}
+
+data "okta_delegate_appointments" "all" {
+  depends_on = [okta_delegate_appointments.test]
+}
+
+data "okta_delegate_appointments" "by_principal" {
+  principal_id = okta_user.delegator.id
+  depends_on   = [okta_delegate_appointments.test]
+}

--- a/examples/resources/okta_delegate_appointments/basic.tf
+++ b/examples/resources/okta_delegate_appointments/basic.tf
@@ -1,0 +1,22 @@
+resource "okta_user" "delegator" {
+  first_name = "TestAcc"
+  last_name  = "Delegator"
+  login      = "testAcc-delegator-replace_with_uuid@example.com"
+  email      = "testAcc-delegator-replace_with_uuid@example.com"
+}
+
+resource "okta_user" "delegate1" {
+  first_name = "TestAcc"
+  last_name  = "Delegate1"
+  login      = "testAcc-delegate1-replace_with_uuid@example.com"
+  email      = "testAcc-delegate1-replace_with_uuid@example.com"
+}
+
+resource "okta_delegate_appointments" "test" {
+  principal_id = okta_user.delegator.id
+
+  appointments {
+    delegate_id = okta_user.delegate1.id
+    note        = "Covering while on PTO"
+  }
+}

--- a/examples/resources/okta_delegate_appointments/updated.tf
+++ b/examples/resources/okta_delegate_appointments/updated.tf
@@ -1,0 +1,22 @@
+resource "okta_user" "delegator" {
+  first_name = "TestAcc"
+  last_name  = "Delegator"
+  login      = "testAcc-delegator-replace_with_uuid@example.com"
+  email      = "testAcc-delegator-replace_with_uuid@example.com"
+}
+
+resource "okta_user" "delegate2" {
+  first_name = "TestAcc"
+  last_name  = "Delegate2"
+  login      = "testAcc-delegate2-replace_with_uuid@example.com"
+  email      = "testAcc-delegate2-replace_with_uuid@example.com"
+}
+
+resource "okta_delegate_appointments" "test" {
+  principal_id = okta_user.delegator.id
+
+  appointments {
+    delegate_id = okta_user.delegate2.id
+    note        = "Switched delegate"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lestrrat-go/jwx v1.2.31
-	github.com/okta/okta-governance-sdk-golang v1.0.1
+	github.com/okta/okta-governance-sdk-golang v1.1.0
 	github.com/okta/okta-sdk-golang/v4 v4.1.2
 	github.com/okta/okta-sdk-golang/v5 v5.0.6
 	github.com/okta/okta-sdk-golang/v6 v6.1.6

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/okta/okta-governance-sdk-golang v1.0.1 h1:gUrN6d/ToDONlH5euT24M2rfZH++TC8ZyoTjDOQO1sk=
-github.com/okta/okta-governance-sdk-golang v1.0.1/go.mod h1:1YDtCwP5TL2yFmN2Wd3kSrlR8bc1lI62Hd4X52YoO00=
+github.com/okta/okta-governance-sdk-golang v1.1.0 h1:yJxaz5qbePDVXf+ivtwXlh6AU0DjPxu6ruL6rXOjBWc=
+github.com/okta/okta-governance-sdk-golang v1.1.0/go.mod h1:RoDv9AnjWCdPkJj1KMk1wuc0+6P50re1jrKYeCe0k8k=
 github.com/okta/okta-sdk-golang/v4 v4.1.2 h1:gSycAYWGrvYeXBW8HakMZnNu/ptMuTvTQ/zZ7lgmtPI=
 github.com/okta/okta-sdk-golang/v4 v4.1.2/go.mod h1:01oiHDXvZQHlZo1Uw084VDYwXIqJe19z34b53PBZpUY=
 github.com/okta/okta-sdk-golang/v5 v5.0.6 h1:p7ptDMB1KxQ/7xSh+6FhMSybwl+ubTV4f1oL4N0Bu6U=

--- a/okta/api/governance.go
+++ b/okta/api/governance.go
@@ -13,7 +13,7 @@ type OktaGovernanceClient interface {
 }
 
 func oktaGovernanceSDKClient(c *OktaAPIConfig) (client *governance.OktaGovernanceAPIClient, err error) {
-	config, _, _ := getV5ClientConfig(c)
+	config, _, _ := getV6ClientConfig(c)
 	client = governance.NewAPIClient(config)
 	return client, nil
 }

--- a/okta/resources/resources.go
+++ b/okta/resources/resources.go
@@ -159,6 +159,7 @@ const (
 	OktaGovernanceCatalogEntryDefault                 = "okta_catalog_entry_default"
 	OktaGovernanceCatalogEntryUserAccessRequestFields = "okta_catalog_entry_user_access_request_fields"
 	OktaGovernanceEndUserMyRequests                   = "okta_end_user_my_requests"
+	OktaGovernanceDelegateAppointments                = "okta_delegate_appointments"
 	OktaIDaaSPushGroup                                = "okta_push_group"
 	OktaIDaaSPushGroups                               = "okta_push_groups"
 )

--- a/okta/services/governance/data_source_delegate_appointments.go
+++ b/okta/services/governance/data_source_delegate_appointments.go
@@ -8,10 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/okta/okta-governance-sdk-golang/governance"
 	"github.com/okta/terraform-provider-okta/okta/config"
 )
 
-var _ datasource.DataSource = &delegateAppointmentsDataSource{}
+var (
+	_ datasource.DataSource              = &delegateAppointmentsDataSource{}
+	_ datasource.DataSourceWithConfigure = &delegateAppointmentsDataSource{}
+)
 
 func newDelegateAppointmentsDataSource() datasource.DataSource {
 	return &delegateAppointmentsDataSource{}
@@ -136,7 +140,7 @@ func (d *delegateAppointmentsDataSource) Read(ctx context.Context, req datasourc
 		apiReq = apiReq.Filter(filter)
 	}
 
-	listResp, _, err := apiReq.Execute()
+	listResp, apiResp, err := apiReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading Delegate Appointments",
@@ -145,8 +149,22 @@ func (d *delegateAppointmentsDataSource) Read(ctx context.Context, req datasourc
 		return
 	}
 
-	appointments := make([]delegateAppointmentDataSourceModel, 0, len(listResp.Data))
-	for _, item := range listResp.Data {
+	allItems := listResp.Data
+	for apiResp.HasNextPage() {
+		var nextPage governance.DelegateAppointmentList
+		apiResp, err = apiResp.Next(&nextPage)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error reading Delegate Appointments",
+				"Could not read next page of delegate appointments: "+err.Error(),
+			)
+			return
+		}
+		allItems = append(allItems, nextPage.Data...)
+	}
+
+	appointments := make([]delegateAppointmentDataSourceModel, 0, len(allItems))
+	for _, item := range allItems {
 		appt := delegateAppointmentDataSourceModel{
 			Id:            types.StringValue(item.Id),
 			DelegatorId:   types.StringValue(item.Delegator.ExternalId),
@@ -177,6 +195,10 @@ func (d *delegateAppointmentsDataSource) Read(ctx context.Context, req datasourc
 	}
 
 	data.Data = appointments
-	data.Id = types.StringValue("delegate-appointments")
+	if !data.PrincipalId.IsNull() && !data.PrincipalId.IsUnknown() {
+		data.Id = types.StringValue("delegate-appointments-" + data.PrincipalId.ValueString())
+	} else {
+		data.Id = types.StringValue("delegate-appointments")
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/okta/services/governance/data_source_delegate_appointments.go
+++ b/okta/services/governance/data_source_delegate_appointments.go
@@ -1,0 +1,182 @@
+package governance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/okta/terraform-provider-okta/okta/config"
+)
+
+var _ datasource.DataSource = &delegateAppointmentsDataSource{}
+
+func newDelegateAppointmentsDataSource() datasource.DataSource {
+	return &delegateAppointmentsDataSource{}
+}
+
+type delegateAppointmentsDataSource struct {
+	*config.Config
+}
+
+type delegateAppointmentsDataSourceModel struct {
+	Id          types.String                         `tfsdk:"id"`
+	PrincipalId types.String                         `tfsdk:"principal_id"`
+	Data        []delegateAppointmentDataSourceModel `tfsdk:"data"`
+}
+
+type delegateAppointmentDataSourceModel struct {
+	Id            types.String `tfsdk:"id"`
+	DelegatorId   types.String `tfsdk:"delegator_id"`
+	DelegatorType types.String `tfsdk:"delegator_type"`
+	DelegateId    types.String `tfsdk:"delegate_id"`
+	DelegateType  types.String `tfsdk:"delegate_type"`
+	Note          types.String `tfsdk:"note"`
+	StartTime     types.String `tfsdk:"start_time"`
+	EndTime       types.String `tfsdk:"end_time"`
+	CreatedBy     types.String `tfsdk:"created_by"`
+	Created       types.String `tfsdk:"created"`
+	LastUpdated   types.String `tfsdk:"last_updated"`
+	LastUpdatedBy types.String `tfsdk:"last_updated_by"`
+}
+
+func (d *delegateAppointmentsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	d.Config = dataSourceConfiguration(req, resp)
+}
+
+func (d *delegateAppointmentsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_delegate_appointments"
+}
+
+func (d *delegateAppointmentsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists delegate appointments in Okta Identity Governance.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The internal identifier for this data source, required by Terraform to track state.",
+			},
+			"principal_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "The Okta principal ID to filter delegate appointments by delegator. If not specified, all delegate appointments in the org are returned.",
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"data": schema.ListNestedBlock{
+				Description: "The list of delegate appointments.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:    true,
+							Description: "Unique identifier for the delegate appointment.",
+						},
+						"delegator_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The Okta ID of the delegator.",
+						},
+						"delegator_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "The type of the delegator principal.",
+						},
+						"delegate_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The Okta ID of the delegate.",
+						},
+						"delegate_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "The type of the delegate principal.",
+						},
+						"note": schema.StringAttribute{
+							Computed:    true,
+							Description: "A note that describes the delegate appointment.",
+						},
+						"start_time": schema.StringAttribute{
+							Computed:    true,
+							Description: "The start time of the delegate appointment in RFC3339 format.",
+						},
+						"end_time": schema.StringAttribute{
+							Computed:    true,
+							Description: "The end time of the delegate appointment in RFC3339 format.",
+						},
+						"created_by": schema.StringAttribute{
+							Computed:    true,
+							Description: "The Okta user ID of the user who created the appointment.",
+						},
+						"created": schema.StringAttribute{
+							Computed:    true,
+							Description: "The ISO 8601 formatted date and time when the appointment was created.",
+						},
+						"last_updated": schema.StringAttribute{
+							Computed:    true,
+							Description: "The ISO 8601 formatted date and time when the appointment was last updated.",
+						},
+						"last_updated_by": schema.StringAttribute{
+							Computed:    true,
+							Description: "The Okta user ID of the user who last updated the appointment.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *delegateAppointmentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data delegateAppointmentsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq := d.OktaGovernanceClient.OktaGovernanceSDKClient().DelegatesAPI.ListDelegateAppointments(ctx)
+	if !data.PrincipalId.IsNull() && !data.PrincipalId.IsUnknown() {
+		filter := fmt.Sprintf(`delegatorId eq "%s"`, data.PrincipalId.ValueString())
+		apiReq = apiReq.Filter(filter)
+	}
+
+	listResp, _, err := apiReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading Delegate Appointments",
+			"Could not read delegate appointments, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	appointments := make([]delegateAppointmentDataSourceModel, 0, len(listResp.Data))
+	for _, item := range listResp.Data {
+		appt := delegateAppointmentDataSourceModel{
+			Id:            types.StringValue(item.Id),
+			DelegatorId:   types.StringValue(item.Delegator.ExternalId),
+			DelegatorType: types.StringValue(string(item.Delegator.Type)),
+			DelegateId:    types.StringValue(item.Delegate.ExternalId),
+			DelegateType:  types.StringValue(string(item.Delegate.Type)),
+			CreatedBy:     types.StringValue(item.CreatedBy),
+			Created:       types.StringValue(item.Created.Format(time.RFC3339)),
+			LastUpdated:   types.StringValue(item.LastUpdated.Format(time.RFC3339)),
+			LastUpdatedBy: types.StringValue(item.LastUpdatedBy),
+		}
+		if item.Note != nil {
+			appt.Note = types.StringValue(*item.Note)
+		} else {
+			appt.Note = types.StringNull()
+		}
+		if item.StartTime != nil {
+			appt.StartTime = types.StringValue(item.StartTime.Format(time.RFC3339))
+		} else {
+			appt.StartTime = types.StringNull()
+		}
+		if item.EndTime != nil {
+			appt.EndTime = types.StringValue(item.EndTime.Format(time.RFC3339))
+		} else {
+			appt.EndTime = types.StringNull()
+		}
+		appointments = append(appointments, appt)
+	}
+
+	data.Data = appointments
+	data.Id = types.StringValue("delegate-appointments")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/okta/services/governance/data_source_delegate_appointments_test.go
+++ b/okta/services/governance/data_source_delegate_appointments_test.go
@@ -1,0 +1,33 @@
+package governance_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+)
+
+func TestAccDelegateAppointments_dataSource(t *testing.T) {
+	mgr := newFixtureManager("data-sources", resources.OktaGovernanceDelegateAppointments, t.Name())
+	config := mgr.ConfigReplace(mgr.GetFixtures("datasource.tf", t))
+	allDataSourceName := fmt.Sprintf("data.%s.all", resources.OktaGovernanceDelegateAppointments)
+	filteredDataSourceName := fmt.Sprintf("data.%s.by_principal", resources.OktaGovernanceDelegateAppointments)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(allDataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(filteredDataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(filteredDataSourceName, "principal_id"),
+				),
+			},
+		},
+	})
+}

--- a/okta/services/governance/data_source_entitlement_bundle.go
+++ b/okta/services/governance/data_source_entitlement_bundle.go
@@ -186,7 +186,7 @@ func (d *entitlementBundleDataSource) Read(ctx context.Context, req datasource.R
 		resp.Diagnostics.AddError("Missing entitlement Id", "The 'id' attribute must be set in the configuration.")
 		return
 	}
-	readEntitlementBundleResp, _, err := d.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetentitlementBundle(ctx, entitlementId).Execute()
+	readEntitlementBundleResp, _, err := d.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetEntitlementBundle(ctx, entitlementId).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read entitlement bundle",

--- a/okta/services/governance/data_source_request_v2.go
+++ b/okta/services/governance/data_source_request_v2.go
@@ -160,7 +160,7 @@ func (d *requestV2DataSource) Read(ctx context.Context, req datasource.ReadReque
 	data.LastUpdated = types.StringValue(getRequestV2Resp.GetLastUpdated().Format(time.RFC3339))
 	data.LastUpdatedBy = types.StringValue(getRequestV2Resp.GetLastUpdatedBy())
 	data.Requested = setRequested(getRequestV2Resp.GetRequested())
-	data.RequestedBy = setRequestedBy(getRequestV2Resp.GetRequestedBy())
+	data.RequestedBy = setRequestedByClientCredential(getRequestV2Resp.GetRequestedBy())
 	data.RequestedFor = setRequestedBy(getRequestV2Resp.GetRequestedFor())
 	// Save Data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/okta/services/governance/data_source_review.go
+++ b/okta/services/governance/data_source_review.go
@@ -338,13 +338,13 @@ func buildReviewerGroupProfile(profile *governance.ReviewerGroupProfile) groupPr
 	}
 }
 
-func buildUserProfileModel(profile *governance.PrincipalProfile) userProfileModel {
+func buildUserProfileModel(profile *governance.PrincipalProfileEnriched) userProfileModel {
 	userProfile := userProfileModel{}
 	if profile == nil {
 		return userProfileModel{}
 	}
 	userProfile.Id = types.StringValue(profile.Id)
-	userProfile.Email = types.StringValue(profile.Email)
+	userProfile.Email = types.StringValue(profile.GetEmail())
 	if profile.FirstName != nil {
 		userProfile.FirstName = types.StringValue(*profile.FirstName)
 	}
@@ -373,7 +373,7 @@ func convertLinks(links *governance.ReviewLinks) *linksModel {
 	}
 }
 
-func convertPrincipalProfile(p *governance.PrincipalProfile) *principalProfileModel {
+func convertPrincipalProfile(p *governance.PrincipalProfileEnriched) *principalProfileModel {
 	if p == nil {
 		return nil
 	}

--- a/okta/services/governance/governance.go
+++ b/okta/services/governance/governance.go
@@ -21,6 +21,7 @@ func FWProviderResources() []func() resource.Resource {
 		newRequestV2Resource,
 		newEndUserMyRequestsResource,
 		newEntitlementBundleResource,
+		newDelegateAppointmentsResource,
 	}
 	// Wrap all resources with SafeResource for panic recovery
 	return resources.WrapResources(rawResources)
@@ -41,6 +42,7 @@ func FWProviderDataSources() []func() datasource.DataSource {
 		newCatalogEntryUserAccessRequestFieldsDataSource,
 		newEndUserMyRequestsDataSource,
 		newEntitlementBundleDataSource,
+		newDelegateAppointmentsDataSource,
 	}
 }
 

--- a/okta/services/governance/resource_campaign.go
+++ b/okta/services/governance/resource_campaign.go
@@ -1075,9 +1075,9 @@ func buildCampaign(d campaignResourceModel) governance.CampaignMutable {
 	ExcludedResources := make([]governance.ResourceSettingsMutableExcludedResourcesInner, 0, len(d.ResourceSettings.ExcludedResources))
 	for _, ex := range d.ResourceSettings.ExcludedResources {
 		x := ex.ResourceId.ValueString()
-		var resourceType *governance.ResourceType
+		var resourceType *governance.ResourceTypeExclude
 		if !ex.ResourceType.IsNull() && ex.ResourceType.ValueString() != "" {
-			rt := governance.ResourceType(ex.ResourceType.ValueString())
+			rt := governance.ResourceTypeExclude(ex.ResourceType.ValueString())
 			resourceType = &rt
 		}
 		excludedRes := governance.ResourceSettingsMutableExcludedResourcesInner{

--- a/okta/services/governance/resource_delegate_appointments.go
+++ b/okta/services/governance/resource_delegate_appointments.go
@@ -181,7 +181,21 @@ func (r *delegateAppointmentsResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
-	applyDelegateAppointmentListToState(&data, listResp)
+	allItems := listResp.Data
+	for apiResp.HasNextPage() {
+		var nextPage governance.DelegateAppointmentList
+		apiResp, err = apiResp.Next(&nextPage)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error reading Delegate Appointments",
+				fmt.Sprintf("Could not read next page of delegate appointments for principal %s: %s", principalId, err.Error()),
+			)
+			return
+		}
+		allItems = append(allItems, nextPage.Data...)
+	}
+
+	applyDelegateAppointmentListToState(&data, allItems)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -316,18 +330,18 @@ func applyDelegateAppointmentsResponseToState(data *delegateAppointmentsResource
 	reorderAppointmentsToMatchPlan(data, apiAppointments)
 }
 
-func applyDelegateAppointmentListToState(data *delegateAppointmentsResourceModel, listResp *governance.DelegateAppointmentList) {
+func applyDelegateAppointmentListToState(data *delegateAppointmentsResourceModel, items []governance.DelegateAppointment) {
 	data.Id = data.PrincipalId
 	if data.PrincipalType.IsNull() || data.PrincipalType.IsUnknown() {
 		data.PrincipalType = types.StringValue(defaultPrincipalType)
 	}
 
-	if listResp == nil {
+	if len(items) == 0 {
 		data.Appointments = []delegateAppointmentBlockModel{}
 		return
 	}
 
-	reorderAppointmentsToMatchPlan(data, listResp.Data)
+	reorderAppointmentsToMatchPlan(data, items)
 }
 
 func reorderAppointmentsToMatchPlan(data *delegateAppointmentsResourceModel, apiAppointments []governance.DelegateAppointment) {

--- a/okta/services/governance/resource_delegate_appointments.go
+++ b/okta/services/governance/resource_delegate_appointments.go
@@ -1,0 +1,378 @@
+package governance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/okta/okta-governance-sdk-golang/governance"
+	"github.com/okta/terraform-provider-okta/okta/config"
+)
+
+const defaultPrincipalType = "OKTA_USER"
+
+var (
+	_ resource.Resource                = &delegateAppointmentsResource{}
+	_ resource.ResourceWithConfigure   = &delegateAppointmentsResource{}
+	_ resource.ResourceWithImportState = &delegateAppointmentsResource{}
+)
+
+func newDelegateAppointmentsResource() resource.Resource {
+	return &delegateAppointmentsResource{}
+}
+
+type delegateAppointmentsResource struct {
+	*config.Config
+}
+
+type delegateAppointmentsResourceModel struct {
+	Id            types.String                    `tfsdk:"id"`
+	PrincipalId   types.String                    `tfsdk:"principal_id"`
+	PrincipalType types.String                    `tfsdk:"principal_type"`
+	Appointments  []delegateAppointmentBlockModel `tfsdk:"appointments"`
+}
+
+type delegateAppointmentBlockModel struct {
+	DelegateId types.String `tfsdk:"delegate_id"`
+	Note       types.String `tfsdk:"note"`
+	StartTime  types.String `tfsdk:"start_time"`
+	EndTime    types.String `tfsdk:"end_time"`
+}
+
+func (r *delegateAppointmentsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_delegate_appointments"
+}
+
+func (r *delegateAppointmentsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages delegate appointments for a principal in Okta Identity Governance. " +
+			"This resource represents settings that always exist in Okta for a given principal. " +
+			"Creating this resource adopts management of the principal's delegate appointments, " +
+			"and destroying it resets the appointments to an empty state.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The internal identifier for this resource, required by Terraform to track state.",
+			},
+			"principal_id": schema.StringAttribute{
+				Required:    true,
+				Description: "The Okta ID of the principal whose delegate appointments are being managed.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"principal_type": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(defaultPrincipalType),
+				Description: fmt.Sprintf("The type of principal. Defaults to %q.", defaultPrincipalType),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"appointments": schema.ListNestedBlock{
+				Description: "The list of delegate appointments for this principal. The API currently supports a maximum of one appointment per principal.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"delegate_id": schema.StringAttribute{
+							Required:    true,
+							Description: "The Okta user ID of the delegate.",
+						},
+						"note": schema.StringAttribute{
+							Optional:    true,
+							Description: "A note that describes the delegate appointment.",
+						},
+						"start_time": schema.StringAttribute{
+							Optional:    true,
+							Description: "The start time of the delegate appointment in RFC3339 format.",
+						},
+						"end_time": schema.StringAttribute{
+							Optional:    true,
+							Description: "The end time of the delegate appointment in RFC3339 format.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *delegateAppointmentsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.Config = resourceConfiguration(req, resp)
+}
+
+func (r *delegateAppointmentsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("principal_id"), req, resp)
+}
+
+func (r *delegateAppointmentsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data delegateAppointmentsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	patchable, diags := buildDelegateAppointmentsPatchable(data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	principalId := data.PrincipalId.ValueString()
+
+	tflog.Debug(ctx, "creating delegate appointments", map[string]interface{}{
+		"principal_id":      principalId,
+		"appointment_count": len(patchable.Delegates.Appointments),
+	})
+
+	settingsResp, apiResp, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().PrincipalSettingsAPI.UpdatePrincipalSettings(ctx, principalId).PrincipalSettingsPatchable(patchable).Execute()
+	if err != nil {
+		errMsg := err.Error()
+		if apiResp != nil && apiResp.Body != nil {
+			defer apiResp.Body.Close()
+			if body, readErr := io.ReadAll(apiResp.Body); readErr == nil && len(body) > 0 {
+				errMsg = fmt.Sprintf("%s — response body: %s", errMsg, string(body))
+			}
+		}
+		resp.Diagnostics.AddError(
+			"Error creating Delegate Appointments",
+			fmt.Sprintf("Could not create delegate appointments for principal %s: %s", principalId, errMsg),
+		)
+		return
+	}
+
+	applyDelegateAppointmentsResponseToState(&data, settingsResp)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *delegateAppointmentsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data delegateAppointmentsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	principalId := data.PrincipalId.ValueString()
+
+	filter := fmt.Sprintf(`delegatorId eq "%s"`, principalId)
+	listResp, apiResp, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().DelegatesAPI.ListDelegateAppointments(ctx).Filter(filter).Execute()
+	if err != nil {
+		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error reading Delegate Appointments",
+			fmt.Sprintf("Could not read delegate appointments for principal %s: %s", principalId, err.Error()),
+		)
+		return
+	}
+
+	applyDelegateAppointmentListToState(&data, listResp)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *delegateAppointmentsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data delegateAppointmentsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	patchable, diags := buildDelegateAppointmentsPatchable(data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	principalId := data.PrincipalId.ValueString()
+
+	tflog.Debug(ctx, "updating delegate appointments", map[string]interface{}{
+		"principal_id":      principalId,
+		"appointment_count": len(patchable.Delegates.Appointments),
+	})
+
+	settingsResp, apiResp, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().PrincipalSettingsAPI.UpdatePrincipalSettings(ctx, principalId).PrincipalSettingsPatchable(patchable).Execute()
+	if err != nil {
+		errMsg := err.Error()
+		if apiResp != nil && apiResp.Body != nil {
+			defer apiResp.Body.Close()
+			if body, readErr := io.ReadAll(apiResp.Body); readErr == nil && len(body) > 0 {
+				errMsg = fmt.Sprintf("%s — response body: %s", errMsg, string(body))
+			}
+		}
+		resp.Diagnostics.AddError(
+			"Error updating Delegate Appointments",
+			fmt.Sprintf("Could not update delegate appointments for principal %s: %s", principalId, errMsg),
+		)
+		return
+	}
+
+	applyDelegateAppointmentsResponseToState(&data, settingsResp)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *delegateAppointmentsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data delegateAppointmentsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	principalId := data.PrincipalId.ValueString()
+	patchable := governance.PrincipalSettingsPatchable{
+		Delegates: &governance.DelegatesPatchable{
+			Appointments: []governance.DelegatePatchable{},
+		},
+	}
+
+	_, apiResp, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().PrincipalSettingsAPI.UpdatePrincipalSettings(ctx, principalId).PrincipalSettingsPatchable(patchable).Execute()
+	if err != nil {
+		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error deleting Delegate Appointments",
+			fmt.Sprintf("Could not remove delegate appointments for principal %s: %s", principalId, err.Error()),
+		)
+		return
+	}
+}
+
+func buildDelegateAppointmentsPatchable(data delegateAppointmentsResourceModel) (governance.PrincipalSettingsPatchable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	appointments := make([]governance.DelegatePatchable, 0, len(data.Appointments))
+	for _, appt := range data.Appointments {
+		dp := governance.DelegatePatchable{
+			Delegate: governance.DelegateAppointmentDelegate{
+				ExternalId: appt.DelegateId.ValueString(),
+				Type:       governance.PRINCIPALTYPE_OKTA_USER,
+			},
+		}
+		if !appt.Note.IsNull() && !appt.Note.IsUnknown() {
+			note := appt.Note.ValueString()
+			dp.Note = &note
+		}
+		if !appt.StartTime.IsNull() && !appt.StartTime.IsUnknown() {
+			t, err := time.Parse(time.RFC3339, appt.StartTime.ValueString())
+			if err != nil {
+				diags.AddAttributeError(
+					path.Root("appointments"),
+					"Invalid start_time",
+					fmt.Sprintf("Could not parse start_time %q as RFC3339: %s", appt.StartTime.ValueString(), err.Error()),
+				)
+				continue
+			}
+			dp.StartTime = &t
+		}
+		if !appt.EndTime.IsNull() && !appt.EndTime.IsUnknown() {
+			t, err := time.Parse(time.RFC3339, appt.EndTime.ValueString())
+			if err != nil {
+				diags.AddAttributeError(
+					path.Root("appointments"),
+					"Invalid end_time",
+					fmt.Sprintf("Could not parse end_time %q as RFC3339: %s", appt.EndTime.ValueString(), err.Error()),
+				)
+				continue
+			}
+			dp.EndTime = &t
+		}
+		appointments = append(appointments, dp)
+	}
+
+	return governance.PrincipalSettingsPatchable{
+		Delegates: &governance.DelegatesPatchable{
+			Appointments: appointments,
+		},
+	}, diags
+}
+
+func applyDelegateAppointmentsResponseToState(data *delegateAppointmentsResourceModel, settingsResp *governance.PrincipalSettings) {
+	data.Id = data.PrincipalId
+	if data.PrincipalType.IsNull() || data.PrincipalType.IsUnknown() {
+		data.PrincipalType = types.StringValue(defaultPrincipalType)
+	}
+
+	if settingsResp.Delegates == nil {
+		data.Appointments = []delegateAppointmentBlockModel{}
+		return
+	}
+
+	apiAppointments := settingsResp.Delegates.GetAppointments()
+	reorderAppointmentsToMatchPlan(data, apiAppointments)
+}
+
+func applyDelegateAppointmentListToState(data *delegateAppointmentsResourceModel, listResp *governance.DelegateAppointmentList) {
+	data.Id = data.PrincipalId
+	if data.PrincipalType.IsNull() || data.PrincipalType.IsUnknown() {
+		data.PrincipalType = types.StringValue(defaultPrincipalType)
+	}
+
+	if listResp == nil {
+		data.Appointments = []delegateAppointmentBlockModel{}
+		return
+	}
+
+	reorderAppointmentsToMatchPlan(data, listResp.Data)
+}
+
+func reorderAppointmentsToMatchPlan(data *delegateAppointmentsResourceModel, apiAppointments []governance.DelegateAppointment) {
+	apiByDelegateId := make(map[string]governance.DelegateAppointment, len(apiAppointments))
+	for _, a := range apiAppointments {
+		apiByDelegateId[a.Delegate.ExternalId] = a
+	}
+
+	matched := make(map[string]bool, len(data.Appointments))
+	result := make([]delegateAppointmentBlockModel, 0, len(apiAppointments))
+	for _, planned := range data.Appointments {
+		delegateId := planned.DelegateId.ValueString()
+		if a, ok := apiByDelegateId[delegateId]; ok {
+			result = append(result, appointmentFromAPI(a))
+			matched[delegateId] = true
+		}
+	}
+
+	for _, a := range apiAppointments {
+		if !matched[a.Delegate.ExternalId] {
+			result = append(result, appointmentFromAPI(a))
+		}
+	}
+
+	data.Appointments = result
+}
+
+func appointmentFromAPI(a governance.DelegateAppointment) delegateAppointmentBlockModel {
+	m := delegateAppointmentBlockModel{
+		DelegateId: types.StringValue(a.Delegate.ExternalId),
+	}
+	if a.Note != nil {
+		m.Note = types.StringValue(*a.Note)
+	} else {
+		m.Note = types.StringNull()
+	}
+	if a.StartTime != nil {
+		m.StartTime = types.StringValue(a.StartTime.Format(time.RFC3339))
+	} else {
+		m.StartTime = types.StringNull()
+	}
+	if a.EndTime != nil {
+		m.EndTime = types.StringValue(a.EndTime.Format(time.RFC3339))
+	} else {
+		m.EndTime = types.StringNull()
+	}
+	return m
+}

--- a/okta/services/governance/resource_delegate_appointments_test.go
+++ b/okta/services/governance/resource_delegate_appointments_test.go
@@ -1,0 +1,111 @@
+package governance_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+)
+
+func TestAccDelegateAppointments_basic(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceDelegateAppointments, t.Name())
+	config := mgr.ConfigReplace(mgr.GetFixtures("basic.tf", t))
+	updatedConfig := mgr.ConfigReplace(mgr.GetFixtures("updated.tf", t))
+	resourceName := fmt.Sprintf("%s.test", resources.OktaGovernanceDelegateAppointments)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkDelegateAppointmentsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "principal_id"),
+					resource.TestCheckResourceAttr(resourceName, "principal_type", "OKTA_USER"),
+					resource.TestCheckResourceAttr(resourceName, "appointments.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "appointments.0.delegate_id"),
+					resource.TestCheckResourceAttr(resourceName, "appointments.0.note", "Covering while on PTO"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "appointments.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "appointments.0.delegate_id"),
+					resource.TestCheckResourceAttr(resourceName, "appointments.0.note", "Switched delegate"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDelegateAppointments_import(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceDelegateAppointments, t.Name())
+	config := mgr.ConfigReplace(mgr.GetFixtures("basic.tf", t))
+	resourceName := fmt.Sprintf("%s.test", resources.OktaGovernanceDelegateAppointments)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "principal_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// checkDelegateAppointmentsDestroy verifies that delegate appointments have been removed
+func checkDelegateAppointmentsDestroy(s *terraform.State) error {
+	if os.Getenv("OKTA_VCR_TF_ACC") == "play" {
+		return nil
+	}
+
+	client := governanceAPIClientForTestUtil
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != resources.OktaGovernanceDelegateAppointments {
+			continue
+		}
+
+		principalId := rs.Primary.Attributes["principal_id"]
+		filter := fmt.Sprintf(`delegatorId eq "%s"`, principalId)
+
+		listResp, apiResp, err := client.OktaGovernanceSDKClient().DelegatesAPI.ListDelegateAppointments(
+			context.Background(),
+		).Filter(filter).Execute()
+
+		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error checking if delegate appointments for principal %s were destroyed: %v", principalId, err)
+		}
+
+		if len(listResp.Data) > 0 {
+			return fmt.Errorf("delegate appointments for principal %s still exist (%d remaining)", principalId, len(listResp.Data))
+		}
+	}
+
+	return nil
+}

--- a/okta/services/governance/resource_entitlement_bundle.go
+++ b/okta/services/governance/resource_entitlement_bundle.go
@@ -166,7 +166,7 @@ func (r *entitlementBundleResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	// Read API call logic
-	getEntitlementBundleResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetentitlementBundle(ctx, data.Id.ValueString()).Execute()
+	getEntitlementBundleResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetEntitlementBundle(ctx, data.Id.ValueString()).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading campaign",

--- a/okta/services/governance/resource_request_v2.go
+++ b/okta/services/governance/resource_request_v2.go
@@ -393,6 +393,13 @@ func setRequestedBy(by governance.TargetPrincipal) *entitlementParentModel {
 	}
 }
 
+func setRequestedByClientCredential(by governance.ClientCredentialPrincipal) *entitlementParentModel {
+	return &entitlementParentModel{
+		Type:       types.StringValue(by.GetType()),
+		ExternalID: types.StringValue(by.GetExternalId()),
+	}
+}
+
 func setRequested(getRequested governance.Requested) *requested {
 	var reqResource requested
 	reqResource.EntryId = types.StringValue(getRequested.GetEntryId())
@@ -406,11 +413,9 @@ func setRequested(getRequested governance.Requested) *requested {
 
 func createRequestReq(data requestV2ResourceModel) governance.RequestCreatable2 {
 	var reqCreatable governance.RequestCreatable2
-	reqCreatable.Requested = governance.RequestResourceCreatable{
-		RequestResourceCatalogEntryCreatable: &governance.RequestResourceCatalogEntryCreatable{
-			Type:    data.Requested.Type.ValueString(),
-			EntryId: data.Requested.EntryId.ValueString(),
-		},
+	reqCreatable.Requested = governance.RequestResourceCatalogEntryCreatable{
+		Type:    data.Requested.Type.ValueString(),
+		EntryId: data.Requested.EntryId.ValueString(),
 	}
 	reqCreatable.RequestedFor = governance.TargetPrincipal{
 		ExternalId: data.RequestedFor.ExternalID.ValueString(),

--- a/test/fixtures/vcr/governance/TestAccDelegateAppointments_basic/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccDelegateAppointments_basic/oie-00.yaml
@@ -1,0 +1,258 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh48r7spvNXo2g1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh48r7spvNXo2g1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh48r7spvNXo2g1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:08:27 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.121447167s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 134
+        host: oie-00.dne-okta.com
+        body: |
+            {"delegates":{"appointments":[{"delegate":{"externalId":"00uxh4hk2eI9OD9Ee1d7","type":"OKTA_USER"},"note":"Covering while on PTO"}]}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/principal-settings/00uxh48r7spvNXo2g1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"delegates":{"appointments":[{"delegator":{"externalId":"00uxh48r7spvNXo2g1d7","type":"OKTA_USER"},"id":"gda1aapefvg6sCx4t1d7","delegate":{"externalId":"00uxh4hk2eI9OD9Ee1d7","type":"OKTA_USER"},"note":"Covering while on PTO","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:08:28Z","lastUpdated":"2026-04-13T06:08:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}]}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:08:29 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.38979725s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh48r7spvNXo2g1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh48r7spvNXo2g1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh48r7spvNXo2g1d7","type":"OKTA_USER"},"id":"gda1aapefvg6sCx4t1d7","delegate":{"externalId":"00uxh4hk2eI9OD9Ee1d7","type":"OKTA_USER"},"note":"Covering while on PTO","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:08:28Z","lastUpdated":"2026-04-13T06:08:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh48r7spvNXo2g1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:08:31 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.080910125s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh48r7spvNXo2g1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh48r7spvNXo2g1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh48r7spvNXo2g1d7","type":"OKTA_USER"},"id":"gda1aapefvg6sCx4t1d7","delegate":{"externalId":"00uxh4hk2eI9OD9Ee1d7","type":"OKTA_USER"},"note":"Covering while on PTO","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:08:28Z","lastUpdated":"2026-04-13T06:08:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh48r7spvNXo2g1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:08:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 693.811458ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 130
+        host: oie-00.dne-okta.com
+        body: |
+            {"delegates":{"appointments":[{"delegate":{"externalId":"00uxh4zu6gSS2SEry1d7","type":"OKTA_USER"},"note":"Switched delegate"}]}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/principal-settings/00uxh48r7spvNXo2g1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"delegates":{"appointments":[{"delegator":{"externalId":"00uxh48r7spvNXo2g1d7","type":"OKTA_USER"},"id":"gda1aapefvg6sCx4t1d7","delegate":{"externalId":"00uxh4zu6gSS2SEry1d7","type":"OKTA_USER"},"note":"Switched delegate","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:08:28Z","lastUpdated":"2026-04-13T06:08:36Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}]}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:08:36 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 970.682667ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh48r7spvNXo2g1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh48r7spvNXo2g1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh48r7spvNXo2g1d7","type":"OKTA_USER"},"id":"gda1aapefvg6sCx4t1d7","delegate":{"externalId":"00uxh4zu6gSS2SEry1d7","type":"OKTA_USER"},"note":"Switched delegate","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:08:28Z","lastUpdated":"2026-04-13T06:08:36Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh48r7spvNXo2g1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:08:39 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 877.682292ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 34
+        host: oie-00.dne-okta.com
+        body: |
+            {"delegates":{"appointments":[]}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/principal-settings/00uxh48r7spvNXo2g1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"delegates":{"appointments":[]}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:08:40 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 736.988084ms

--- a/test/fixtures/vcr/governance/TestAccDelegateAppointments_dataSource/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccDelegateAppointments_dataSource/oie-00.yaml
@@ -1,0 +1,425 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh4k8qtH8qqjBi1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh4k8qtH8qqjBi1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh4k8qtH8qqjBi1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:27 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 676.160167ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 145
+        host: oie-00.dne-okta.com
+        body: |
+            {"delegates":{"appointments":[{"delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source"}]}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/principal-settings/00uxh4k8qtH8qqjBi1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"delegates":{"appointments":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}]}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 950.4175ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh4k8qtH8qqjBi1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh4k8qtH8qqjBi1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh4k8qtH8qqjBi1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:29 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 985.179875ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:29 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.012684416s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:30 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 672.375375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh4k8qtH8qqjBi1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh4k8qtH8qqjBi1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh4k8qtH8qqjBi1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:30 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 676.419ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh4k8qtH8qqjBi1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh4k8qtH8qqjBi1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh4k8qtH8qqjBi1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:32 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 645.352458ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh4k8qtH8qqjBi1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh4k8qtH8qqjBi1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh4k8qtH8qqjBi1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:32 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 660.76075ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 989.011291ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 650.68675ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh4k8qtH8qqjBi1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh4k8qtH8qqjBi1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh4k8qtH8qqjBi1d7","type":"OKTA_USER"},"id":"gda1aapf7jPIBi0E91d7","delegate":{"externalId":"00uxh4b8p6vckNAUo1d7","type":"OKTA_USER"},"note":"Test appointment for data source","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:28Z","lastUpdated":"2026-04-13T06:09:28Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh4k8qtH8qqjBi1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 660.382583ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 34
+        host: oie-00.dne-okta.com
+        body: |
+            {"delegates":{"appointments":[]}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/principal-settings/00uxh4k8qtH8qqjBi1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"delegates":{"appointments":[]}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:35 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 910.408417ms

--- a/test/fixtures/vcr/governance/TestAccDelegateAppointments_import/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccDelegateAppointments_import/oie-00.yaml
@@ -1,0 +1,185 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh3zslt9yx5zgP1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh3zslt9yx5zgP1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh3zslt9yx5zgP1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 666.046292ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 134
+        host: oie-00.dne-okta.com
+        body: |
+            {"delegates":{"appointments":[{"delegate":{"externalId":"00uxh4gy1adcOO6tb1d7","type":"OKTA_USER"},"note":"Covering while on PTO"}]}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/principal-settings/00uxh3zslt9yx5zgP1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"delegates":{"appointments":[{"delegator":{"externalId":"00uxh3zslt9yx5zgP1d7","type":"OKTA_USER"},"id":"gda1aapf6ynw7Jail1d7","delegate":{"externalId":"00uxh4gy1adcOO6tb1d7","type":"OKTA_USER"},"note":"Covering while on PTO","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:01Z","lastUpdated":"2026-04-13T06:09:01Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}]}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 959.127541ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh3zslt9yx5zgP1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh3zslt9yx5zgP1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh3zslt9yx5zgP1d7","type":"OKTA_USER"},"id":"gda1aapf6ynw7Jail1d7","delegate":{"externalId":"00uxh4gy1adcOO6tb1d7","type":"OKTA_USER"},"note":"Covering while on PTO","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:01Z","lastUpdated":"2026-04-13T06:09:01Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh3zslt9yx5zgP1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:03 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 866.913666ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - delegatorId eq "00uxh3zslt9yx5zgP1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/delegates?filter=delegatorId+eq+%2200uxh3zslt9yx5zgP1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"delegator":{"externalId":"00uxh3zslt9yx5zgP1d7","type":"OKTA_USER"},"id":"gda1aapf6ynw7Jail1d7","delegate":{"externalId":"00uxh4gy1adcOO6tb1d7","type":"OKTA_USER"},"note":"Covering while on PTO","createdBy":"00u5m6b6h6YuejsVW1d7","created":"2026-04-13T06:09:01Z","lastUpdated":"2026-04-13T06:09:01Z","lastUpdatedBy":"00u5m6b6h6YuejsVW1d7"}],"_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v1/delegates?filter=delegatorId%20eq%20%2200uxh3zslt9yx5zgP1d7%22&limit=20","hints":{}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:05 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 848.680916ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 34
+        host: oie-00.dne-okta.com
+        body: |
+            {"delegates":{"appointments":[]}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/principal-settings/00uxh3zslt9yx5zgP1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"delegates":{"appointments":[]}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 13 Apr 2026 06:09:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 919.030958ms


### PR DESCRIPTION
Add resource and data source for managing `delegate appointments` in Okta Identity Governance

The resource models delegate settings as a piece of configuration that always exists in Okta (PATCH-only API), create applies the desired state, destroy resets the configuration to empty (no defined delegates)

Also upgrades okta-governance-sdk-golang v1.0.1 → v1.1.0
which required fixing breaking changes in 6 existing governance files (method renames, type changes)