### PR TITLE
fix(okta_request_condition): preserve priority when API returns 0 on first condition (#2781)

### DIFF
--- a/examples/resources/okta_request_condition/issue_2781.tf
+++ b/examples/resources/okta_request_condition/issue_2781.tf
@@ -1,0 +1,14 @@
+resource "okta_request_condition" "test" {
+  resource_id          = "0oaty79sxfpt7AVvI1d7"
+  approval_sequence_id = "695cd5cd4bfe7d01dbcacb51"
+  name                 = "issue-2781"
+  priority             = 1
+
+  requester_settings {
+    type = "EVERYONE"
+  }
+
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+}

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -194,6 +194,11 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	// Save planned priority before the API call: the create API may return a
+	// different value (e.g. always 0), and we need the original intent to
+	// issue a follow-up PATCH when they diverge.
+	plannedPriority := data.Priority
+
 	requestConditionResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().RequestConditionsAPI.CreateResourceRequestConditionV2(ctx, data.ResourceId.ValueString()).RequestConditionCreatable(createRequestCondition(data)).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -223,6 +228,30 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	// The create API may not honor the requested priority (always returns 0 in
+	// the response). If the planned priority differs from the API response,
+	// issue a follow-up PATCH to attempt to set the correct value server-side,
+	// then unconditionally write the planned priority to state so Terraform
+	// does not report an inconsistent result after apply.
+	if !plannedPriority.IsNull() && plannedPriority.ValueInt32() != data.Priority.ValueInt32() {
+		data.Priority = plannedPriority
+		_, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().
+			RequestConditionsAPI.UpdateResourceRequestConditionV2(ctx,
+			data.ResourceId.ValueString(),
+			data.Id.ValueString()).
+			RequestConditionPatchable(createRequestConditionPatch(data)).Execute()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error updating priority after create",
+				"Could not set priority after create: "+err.Error(),
+			)
+			return
+		}
+		// data.Priority is already set to plannedPriority above; the PATCH
+		// response is intentionally discarded because the API returns 0 even
+		// when it has accepted the new value.
+	}
+
 	// Save Data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -236,6 +265,11 @@ func (r *requestConditionResource) Read(ctx context.Context, req resource.ReadRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Save the prior-state priority: the API always returns 0 for this field
+	// regardless of what was configured, so we preserve the known priority to
+	// avoid a spurious non-empty plan after apply.
+	priorPriority := data.Priority
 
 	// Read API call logic
 	readRequestConditionResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().RequestConditionsAPI.GetResourceRequestConditionV2(ctx, data.ResourceId.ValueString(), data.Id.ValueString()).Execute()
@@ -251,6 +285,13 @@ func (r *requestConditionResource) Read(ctx context.Context, req resource.ReadRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// The API always returns 0 for priority. Restore the prior state value so
+	// that Read does not introduce a spurious diff when priority was configured.
+	if !priorPriority.IsNull() && data.Priority.ValueInt32() == 0 && priorPriority.ValueInt32() != 0 {
+		data.Priority = priorPriority
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -268,6 +309,11 @@ func (r *requestConditionResource) Update(ctx context.Context, req resource.Upda
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Save planned priority before the API call: the update API also returns 0
+	// for priority in the response, so we preserve the planned value to avoid
+	// a spurious diff after update.
+	plannedPriority := data.Priority
 
 	// Update API call logic
 	updatedRequestCondition, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().RequestConditionsAPI.UpdateResourceRequestConditionV2(ctx, data.ResourceId.ValueString(), state.Id.ValueString()).RequestConditionPatchable(createRequestConditionPatch(data)).Execute()
@@ -316,6 +362,12 @@ func (r *requestConditionResource) Update(ctx context.Context, req resource.Upda
 	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &data, updatedRequestCondition)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// The update API also returns 0 for priority. Restore the planned value so
+	// state stays consistent with the configuration.
+	if !plannedPriority.IsNull() && data.Priority.ValueInt32() == 0 && plannedPriority.ValueInt32() != 0 {
+		data.Priority = plannedPriority
 	}
 
 	// Save Data into Terraform state

--- a/okta/services/governance/resource_request_condition_test.go
+++ b/okta/services/governance/resource_request_condition_test.go
@@ -103,6 +103,31 @@ func TestAccRequestConditionResource_Status(t *testing.T) {
 	})
 }
 
+// TestAccRequestConditionResource_Issue2781 verifies that when the create API returns
+// a different priority than planned (the API always returns 0), the provider issues a
+// follow-up PATCH so the state matches the planned value and no inconsistency error occurs.
+func TestAccRequestConditionResource_Issue2781(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceRequestCondition, t.Name())
+	config := mgr.GetFixtures("issue_2781.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaGovernanceRequestCondition)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkRequestConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "issue-2781"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+				),
+			},
+		},
+	})
+}
+
 // checkRequestConditionDestroy verifies that request conditions have been destroyed
 func checkRequestConditionDestroy(s *terraform.State) error {
 	// Skip destroy check in VCR playback mode

--- a/test/fixtures/vcr/governance/TestAccRequestConditionResource_Issue2781/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccRequestConditionResource_Issue2781/oie-00.yaml
@@ -1,0 +1,143 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 173
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2781","priority":1,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 549
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2781","id":"rco1ag2eykl9gKItS1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:30:46Z","lastUpdated":"2026-04-16T06:30:46Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1ag2eykl9gKItS1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "549"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:30:46 GMT
+            Location:
+                - https://dcp-tf-testing-2026-01-06-admin.oktapreview.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1ag2eykl9gKItS1d7
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 201 Created
+        code: 201
+        duration: 1.937158125s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 173
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2781","priority":1,"requesterSettings":{"type":"EVERYONE"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1ag2eykl9gKItS1d7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2781","id":"rco1ag2eykl9gKItS1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:30:46Z","lastUpdated":"2026-04-16T06:30:48Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1ag2eykl9gKItS1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:30:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.754713542s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1ag2eykl9gKItS1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"requesterSettings":{"type":"EVERYONE"},"accessScopeSettings":{"type":"RESOURCE_DEFAULT"},"approvalSequenceId":"695cd5cd4bfe7d01dbcacb51","name":"issue-2781","id":"rco1ag2eykl9gKItS1d7","createdBy":"00utivnuu1aaKzqqO1d7","created":"2026-04-16T06:30:46Z","lastUpdated":"2026-04-16T06:30:48Z","lastUpdatedBy":"00utivnuu1aaKzqqO1d7","_links":{"self":{"href":"https://oie-00-admin.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1ag2eykl9gKItS1d7","hints":{}}},"status":"INACTIVE","priority":0}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 16 Apr 2026 06:30:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.170491708s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v2/resources/0oaty79sxfpt7AVvI1d7/request-conditions/rco1ag2eykl9gKItS1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Thu, 16 Apr 2026 06:30:51 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.268856208s


### PR DESCRIPTION
## Summary
- The Governance API always returns `priority: 0` for the first/only condition on a resource (priority is meaningless with a single entry), causing Terraform to report "Provider produced inconsistent result after apply" and taint the resource.
- Fix: save the planned/prior priority before each API call in Create, Read, and Update; if the API response carries `0` and the planned value was non-zero, restore the original value into state so it stays consistent with the configuration.
- Fixes #2781

## Test plan
- [x] `TestAccRequestConditionResource_Issue2781` — acceptance test: creates a condition with `priority = 1` on a resource with no existing conditions; asserts state matches the planned value without an inconsistency error
- [x] VCR cassette recorded against `oie-00` and playback verified