### PR TITLE
fix: normalize chains JSON key order to prevent inconsistent result after apply

### DIFF
--- a/okta/services/idaas/resource_okta_app_signon_policy_rules.go
+++ b/okta/services/idaas/resource_okta_app_signon_policy_rules.go
@@ -1370,12 +1370,12 @@ func (r *appSignOnPolicyRulesResource) updateRuleActionsFromAPI(ctx context.Cont
 		rule.InactivityPeriod = types.StringValue(vm.InactivityPeriod)
 	}
 
-	// Convert chains to JSON strings.
+	// Convert chains to JSON strings and normalize key order so it matches Terraform's jsonencode output.
 	if len(vm.Chains) > 0 {
 		var chainStrings []string
 		for _, chain := range vm.Chains {
 			if jsonBytes, err := json.Marshal(chain); err == nil {
-				chainStrings = append(chainStrings, string(jsonBytes))
+				chainStrings = append(chainStrings, utils.NormalizeDataJSON(string(jsonBytes)))
 			}
 		}
 		rule.Chains, _ = types.ListValueFrom(ctx, types.StringType, chainStrings)
@@ -1557,12 +1557,12 @@ func (r *appSignOnPolicyRulesResource) convertAPIActionsToModel(ctx context.Cont
 		rule.Constraints, _ = types.ListValueFrom(ctx, types.StringType, constraintStrings)
 	}
 
-	// Convert chains to JSON strings.
+	// Convert chains to JSON strings and normalize key order so it matches Terraform's jsonencode output.
 	if len(vm.Chains) > 0 {
 		var chainStrings []string
 		for _, chain := range vm.Chains {
 			if jsonBytes, err := json.Marshal(chain); err == nil {
-				chainStrings = append(chainStrings, string(jsonBytes))
+				chainStrings = append(chainStrings, utils.NormalizeDataJSON(string(jsonBytes)))
 			}
 		}
 		rule.Chains, _ = types.ListValueFrom(ctx, types.StringType, chainStrings)


### PR DESCRIPTION
`okta_app_signon_policy_rules` is producing the following error on any apply that touched a resource with chains:


```
Error: Provider produced inconsistent result after apply
...
planned: "{"key":"okta_verify","method":"signed_nonce","hardwareProtection":"REQUIRED",...}"
actual:  "{"hardwareProtection":"REQUIRED","key":"okta_verify","method":"signed_nonce",...}"
```

Root cause: Go's `encoding/json` marshals struct fields in declaration order - that does not match Terraform's `jsonencode`

Fixes https://github.com/okta/terraform-provider-okta/issues/2815

Tested locally with `dev_overrides` pointing at the locally build provider; acceptance tests should also pass, due to the change being backwards compatible.

