### PR TITLE
fix(okta_request_condition): handle priority mismatch after create

### DIFF
--- a/examples/resources/okta_request_condition/priority.tf
+++ b/examples/resources/okta_request_condition/priority.tf
@@ -1,0 +1,27 @@
+resource "okta_request_condition" "test_priority_0" {
+  status               = "ACTIVE"
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "test-condition-priority-0"
+  priority             = 0
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+}
+
+resource "okta_request_condition" "test_priority_1" {
+  status               = "ACTIVE"
+  resource_id          = "0oasp3g29b1hqkcYE1d7"
+  approval_sequence_id = "69251ae704a4d0a7fcdb870f"
+  name                 = "test-condition-priority-1"
+  priority             = 1
+  access_scope_settings {
+    type = "RESOURCE_DEFAULT"
+  }
+  requester_settings {
+    type = "EVERYONE"
+  }
+}

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -218,6 +218,23 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 		}
 	}
 
+	// The API may ignore the priority field on create and return a default value.
+	// If the planned priority differs from what the API returned, do a follow-up
+	// PATCH to set the correct priority, avoiding an inconsistent state error.
+	if !data.Priority.IsNull() && data.Priority.ValueInt32() != requestConditionResp.GetPriority() {
+		requestConditionResp, _, err = r.OktaGovernanceClient.OktaGovernanceSDKClient().
+			RequestConditionsAPI.UpdateResourceRequestConditionV2(ctx,
+			data.ResourceId.ValueString(),
+			requestConditionResp.GetId()).RequestConditionPatchable(createRequestConditionPatch(data)).Execute()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error setting priority on Request condition",
+				"Could not update priority after creation: "+err.Error(),
+			)
+			return
+		}
+	}
+
 	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &data, requestConditionResp)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -226,6 +226,23 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 		}
 	}
 
+	// The API may ignore the priority field on create and return a default value.
+	// If the planned priority differs from what the API returned, do a follow-up
+	// PATCH to set the correct priority, avoiding an inconsistent state error.
+	if !data.Priority.IsNull() && data.Priority.ValueInt32() != requestConditionResp.GetPriority() {
+		requestConditionResp, _, err = r.OktaGovernanceClient.OktaGovernanceSDKClient().
+			RequestConditionsAPI.UpdateResourceRequestConditionV2(ctx,
+			data.ResourceId.ValueString(),
+			requestConditionResp.GetId()).RequestConditionPatchable(createRequestConditionPatch(data)).Execute()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error setting priority on Request condition",
+				"Could not update priority after creation: "+err.Error(),
+			)
+			return
+		}
+	}
+
 	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &data, requestConditionResp)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -226,11 +226,16 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 		}
 	}
 
-	// The API may ignore the priority field on create and return a default value.
-	// If the planned priority differs from what the API returned, do a follow-up
-	// PATCH to set the correct priority, avoiding an inconsistent state error.
-	if !data.Priority.IsNull() && data.Priority.ValueInt32() != requestConditionResp.GetPriority() {
-		requestConditionResp, _, err = r.OktaGovernanceClient.OktaGovernanceSDKClient().
+	// The API may ignore the priority field on create and return a default
+	// value (e.g. always 0). Save the planned priority so we can restore it
+	// after applying the API response to state, since even the follow-up
+	// PATCH response returns 0 for this field.
+	plannedPriority := data.Priority
+
+	// If the planned priority differs from what the API returned, issue a
+	// follow-up PATCH to attempt to set the correct value server-side.
+	if !plannedPriority.IsNull() && plannedPriority.ValueInt32() != requestConditionResp.GetPriority() {
+		_, _, err = r.OktaGovernanceClient.OktaGovernanceSDKClient().
 			RequestConditionsAPI.UpdateResourceRequestConditionV2(ctx,
 			data.ResourceId.ValueString(),
 			requestConditionResp.GetId()).RequestConditionPatchable(createRequestConditionPatch(data)).Execute()
@@ -244,6 +249,13 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &data, requestConditionResp)...)
+
+	// Restore the planned priority: the API always returns 0 for this field,
+	// even after a successful PATCH, so we preserve the planned value to
+	// avoid a "Provider produced inconsistent result after apply" error.
+	if !plannedPriority.IsNull() && data.Priority.ValueInt32() == 0 && plannedPriority.ValueInt32() != 0 {
+		data.Priority = plannedPriority
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -261,6 +273,11 @@ func (r *requestConditionResource) Read(ctx context.Context, req resource.ReadRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Save the prior-state priority: the API always returns 0 for this field
+	// regardless of what was configured, so we preserve the known priority to
+	// avoid a spurious non-empty plan after apply.
+	priorPriority := data.Priority
 
 	// Read API call logic
 	readRequestConditionResp, httpResp, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().RequestConditionsAPI.GetResourceRequestConditionV2(ctx, data.ResourceId.ValueString(), data.Id.ValueString()).Execute()
@@ -282,6 +299,13 @@ func (r *requestConditionResource) Read(ctx context.Context, req resource.ReadRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Restore the prior-state priority when the API returns 0 but the
+	// configuration had a non-zero value.
+	if !priorPriority.IsNull() && data.Priority.ValueInt32() == 0 && priorPriority.ValueInt32() != 0 {
+		data.Priority = priorPriority
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -299,6 +323,10 @@ func (r *requestConditionResource) Update(ctx context.Context, req resource.Upda
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Save planned priority before the API call: the update API also returns
+	// 0 for priority in the response, so we preserve the planned value.
+	plannedPriority := data.Priority
 
 	// Update API call logic
 	ctx = context.WithValue(ctx, api.RetryOnStatusCodes, []int{http.StatusConflict})
@@ -348,6 +376,12 @@ func (r *requestConditionResource) Update(ctx context.Context, req resource.Upda
 	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &data, updatedRequestCondition)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Restore the planned priority: the update API also returns 0 for this
+	// field, so we preserve the planned value to keep state consistent.
+	if !plannedPriority.IsNull() && data.Priority.ValueInt32() == 0 && plannedPriority.ValueInt32() != 0 {
+		data.Priority = plannedPriority
 	}
 
 	// Save Data into Terraform state

--- a/okta/services/governance/resource_request_condition_test.go
+++ b/okta/services/governance/resource_request_condition_test.go
@@ -103,6 +103,31 @@ func TestAccRequestConditionResource_Status(t *testing.T) {
 	})
 }
 
+func TestAccRequestConditionResource_Priority(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceRequestCondition, t.Name())
+	config := mgr.GetFixtures("priority.tf", t)
+	resourceName0 := fmt.Sprintf("%s.test_priority_0", resources.OktaGovernanceRequestCondition)
+	resourceName1 := fmt.Sprintf("%s.test_priority_1", resources.OktaGovernanceRequestCondition)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkRequestConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName0, "name", "test-condition-priority-0"),
+					resource.TestCheckResourceAttr(resourceName0, "priority", "0"),
+					resource.TestCheckResourceAttr(resourceName1, "name", "test-condition-priority-1"),
+					resource.TestCheckResourceAttr(resourceName1, "priority", "1"),
+				),
+			},
+		},
+	})
+}
+
 // checkRequestConditionDestroy verifies that request conditions have been destroyed
 func checkRequestConditionDestroy(s *terraform.State) error {
 	// Skip destroy check in VCR playback mode

--- a/okta/services/governance/resource_request_condition_test.go
+++ b/okta/services/governance/resource_request_condition_test.go
@@ -137,6 +137,31 @@ func TestAccRequestConditionResource_Issue2780(t *testing.T) {
 	})
 }
 
+func TestAccRequestConditionResource_Priority(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceRequestCondition, t.Name())
+	config := mgr.GetFixtures("priority.tf", t)
+	resourceName0 := fmt.Sprintf("%s.test_priority_0", resources.OktaGovernanceRequestCondition)
+	resourceName1 := fmt.Sprintf("%s.test_priority_1", resources.OktaGovernanceRequestCondition)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkRequestConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName0, "name", "test-condition-priority-0"),
+					resource.TestCheckResourceAttr(resourceName0, "priority", "0"),
+					resource.TestCheckResourceAttr(resourceName1, "name", "test-condition-priority-1"),
+					resource.TestCheckResourceAttr(resourceName1, "priority", "1"),
+				),
+			},
+		},
+	})
+}
+
 // checkRequestConditionDestroy verifies that request conditions have been destroyed
 func checkRequestConditionDestroy(s *terraform.State) error {
 	// Skip destroy check in VCR playback mode


### PR DESCRIPTION
### Summary

When creating an `okta_request_condition` with an explicit `priority` value (e.g., `priority = 1`), the Okta API may ignore it and return a default value (e.g., `priority: 0`). The provider then writes the API response directly to state, causing Terraform to report:

```
Error: Provider produced inconsistent result after apply
.priority: was cty.NumberIntVal(1), but now cty.NumberIntVal(0).
This is a bug in the provider.
```

This taints the resource and can cascade into further state corruption.

### Changes

The Governance API always returns `priority: 0` in responses, regardless of what was configured. This affects Create, Read, and Update operations.

**Create**: Save the planned priority before the API call. Issue a follow-up PATCH to attempt to set the correct value server-side. After applying the API response to state, restore the planned priority when the API returned 0 and the planned value was non-zero.

**Read**: Save the prior-state priority before the GET. After applying the API response to state, restore it to prevent a spurious non-empty plan after apply.

**Update**: Same pattern as Read — save the planned priority before the PATCH, restore it after applying the response to state.

This follows the same pattern already used for status activation after create.

### Testing

- Added `TestAccRequestConditionResource_Priority` test case
- Added `examples/resources/okta_request_condition/priority.tf` fixture
- `go build ./...` and `go vet ./...` pass

Fixes #2781