### PR TITLE
fix(okta_request_condition): mark resource_id as RequiresReplace

### DIFF
--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/okta/okta-governance-sdk-golang/governance"
@@ -92,6 +94,9 @@ func (r *requestConditionResource) Schema(ctx context.Context, req resource.Sche
 			"resource_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The id of the resource in Okta ID format.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"approval_sequence_id": schema.StringAttribute{
 				Required:    true,


### PR DESCRIPTION
### Summary

Changing `resource_id` on an `okta_request_condition` causes a 404 error because the provider attempts an in-place update. Request conditions are scoped to a specific app via the API path (`/governance/api/v2/resources/{resourceId}/request-conditions/{requestConditionId}`), so they cannot be moved between apps.

### Changes

Added `RequiresReplace()` plan modifier to the `resource_id` schema attribute, ensuring Terraform destroys and recreates the resource when `resource_id` changes. This follows the same pattern used in `resource_campaign.go`.

### Testing

Existing acceptance tests continue to pass. The fix is a schema-level change that doesn't alter runtime behavior for unchanged `resource_id` values.

Fixes #2780