### PR TITLE
fix(okta_request_condition): add RequiresReplace to resource_id (#2780)

### DIFF
--- a/examples/resources/okta_request_condition/issue_2780.tf
+++ b/examples/resources/okta_request_condition/issue_2780.tf
@@ -1,0 +1,13 @@
+resource "okta_request_condition" "test" {
+  resource_id          = "0oatu8k9anRWwR1oq1d7"
+  approval_sequence_id = "695cd5cd4bfe7d01dbcacb51"
+  name                 = "issue-2780"
+
+  requester_settings {
+    type = "EVERYONE"
+  }
+
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+}

--- a/examples/resources/okta_request_condition/issue_2780_updated.tf
+++ b/examples/resources/okta_request_condition/issue_2780_updated.tf
@@ -1,0 +1,13 @@
+resource "okta_request_condition" "test" {
+  resource_id          = "0oaty79sxfpt7AVvI1d7"
+  approval_sequence_id = "695cd5cd4bfe7d01dbcacb51"
+  name                 = "issue-2780"
+
+  requester_settings {
+    type = "EVERYONE"
+  }
+
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+}

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-governance-sdk-golang/governance"
@@ -92,6 +94,9 @@ func (r *requestConditionResource) Schema(ctx context.Context, req resource.Sche
 			"resource_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The id of the resource in Okta ID format.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"approval_sequence_id": schema.StringAttribute{
 				Required:    true,

--- a/okta/services/governance/resource_request_condition_test.go
+++ b/okta/services/governance/resource_request_condition_test.go
@@ -103,6 +103,40 @@ func TestAccRequestConditionResource_Status(t *testing.T) {
 	})
 }
 
+// TestAccRequestConditionResource_Issue2780 verifies that changing resource_id
+// triggers a destroy+create (replacement) rather than an in-place update that
+// would 404 because the condition does not exist on the new resource.
+func TestAccRequestConditionResource_Issue2780(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceRequestCondition, t.Name())
+	config := mgr.GetFixtures("issue_2780.tf", t)
+	updatedConfig := mgr.GetFixtures("issue_2780_updated.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaGovernanceRequestCondition)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkRequestConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "issue-2780"),
+					resource.TestCheckResourceAttr(resourceName, "resource_id", "0oatu8k9anRWwR1oq1d7"),
+				),
+			},
+			{
+				// Changing resource_id must trigger destroy+create, not a 404-failing update.
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "issue-2780"),
+					resource.TestCheckResourceAttr(resourceName, "resource_id", "0oaty79sxfpt7AVvI1d7"),
+				),
+			},
+		},
+	})
+}
+
 // checkRequestConditionDestroy verifies that request conditions have been destroyed
 func checkRequestConditionDestroy(s *terraform.State) error {
 	// Skip destroy check in VCR playback mode

--- a/test/fixtures/vcr/governance/TestAccRequestConditionResource_Issue2780/classic-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccRequestConditionResource_Issue2780/classic-00.yaml
@@ -1,0 +1,242 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 173
+        host: classic-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","priority":0,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 549
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afx8mlNgzYWFA1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:01:07Z","lastUpdated":"2026-04-16T06:01:07Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afx8mlNgzYWFA1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "549"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:01:07 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afx8mlNgzYWFA1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.729996916s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afx8mlNgzYWFA1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afx8mlNgzYWFA1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:01:07Z","lastUpdated":"2026-04-16T06:01:07Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afx8mlNgzYWFA1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:01:09 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.136876917s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afx8mlNgzYWFA1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afx8mlNgzYWFA1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:01:07Z","lastUpdated":"2026-04-16T06:01:07Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afx8mlNgzYWFA1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:01:10 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.125969333s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afx8mlNgzYWFA1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 16 Apr 2026 06:01:11 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.222007667s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 173
+        host: classic-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","priority":0,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 549
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afzjx7gg4N1F21d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:01:13Z","lastUpdated":"2026-04-16T06:01:13Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afzjx7gg4N1F21d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "549"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:01:13 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afzjx7gg4N1F21d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.67291625s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afzjx7gg4N1F21d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afzjx7gg4N1F21d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:01:13Z","lastUpdated":"2026-04-16T06:01:13Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://classic-00-admin.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afzjx7gg4N1F21d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:01:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.113451459s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afzjx7gg4N1F21d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 16 Apr 2026 06:01:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.221252375s

--- a/test/fixtures/vcr/governance/TestAccRequestConditionResource_Issue2780/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccRequestConditionResource_Issue2780/oie-00.yaml
@@ -1,0 +1,242 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 173
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","priority":0,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 549
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afzjx2mlKJR451d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:00:45Z","lastUpdated":"2026-04-16T06:00:45Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afzjx2mlKJR451d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "549"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:00:45 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afzjx2mlKJR451d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 2.033089917s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afzjx2mlKJR451d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afzjx2mlKJR451d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:00:45Z","lastUpdated":"2026-04-16T06:00:45Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afzjx2mlKJR451d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:00:46 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.134236792s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afzjx2mlKJR451d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afzjx2mlKJR451d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:00:45Z","lastUpdated":"2026-04-16T06:00:45Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afzjx2mlKJR451d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:00:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.130393042s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oatu8k9anRWwR1oq1d7/request-conditions/rco1afzjx2mlKJR451d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 16 Apr 2026 06:00:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.200577458s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 173
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","priority":0,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 549
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afx8miZ20srs51d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:00:51Z","lastUpdated":"2026-04-16T06:00:51Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afx8miZ20srs51d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "549"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:00:51 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afx8miZ20srs51d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.906402459s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afx8miZ20srs51d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2780","id":"rco1afx8miZ20srs51d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:00:51Z","lastUpdated":"2026-04-16T06:00:51Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afx8miZ20srs51d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:00:52 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.113576834s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1afx8miZ20srs51d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 16 Apr 2026 06:00:54 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.325949042s


### PR DESCRIPTION
## Summary
- `resource_id` lacked `RequiresReplace()`, so changing it triggered an in-place Update that 404'd because the condition only exists under the original resource
- Added `stringplanmodifier.RequiresReplace()` to `resource_id` schema attribute so Terraform performs destroy+create instead
- Fixes #2780

## Test plan
- [x] `TestAccRequestConditionResource_Issue2780` — two-step acceptance test: create with resource A, update to resource B, verifies destroy+create path
- [x] VCR cassette recorded and playback verified