### PR TITLE
feat: add non-blocking plan time warning for unrecognized image format

### DIFF
--- a/okta/utils/utils.go
+++ b/okta/utils/utils.go
@@ -850,8 +850,40 @@ func LogoFileIsValid() schema.SchemaValidateDiagFunc {
 		if stat.Size() > 1<<20 { // should be less than 1 MB in size.
 			return diag.Errorf("file '%s' should be less than 1 MB in size", v)
 		}
-		return nil
+
+		var diags diag.Diagnostics
+		if !logoFileLooksSupported(v) {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Warning,
+				Summary:       "Unable to verify logo file matches one of the supported formats (PNG, JPG, GIF)",
+				Detail:        "This may fail during terraform apply.",
+				AttributePath: k,
+			})
+		}
+		return diags
 	}
+}
+
+// logoFileLooksSupported reads the first bytes of the file and reports whether
+// they sniff as one of the formats Okta accepts for app logos. A false return
+// is best-effort — the file may still be valid (e.g. an unreadable file or an
+// edge-case encoding); callers should treat it as "unverified", not "invalid".
+func logoFileLooksSupported(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return true // can't sniff; don't warn on top of whatever os.Stat already caught
+	}
+	defer f.Close()
+	buf := make([]byte, 512)
+	n, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		return true
+	}
+	switch http.DetectContentType(buf[:n]) {
+	case "image/png", "image/jpeg", "image/gif":
+		return true
+	}
+	return false
 }
 
 // NewExponentialBackOffWithContext helper to dry up creating a backoff object that is exponential and has context

--- a/okta/utils/utils_test.go
+++ b/okta/utils/utils_test.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"encoding/json"
 	"log"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -379,6 +381,98 @@ func TestIntersection(t *testing.T) {
 	assert.Equal(t, []string{"c", "d", "e"}, intersection)
 	assert.Equal(t, []string{"a", "b"}, exclusiveOld)
 	assert.Equal(t, []string{"f", "g"}, exclusiveNew)
+}
+
+func TestLogoFileIsValid(t *testing.T) {
+	const supportedPNG = "../../examples/resources/okta_app_basic_auth/terraform_icon.png"
+
+	dir := t.TempDir()
+
+	svgPath := filepath.Join(dir, "logo.svg")
+	if err := os.WriteFile(svgPath, []byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`), 0o600); err != nil {
+		t.Fatalf("write svg fixture: %v", err)
+	}
+	garbagePath := filepath.Join(dir, "logo.png")
+	if err := os.WriteFile(garbagePath, []byte("not actually an image"), 0o600); err != nil {
+		t.Fatalf("write garbage fixture: %v", err)
+	}
+	oversizedPath := filepath.Join(dir, "big.png")
+	if err := os.WriteFile(oversizedPath, make([]byte, (1<<20)+1), 0o600); err != nil {
+		t.Fatalf("write oversized fixture: %v", err)
+	}
+
+	cases := []struct {
+		name          string
+		input         string
+		wantErrors    bool
+		wantWarnings  bool
+		summarySubstr string
+	}{
+		{
+			name:  "supported png",
+			input: supportedPNG,
+		},
+		{
+			name:          "unsupported svg warns but does not error",
+			input:         svgPath,
+			wantWarnings:  true,
+			summarySubstr: "supported formats",
+		},
+		{
+			name:          "garbage bytes warn but do not error",
+			input:         garbagePath,
+			wantWarnings:  true,
+			summarySubstr: "supported formats",
+		},
+		{
+			name:          "missing file errors",
+			input:         filepath.Join(dir, "does-not-exist"),
+			wantErrors:    true,
+			summarySubstr: "invalid",
+		},
+		{
+			name:          "oversized file errors",
+			input:         oversizedPath,
+			wantErrors:    true,
+			summarySubstr: "less than 1 MB",
+		},
+	}
+
+	validate := LogoFileIsValid()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diags := validate(c.input, cty.Path{})
+			var hasErr, hasWarn bool
+			var summaries []string
+			for _, d := range diags {
+				summaries = append(summaries, d.Summary)
+				if d.Severity == diag.Error {
+					hasErr = true
+				}
+				if d.Severity == diag.Warning {
+					hasWarn = true
+				}
+			}
+			if hasErr != c.wantErrors {
+				t.Errorf("errors: got %v want %v (diags=%v)", hasErr, c.wantErrors, summaries)
+			}
+			if hasWarn != c.wantWarnings {
+				t.Errorf("warnings: got %v want %v (diags=%v)", hasWarn, c.wantWarnings, summaries)
+			}
+			if c.summarySubstr != "" {
+				found := false
+				for _, s := range summaries {
+					if strings.Contains(s, c.summarySubstr) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected summary containing %q, got %v", c.summarySubstr, summaries)
+				}
+			}
+		})
+	}
 }
 
 func TestLogoStateFunc(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a non-blocking, plan-time warning when the file pointed to by a
`logo` attribute doesn't sniff as one of the formats the Okta API
accepts (PNG, JPG, GIF). Previously the schema validator only checked
existence and size, so a misnamed or unsupported file (e.g. an `.svg`
or a renamed text file) silently passed and the failure surfaced later
as an API error during `terraform apply`.

Affects every resource that uses the shared `logo` attribute:
- `okta_app_*` (oauth, saml, swa, basic_auth, bookmark, etc.) via the
  shared schema in `okta/services/idaas/app.go`
- `okta_org_configuration`

## Why a warning, not an error

- Sniffing `http.DetectContentType` is best-effort; unreadable files or
  edge-case encodings shouldn't be hard-blocked by the provider when
  the API itself might still accept them.
- The set of formats Okta accepts may grow over time (e.g. SVG support
  in the future); a hard error here would block users from adopting
  new API support until the provider catches up.