### PR TITLE
fix(provider): allow provider configuration without credentials (#2799, #2588)

### DIFF
--- a/okta/provider/provider.go
+++ b/okta/provider/provider.go
@@ -128,14 +128,6 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	log.Printf("[INFO] Initializing Okta client")
 	cfg := config.NewConfig(d)
-	if cfg.ApiToken == "" && cfg.AccessToken == "" && cfg.PrivateKey == "" {
-		return nil, diag.Errorf(
-			"[ERROR] no Okta credentials provided. Please set one of the following: " +
-				"'api_token' (or OKTA_API_TOKEN env var), " +
-				"'access_token' (or OKTA_ACCESS_TOKEN env var), or " +
-				"'private_key' + 'client_id' (or OKTA_API_PRIVATE_KEY + OKTA_API_CLIENT_ID env vars). " +
-				"See https://registry.terraform.io/providers/okta/okta/latest/docs for more information")
-	}
 	if err := cfg.LoadAPIClient(); err != nil {
 		return nil, diag.Errorf("[ERROR] failed to load sdk clients: %v", err)
 	}

--- a/sdk/v2_validator.go
+++ b/sdk/v2_validator.go
@@ -55,8 +55,11 @@ func validateOktaDomain(c *config) error {
 }
 
 func validateAPIToken(c *config) error {
+	// An empty token is allowed at init time; any API call will return a 401
+	// from the server. This permits provider configuration without credentials
+	// when no Okta resources are actually deployed (e.g. count = 0 / for_each = {}).
 	if c.Okta.Client.Token == "" {
-		return errors.New("your Okta API token is missing. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token")
+		return nil
 	}
 
 	if strings.Contains(c.Okta.Client.Token, "{apiToken}") {


### PR DESCRIPTION
## Summary
- **Root cause (#2799):** PR #2669 introduced an early credential check in \`providerConfigure()\` that fires even when \`count = 0\` / \`for_each = {}\` (no resources deployed), forcing credentials in all environments.
- **Root cause (#2588):** The local v2 SDK's \`validateConfig()\` rejected an empty token at init time, leaving \`OktaIDaaSClient\` nil and causing a nil pointer panic on any subsequent API call.
- **Fix 1 (\`okta/provider/provider.go\`):** Remove the early credential guard from #2669; credentials validated lazily when an actual API call is made.
- **Fix 2 (\`sdk/v2_validator.go\`):** Allow empty token at SDK client init — unauthenticated API calls return a proper 401 from Okta instead of crashing with nil dereference.
- The nil-check and error-propagation improvements from #2669 (\`fwprovider/framework_provider.go\`, \`okta/config/config.go\`) are preserved.
- Fixes #2799
- Fixes #2588

## Test plan
- [ ] \`count = 0\` Terraform config with no credentials — provider configures, plan/apply succeeds
- [ ] Resources with valid credentials — provider configures and API calls succeed as before
- [ ] Resources with no credentials — API calls return 401 from Okta (no nil pointer panic)
