### PR TITLE
GH-2775 | Import "users" When Importing okta_group_memberships

### DIFF
--- a/examples/resources/okta_group_memberships/import.tf
+++ b/examples/resources/okta_group_memberships/import.tf
@@ -1,0 +1,32 @@
+import {
+  to = okta_group_memberships.test
+  id = okta_group.test.id
+}
+
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "testing import"
+}
+
+resource "okta_user" "test1" {
+  first_name = "ImportTestAcc1"
+  last_name  = "User"
+  login      = "import-testAcc1-replace_with_uuid@example.com"
+  email      = "import-testAcc1-replace_with_uuid@example.com"
+}
+
+resource "okta_user" "test2" {
+  first_name = "ImportTestAcc2"
+  last_name  = "User"
+  login      = "import-testAcc2-replace_with_uuid@example.com"
+  email      = "import-testAcc2-replace_with_uuid@example.com"
+}
+
+resource "okta_group_memberships" "test" {
+  group_id        = okta_group.test.id
+  track_all_users = true
+  users = [
+    okta_user.test1.id,
+    okta_user.test2.id,
+  ]
+}

--- a/examples/resources/okta_group_memberships/import_base.tf
+++ b/examples/resources/okta_group_memberships/import_base.tf
@@ -1,0 +1,27 @@
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "testing import"
+}
+
+resource "okta_user" "test1" {
+  first_name = "ImportTestAcc1"
+  last_name  = "User"
+  login      = "import-testAcc1-replace_with_uuid@example.com"
+  email      = "import-testAcc1-replace_with_uuid@example.com"
+}
+
+resource "okta_user" "test2" {
+  first_name = "ImportTestAcc2"
+  last_name  = "User"
+  login      = "import-testAcc2-replace_with_uuid@example.com"
+  email      = "import-testAcc2-replace_with_uuid@example.com"
+}
+
+resource "okta_group_memberships" "test" {
+  group_id        = okta_group.test.id
+  track_all_users = true
+  users = [
+    okta_user.test1.id,
+    okta_user.test2.id,
+  ]
+}

--- a/okta/services/idaas/resource_okta_group_memberships.go
+++ b/okta/services/idaas/resource_okta_group_memberships.go
@@ -30,8 +30,34 @@ func resourceGroupMemberships() *schema.Resource {
 				if len(importID) == 2 {
 					d.Set("track_all_users", importID[1] == "true")
 				}
-				d.SetId(importID[0])
-				d.Set("group_id", importID[0])
+				groupId := importID[0]
+				d.SetId(groupId)
+				d.Set("group_id", groupId)
+
+				// Fetch current group members so the state is populated on import,
+				// preventing Terraform from treating existing members as pending additions.
+				client := getOktaClientFromMetadata(meta)
+				groupUsers, resp, err := client.Group.ListGroupUsers(ctx, groupId, &query.Params{Limit: utils.DefaultPaginationLimit})
+				if err != nil {
+					return nil, fmt.Errorf("error fetching group users during import: %w ID is %v", err, groupId)
+				}
+
+				userIDs := make([]string, 0, len(groupUsers))
+				for _, user := range groupUsers {
+					userIDs = append(userIDs, user.Id)
+				}
+				for resp.HasNextPage() {
+					groupUsers = nil
+					resp, err = resp.Next(ctx, &groupUsers)
+					if err != nil {
+						return nil, fmt.Errorf("error fetching group users during import: %w", err)
+					}
+					for _, user := range groupUsers {
+						userIDs = append(userIDs, user.Id)
+					}
+				}
+				d.Set("users", utils.ConvertStringSliceToSet(userIDs))
+
 				return []*schema.ResourceData{d}, nil
 			},
 		},

--- a/okta/services/idaas/resource_okta_group_memberships_test.go
+++ b/okta/services/idaas/resource_okta_group_memberships_test.go
@@ -37,7 +37,7 @@ func TestAccResourceOktaGroupMemberships_crud(t *testing.T) {
 	})
 }
 
-func TestAccResourceOktaGroupMembershipsGH2775(t *testing.T) {
+func TestAccResourceOktaGroupMemberships_GH2775(t *testing.T) {
 	mgr := newFixtureManager("resources", resources.OktaIDaaSGroupMemberships, t.Name())
 	baseConfig := mgr.GetFixtures("import_base.tf", t)
 	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSGroupMemberships)
@@ -79,8 +79,8 @@ func TestAccResourceOktaGroupMembershipsGH2775(t *testing.T) {
 	})
 }
 
-// TestAccResourceOktaGroupMembershipsIssue1072 addresses https://github.com/okta/terraform-provider-okta/issues/1072
-func TestAccResourceOktaGroupMembershipsIssue1072(t *testing.T) {
+// TestAccResourceOktaGroupMemberships_Issue1072 addresses https://github.com/okta/terraform-provider-okta/issues/1072
+func TestAccResourceOktaGroupMemberships_Issue1072(t *testing.T) {
 	acctest.OktaResourceTest(t, resource.TestCase{
 		PreCheck:                 acctest.AccPreCheck(t),
 		ErrorCheck:               testAccErrorChecks(t),

--- a/okta/services/idaas/resource_okta_group_memberships_test.go
+++ b/okta/services/idaas/resource_okta_group_memberships_test.go
@@ -37,7 +37,7 @@ func TestAccResourceOktaGroupMemberships_crud(t *testing.T) {
 	})
 }
 
-func TestAccResourceOktaGroupMemberships_import(t *testing.T) {
+func TestAccResourceOktaGroupMembershipsGH2775(t *testing.T) {
 	mgr := newFixtureManager("resources", resources.OktaIDaaSGroupMemberships, t.Name())
 	baseConfig := mgr.GetFixtures("import_base.tf", t)
 	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSGroupMemberships)

--- a/okta/services/idaas/resource_okta_group_memberships_test.go
+++ b/okta/services/idaas/resource_okta_group_memberships_test.go
@@ -79,8 +79,8 @@ func TestAccResourceOktaGroupMembershipsGH2775(t *testing.T) {
 	})
 }
 
-// TestAccResourceOktaGroupMemberships_Issue1072 addresses https://github.com/okta/terraform-provider-okta/issues/1072
-func TestAccResourceOktaGroupMemberships_Issue1072(t *testing.T) {
+// TestAccResourceOktaGroupMembershipsIssue1072 addresses https://github.com/okta/terraform-provider-okta/issues/1072
+func TestAccResourceOktaGroupMembershipsIssue1072(t *testing.T) {
 	acctest.OktaResourceTest(t, resource.TestCase{
 		PreCheck:                 acctest.AccPreCheck(t),
 		ErrorCheck:               testAccErrorChecks(t),

--- a/okta/services/idaas/resource_okta_group_memberships_test.go
+++ b/okta/services/idaas/resource_okta_group_memberships_test.go
@@ -1,11 +1,13 @@
 package idaas_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/okta/terraform-provider-okta/okta/acctest"
 	"github.com/okta/terraform-provider-okta/okta/resources"
 )
@@ -30,6 +32,48 @@ func TestAccResourceOktaGroupMemberships_crud(t *testing.T) {
 			},
 			{
 				Config: remove,
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaGroupMemberships_import(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSGroupMemberships, t.Name())
+	baseConfig := mgr.GetFixtures("import_base.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSGroupMemberships)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: baseConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "group_id"),
+					resource.TestCheckResourceAttr(resourceName, "users.#", "2"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return errors.New("failed to import resource into state")
+					}
+					if s[0].Attributes["group_id"] == "" {
+						return errors.New("group_id is empty after import")
+					}
+					if s[0].ID != s[0].Attributes["group_id"] {
+						return errors.New("group_id does not match imported resource ID")
+					}
+					if s[0].Attributes["users.#"] == "" || s[0].Attributes["users.#"] == "0" {
+						return errors.New("users is empty after import")
+					}
+
+					return nil
+				},
 			},
 		},
 	})

--- a/okta/services/idaas/resource_okta_push_group.go
+++ b/okta/services/idaas/resource_okta_push_group.go
@@ -346,8 +346,10 @@ func mapPushGroupResourceToState(groupPushMapping *v6okta.GroupPushMapping, stat
 	state.SourceGroupId = types.StringPointerValue(groupPushMapping.SourceGroupId)
 	state.TargetGroupId = types.StringPointerValue(groupPushMapping.TargetGroupId)
 	state.Status = types.StringPointerValue(groupPushMapping.Status)
+	state.AppConfig = types.ObjectNull(appConfigAttrTypes)
 
-	// Preserve app_config in state from the API response
+	// Preserve app_config in state only when the API returns at least one concrete value.
+	// Some mappings return an empty app_config envelope, which must stay null in state.
 	if groupPushMapping.HasAppConfig() {
 		apiAppConfig := groupPushMapping.GetAppConfig()
 		appConfigAttrs := map[string]attr.Value{
@@ -357,9 +359,14 @@ func mapPushGroupResourceToState(groupPushMapping *v6okta.GroupPushMapping, stat
 			"group_type":         types.StringNull(),
 			"sam_account_name":   types.StringNull(),
 		}
+		hasConcreteValue := false
 
 		if apiAppConfig.HasType() {
-			appConfigAttrs["type"] = types.StringValue(apiAppConfig.GetType())
+			typeValue := apiAppConfig.GetType()
+			if typeValue != "" {
+				appConfigAttrs["type"] = types.StringValue(typeValue)
+				hasConcreteValue = true
+			}
 		}
 
 		// Map camelCase additional properties back to underscore attributes
@@ -369,13 +376,19 @@ func mapPushGroupResourceToState(groupPushMapping *v6okta.GroupPushMapping, stat
 				continue
 			}
 			if strVal, ok := val.(string); ok {
+				if strVal == "" {
+					continue
+				}
 				appConfigAttrs[underscoreKey] = types.StringValue(strVal)
+				hasConcreteValue = true
 			}
 		}
 
-		appConfigObj, objDiags := types.ObjectValue(appConfigAttrTypes, appConfigAttrs)
-		diags.Append(objDiags...)
-		state.AppConfig = appConfigObj
+		if hasConcreteValue {
+			appConfigObj, objDiags := types.ObjectValue(appConfigAttrTypes, appConfigAttrs)
+			diags.Append(objDiags...)
+			state.AppConfig = appConfigObj
+		}
 	}
 
 	return diags

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_import/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_import/classic-00.yaml
@@ -1,0 +1,775 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 72
+        host: classic-00.dne-okta.com
+        body: |
+            {"profile":{"name":"testAcc_322766309","description":"testing import"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0yl8ngKxTS3h1d7","created":"2026-05-11T09:18:00.000Z","lastUpdated":"2026-05-11T09:18:00.000Z","lastMembershipUpdated":"2026-05-11T09:18:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.13994425s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 208
+        host: classic-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"import-testAcc2-322766309@example.com","firstName":"ImportTestAcc2","lastName":"User","login":"import-testAcc2-322766309@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym112pwBbDKyF51d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.676789s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 208
+        host: classic-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"import-testAcc1-322766309@example.com","firstName":"ImportTestAcc1","lastName":"User","login":"import-testAcc1-322766309@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://classic-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym10gaf6yszvPh1d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.695408292s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0yl8ngKxTS3h1d7","created":"2026-05-11T09:18:00.000Z","lastUpdated":"2026-05-11T09:18:00.000Z","lastMembershipUpdated":"2026-05-11T09:18:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.089586625s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym112pwBbDKyF51d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:02 GMT
+            Etag:
+                - W/"95c74dd95a44a4b6e58ded8bb059b0acecaf32932e0afc89e6f3280001b60740"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.271709042s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym10gaf6yszvPh1d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:02 GMT
+            Etag:
+                - W/"841729d4209c15d4d2f708c95e230e4025d7722c4c0f6141a6b7d112e39b7f29"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.297890042s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0yl8ngKxTS3h1d7","created":"2026-05-11T09:18:00.000Z","lastUpdated":"2026-05-11T09:18:00.000Z","lastMembershipUpdated":"2026-05-11T09:18:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:02 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.068511875s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users/00uym112pwBbDKyF51d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:03 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.128671083s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users/00uym10gaf6yszvPh1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:05 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.112006833s
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym10gaf6yszvPh1d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7"}}},{"id":"00uym112pwBbDKyF51d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:06 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.2088835s
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0yl8ngKxTS3h1d7","created":"2026-05-11T09:18:00.000Z","lastUpdated":"2026-05-11T09:18:00.000Z","lastMembershipUpdated":"2026-05-11T09:18:05.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/owners"},"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.096242417s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym112pwBbDKyF51d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:07 GMT
+            Etag:
+                - W/"95c74dd95a44a4b6e58ded8bb059b0acecaf32932e0afc89e6f3280001b60740"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.256640459s
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym10gaf6yszvPh1d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://classic-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7"},"resetFactors":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://classic-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:07 GMT
+            Etag:
+                - W/"841729d4209c15d4d2f708c95e230e4025d7722c4c0f6141a6b7d112e39b7f29"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.259719709s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym10gaf6yszvPh1d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7"}}},{"id":"00uym112pwBbDKyF51d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:08 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.158529791s
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym10gaf6yszvPh1d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7"}}},{"id":"00uym112pwBbDKyF51d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:10 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.186635208s
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym10gaf6yszvPh1d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7"}}},{"id":"00uym112pwBbDKyF51d7","status":"PROVISIONED","created":"2026-05-11T09:18:00.000Z","activated":"2026-05-11T09:18:01.000Z","statusChanged":"2026-05-11T09:18:01.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:18:01.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:18:11 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.141175791s
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users/00uym112pwBbDKyF51d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:13 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.14379075s
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7/users/00uym10gaf6yszvPh1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.139186709s
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00gym0yl8ngKxTS3h1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.119402667s
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.442932833s
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.449714417s
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym10gaf6yszvPh1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:17 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.487057s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: classic-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/users/00uym112pwBbDKyF51d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:18:18 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 2.341892875s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_import/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_import/oie-00.yaml
@@ -1,0 +1,775 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 72
+        host: oie-00.dne-okta.com
+        body: |
+            {"profile":{"name":"testAcc_322766309","description":"testing import"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0tz5bYNtkn0x1d7","created":"2026-05-11T09:14:59.000Z","lastUpdated":"2026-05-11T09:14:59.000Z","lastMembershipUpdated":"2026-05-11T09:14:59.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:14:59 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.151704916s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 208
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"import-testAcc2-322766309@example.com","firstName":"ImportTestAcc2","lastName":"User","login":"import-testAcc2-322766309@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym0v2hvYmVDRfe1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.56821275s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 208
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"import-testAcc1-322766309@example.com","firstName":"ImportTestAcc1","lastName":"User","login":"import-testAcc1-322766309@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym0uet2hE5CKyo1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.662829834s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0tz5bYNtkn0x1d7","created":"2026-05-11T09:14:59.000Z","lastUpdated":"2026-05-11T09:14:59.000Z","lastMembershipUpdated":"2026-05-11T09:14:59.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.089119458s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym0v2hvYmVDRfe1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:01 GMT
+            Etag:
+                - W/"95c74dd95a44a4b6e58ded8bb059b0acecaf32932e0afc89e6f3280001b60740"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.306649875s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym0uet2hE5CKyo1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:01 GMT
+            Etag:
+                - W/"841729d4209c15d4d2f708c95e230e4025d7722c4c0f6141a6b7d112e39b7f29"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.273035875s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0tz5bYNtkn0x1d7","created":"2026-05-11T09:14:59.000Z","lastUpdated":"2026-05-11T09:14:59.000Z","lastMembershipUpdated":"2026-05-11T09:14:59.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:02 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.066821333s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users/00uym0v2hvYmVDRfe1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:03 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.082933667s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users/00uym0uet2hE5CKyo1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:04 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.160649875s
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym0v2hvYmVDRfe1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:05 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.116670584s
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gym0tz5bYNtkn0x1d7","created":"2026-05-11T09:14:59.000Z","lastUpdated":"2026-05-11T09:14:59.000Z","lastMembershipUpdated":"2026-05-11T09:14:59.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_322766309","description":"testing import"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.061560625s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym0v2hvYmVDRfe1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:07 GMT
+            Etag:
+                - W/"95c74dd95a44a4b6e58ded8bb059b0acecaf32932e0afc89e6f3280001b60740"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.237077667s
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uym0uet2hE5CKyo1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/oscnkw1sdzpoFCZMq1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otynkw1sdzpoFCZMq1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:07 GMT
+            Etag:
+                - W/"841729d4209c15d4d2f708c95e230e4025d7722c4c0f6141a6b7d112e39b7f29"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.311903959s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym0uet2hE5CKyo1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7"}}},{"id":"00uym0v2hvYmVDRfe1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:08 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.1192445s
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym0uet2hE5CKyo1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7"}}},{"id":"00uym0v2hvYmVDRfe1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:09 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.124875042s
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00uym0uet2hE5CKyo1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc1-322766309@example.com","email":"import-testAcc1-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7"}}},{"id":"00uym0v2hvYmVDRfe1d7","status":"PROVISIONED","created":"2026-05-11T09:14:59.000Z","activated":"2026-05-11T09:15:00.000Z","statusChanged":"2026-05-11T09:15:00.000Z","lastLogin":null,"lastUpdated":"2026-05-11T09:15:00.000Z","passwordChanged":null,"realmId":"guonkwfhlqM6PFD8m1d7","type":{"id":"otynkw1sdzpoFCZMq1d7"},"profile":{"firstName":"ImportTestAcc2","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"import-testAcc2-322766309@example.com","email":"import-testAcc2-322766309@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 11 May 2026 09:15:10 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.106267125s
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users/00uym0v2hvYmVDRfe1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:12 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.096436208s
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7/users/00uym0uet2hE5CKyo1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:13 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.144091666s
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gym0tz5bYNtkn0x1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.135092792s
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.557063417s
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 2.359431666s
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0v2hvYmVDRfe1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.216602334s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uym0uet2hE5CKyo1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 11 May 2026 09:15:17 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.353242083s


### PR DESCRIPTION
`users` isn’t being imported when importing the resource `okta_group_memberships`.
This is because the import function currently just sets the group ID and not the users, which requires another API call.

Additionally this PR also fixes the VCR test `TestAccResourceOktaPushGroup_crud` by only setting app_config in the state file if at least one of the underlying fields has a non null value in the response.