### PR TITLE
Add schema property default support

### DIFF
--- a/docs/resources/app_user_schema_property.md
+++ b/docs/resources/app_user_schema_property.md
@@ -31,17 +31,10 @@ resource "okta_app_user_schema_property" "example" {
   title       = "customPropertyName"
   type        = "string"
   description = "My custom property name"
+  enum        = ["PRIMARY", "SECONDARY"]
+  default     = "PRIMARY"
   master      = "OKTA"
   scope       = "SELF"
-  array_enum =  ["1", "2"]	
-  array_one_of {
-    const = "1"
-    title = "one"
-  }
-  array_one_of {
-    const = "2"
-    title = "two"
-  }	
 }
 ```
 
@@ -62,6 +55,7 @@ resource "okta_app_user_schema_property" "example" {
 	- 'const' - (Required) value mapping to member of 'enum'.
 	- 'title' - (Required) display name for the enum value. (see [below for nested schema](#nestedblock--array_one_of))
 - `array_type` (String) The type of the array elements if `type` is set to `array`. Set it to `string` when array enum type is `boolean`.
+- `default` (String) Default value for the schema property. For `number`, `integer`, and `boolean` types, provide the value as a string. For `array` and `object` types, provide a JSON encoded value.
 - `description` (String) The description of the user schema property.
 - `enum` (List of String) Array of values a primitive property can be set to. See `array_enum` for arrays.
 - `external_name` (String) External name of the user schema property.

--- a/docs/resources/user_schema_property.md
+++ b/docs/resources/user_schema_property.md
@@ -43,6 +43,8 @@ resource "okta_user_schema_property" "example" {
   title       = "customPropertyName"
   type        = "string"
   description = "My custom property name"
+  enum        = ["PRIMARY", "SECONDARY"]
+  default     = "PRIMARY"
   master      = "OKTA"
   scope       = "SELF"
   user_type   = data.okta_user_type.example.id
@@ -65,6 +67,7 @@ resource "okta_user_schema_property" "example" {
 	- 'const' - (Required) value mapping to member of 'enum'.
 	- 'title' - (Required) display name for the enum value. (see [below for nested schema](#nestedblock--array_one_of))
 - `array_type` (String) The type of the array elements if `type` is set to `array`
+- `default` (String) Default value for the schema property. For `number`, `integer`, and `boolean` types, provide the value as a string. For `array` and `object` types, provide a JSON encoded value.
 - `description` (String) The description of the user schema property.
 - `enum` (List of String) Array of values a primitive property can be set to. See `array_enum` for arrays.
 - `external_name` (String) External name of the user schema property.

--- a/examples/resources/okta_app_user_schema_property/resource.tf
+++ b/examples/resources/okta_app_user_schema_property/resource.tf
@@ -4,6 +4,8 @@ resource "okta_app_user_schema_property" "example" {
   title       = "customPropertyName"
   type        = "string"
   description = "My custom property name"
+  enum        = ["PRIMARY", "SECONDARY"]
+  default     = "PRIMARY"
   master      = "OKTA"
   scope       = "SELF"
 }

--- a/examples/resources/okta_user_schema_property/resource.tf
+++ b/examples/resources/okta_user_schema_property/resource.tf
@@ -3,6 +3,8 @@ resource "okta_user_schema_property" "example" {
   title       = "customPropertyName"
   type        = "string"
   description = "My custom property name"
+  enum        = ["PRIMARY", "SECONDARY"]
+  default     = "PRIMARY"
   master      = "OKTA"
   scope       = "SELF"
   user_type   = data.okta_user_type.example.id

--- a/okta/services/idaas/resource_okta_app_user_custom_schema_property.go
+++ b/okta/services/idaas/resource_okta_app_user_custom_schema_property.go
@@ -31,6 +31,7 @@ Okta API calls. Same holds for the 'const' value of 'one_of' as well as the
 'array_*' variation of 'enum' and 'one_of'`,
 		Schema: utils.BuildSchema(
 			userSchemaSchema,
+			userSchemaDefaultSchema,
 			userBaseSchemaSchema,
 			userTypeSchema,
 			// userPatternSchema,

--- a/okta/services/idaas/resource_okta_user_custom_schema_property.go
+++ b/okta/services/idaas/resource_okta_user_custom_schema_property.go
@@ -40,6 +40,7 @@ func resourceUserCustomSchemaProperty() *schema.Resource {
 		Schema: utils.BuildSchema(
 			userBaseSchemaSchema,
 			userSchemaSchema,
+			userSchemaDefaultSchema,
 			userTypeSchema,
 			userPatternSchema,
 			map[string]*schema.Schema{

--- a/okta/services/idaas/user_schema_property.go
+++ b/okta/services/idaas/user_schema_property.go
@@ -141,6 +141,14 @@ var (
 		},
 	}
 
+	userSchemaDefaultSchema = map[string]*schema.Schema{
+		"default": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Default value for the schema property. For `number`, `integer`, and `boolean` types, provide the value as a string. For `array` and `object` types, provide a JSON encoded value.",
+		},
+	}
+
 	userTypeSchema = map[string]*schema.Schema{
 		"user_type": {
 			Type:        schema.TypeString,
@@ -169,6 +177,11 @@ func syncCustomUserSchema(d *schema.ResourceData, subschema *sdk.UserSchemaAttri
 	if subschema.MaxLengthPtr != nil {
 		_ = d.Set("max_length", subschema.MaxLengthPtr)
 	}
+	defaultValue, err := flattenSchemaDefault(subschema.Type, subschema.Default)
+	if err != nil {
+		return err
+	}
+	_ = d.Set("default", defaultValue)
 	_ = d.Set("scope", subschema.Scope)
 	_ = d.Set("external_name", subschema.ExternalName)
 	_ = d.Set("external_namespace", subschema.ExternalNamespace)
@@ -376,6 +389,13 @@ func buildUserCustomSchemaAttribute(d *schema.ResourceData) (*sdk.UserSchemaAttr
 		ExternalNamespace: d.Get("external_namespace").(string),
 		Unique:            d.Get("unique").(string),
 	}
+	defaultValue, ok, err := buildSchemaDefault(d)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		attribute.Default = defaultValue
+	}
 	if min, ok := d.GetOk("min_length"); ok {
 		attribute.MinLengthPtr = utils.Int64Ptr(min.(int))
 	}
@@ -385,6 +405,61 @@ func buildUserCustomSchemaAttribute(d *schema.ResourceData) (*sdk.UserSchemaAttr
 	rawEnum := d.Get("enum")
 	attribute.Enum, _ = utils.BuildEnum(rawEnum.([]interface{}), d.Get("type").(string))
 	return attribute, nil
+}
+
+func buildSchemaDefault(d *schema.ResourceData) (interface{}, bool, error) {
+	rawDefault, ok := d.GetOk("default")
+	if !ok {
+		return nil, false, nil
+	}
+	defaultValue := rawDefault.(string)
+	attributeType := d.Get("type").(string)
+	switch attributeType {
+	case "array":
+		var value interface{}
+		if err := json.Unmarshal([]byte(defaultValue), &value); err != nil {
+			return nil, true, fmt.Errorf("default must be valid JSON for %q schema properties: %w", attributeType, err)
+		}
+		if _, ok := value.([]interface{}); !ok {
+			return nil, true, fmt.Errorf("default must be a JSON array for %q schema properties", attributeType)
+		}
+		return value, true, nil
+	case "object":
+		var value interface{}
+		if err := json.Unmarshal([]byte(defaultValue), &value); err != nil {
+			return nil, true, fmt.Errorf("default must be valid JSON for %q schema properties: %w", attributeType, err)
+		}
+		if _, ok := value.(map[string]interface{}); !ok {
+			return nil, true, fmt.Errorf("default must be a JSON object for %q schema properties", attributeType)
+		}
+		return value, true, nil
+	default:
+		value, err := coerceCorrectTypedValue(attributeType, defaultValue)
+		if err != nil {
+			return nil, true, fmt.Errorf("default must match %q schema property type: %w", attributeType, err)
+		}
+		return value, true, nil
+	}
+}
+
+func flattenSchemaDefault(attributeType string, defaultValue interface{}) (string, error) {
+	if defaultValue == nil {
+		return "", nil
+	}
+	switch attributeType {
+	case "array", "object":
+		value, err := json.Marshal(defaultValue)
+		if err != nil {
+			return "", fmt.Errorf("failed to flatten default value for %q schema property: %w", attributeType, err)
+		}
+		return string(value), nil
+	default:
+		value, err := coerceStringValue(attributeType, defaultValue)
+		if err != nil {
+			return "", fmt.Errorf("failed to flatten default value for %q schema property: %w", attributeType, err)
+		}
+		return value.(string), nil
+	}
 }
 
 func buildUserBaseSchemaAttribute(d *schema.ResourceData) *sdk.UserSchemaAttribute {

--- a/okta/services/idaas/user_schema_property_test.go
+++ b/okta/services/idaas/user_schema_property_test.go
@@ -1,0 +1,245 @@
+package idaas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/okta/terraform-provider-okta/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildUserCustomSchemaAttributeDefaultStringEnum(t *testing.T) {
+	d := userCustomSchemaResourceData(t, map[string]interface{}{
+		"index":   "customSource",
+		"title":   "Custom Source",
+		"type":    "string",
+		"default": "PRIMARY",
+		"enum":    []interface{}{"PRIMARY", "SECONDARY"},
+		"one_of": []interface{}{
+			map[string]interface{}{"const": "PRIMARY", "title": "Primary"},
+			map[string]interface{}{"const": "SECONDARY", "title": "Secondary"},
+		},
+	})
+
+	attribute, err := buildUserCustomSchemaAttribute(d)
+	require.NoError(t, err)
+	require.Equal(t, "PRIMARY", attribute.Default)
+
+	payload, err := json.Marshal(BuildCustomUserSchema(d.Get("index").(string), attribute))
+	require.NoError(t, err)
+	require.Contains(t, string(payload), `"default":"PRIMARY"`)
+}
+
+func TestBuildUserCustomSchemaAttributeDefaultCoercesPrimitiveTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		attributeType string
+		defaultValue  string
+		expected      interface{}
+	}{
+		{
+			name:          "string",
+			attributeType: "string",
+			defaultValue:  "PRIMARY",
+			expected:      "PRIMARY",
+		},
+		{
+			name:          "number",
+			attributeType: "number",
+			defaultValue:  "12.5",
+			expected:      12.5,
+		},
+		{
+			name:          "integer",
+			attributeType: "integer",
+			defaultValue:  "12",
+			expected:      12,
+		},
+		{
+			name:          "integer zero",
+			attributeType: "integer",
+			defaultValue:  "0",
+			expected:      0,
+		},
+		{
+			name:          "boolean",
+			attributeType: "boolean",
+			defaultValue:  "true",
+			expected:      true,
+		},
+		{
+			name:          "boolean false",
+			attributeType: "boolean",
+			defaultValue:  "false",
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := userCustomSchemaResourceData(t, map[string]interface{}{
+				"index":   "customSource",
+				"title":   "Custom Source",
+				"type":    tt.attributeType,
+				"default": tt.defaultValue,
+			})
+
+			attribute, err := buildUserCustomSchemaAttribute(d)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, attribute.Default)
+		})
+	}
+}
+
+func TestBuildUserCustomSchemaAttributeDefaultMarshalsZeroValues(t *testing.T) {
+	tests := []struct {
+		name          string
+		attributeType string
+		defaultValue  string
+		expectedJSON  string
+	}{
+		{
+			name:          "integer zero",
+			attributeType: "integer",
+			defaultValue:  "0",
+			expectedJSON:  `"default":0`,
+		},
+		{
+			name:          "boolean false",
+			attributeType: "boolean",
+			defaultValue:  "false",
+			expectedJSON:  `"default":false`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := userCustomSchemaResourceData(t, map[string]interface{}{
+				"index":   "customSource",
+				"title":   "Custom Source",
+				"type":    tt.attributeType,
+				"default": tt.defaultValue,
+			})
+
+			attribute, err := buildUserCustomSchemaAttribute(d)
+			require.NoError(t, err)
+
+			payload, err := json.Marshal(BuildCustomUserSchema(d.Get("index").(string), attribute))
+			require.NoError(t, err)
+			require.Contains(t, string(payload), tt.expectedJSON)
+		})
+	}
+}
+
+func TestBuildUserCustomSchemaAttributeDefaultJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		attributeType string
+		defaultValue  string
+		expected      interface{}
+	}{
+		{
+			name:          "array",
+			attributeType: "array",
+			defaultValue:  `["PRIMARY","SECONDARY"]`,
+			expected:      []interface{}{"PRIMARY", "SECONDARY"},
+		},
+		{
+			name:          "object",
+			attributeType: "object",
+			defaultValue:  `{"source":"PRIMARY"}`,
+			expected:      map[string]interface{}{"source": "PRIMARY"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := userCustomSchemaResourceData(t, map[string]interface{}{
+				"index":   "customSource",
+				"title":   "Custom Source",
+				"type":    tt.attributeType,
+				"default": tt.defaultValue,
+			})
+
+			attribute, err := buildUserCustomSchemaAttribute(d)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, attribute.Default)
+		})
+	}
+}
+
+func TestSyncCustomUserSchemaDefault(t *testing.T) {
+	tests := []struct {
+		name          string
+		attributeType string
+		defaultValue  interface{}
+		expected      string
+	}{
+		{
+			name:          "string",
+			attributeType: "string",
+			defaultValue:  "PRIMARY",
+			expected:      "PRIMARY",
+		},
+		{
+			name:          "number",
+			attributeType: "number",
+			defaultValue:  12.5,
+			expected:      "12.5",
+		},
+		{
+			name:          "integer",
+			attributeType: "integer",
+			defaultValue:  float64(12),
+			expected:      "12",
+		},
+		{
+			name:          "boolean",
+			attributeType: "boolean",
+			defaultValue:  true,
+			expected:      "true",
+		},
+		{
+			name:          "array",
+			attributeType: "array",
+			defaultValue:  []interface{}{"PRIMARY", "SECONDARY"},
+			expected:      `["PRIMARY","SECONDARY"]`,
+		},
+		{
+			name:          "object",
+			attributeType: "object",
+			defaultValue:  map[string]interface{}{"source": "PRIMARY"},
+			expected:      `{"source":"PRIMARY"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := userCustomSchemaResourceData(t, map[string]interface{}{
+				"index": "customSource",
+				"title": "Custom Source",
+				"type":  tt.attributeType,
+			})
+
+			err := syncCustomUserSchema(d, &sdk.UserSchemaAttribute{
+				Title:       "Custom Source",
+				Type:        tt.attributeType,
+				Default:     tt.defaultValue,
+				Required:    boolPtr(false),
+				Permissions: []*sdk.UserSchemaAttributePermission{{Action: "READ_ONLY", Principal: "SELF"}},
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, d.Get("default"))
+		})
+	}
+}
+
+func userCustomSchemaResourceData(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, resourceUserCustomSchemaProperty().Schema, raw)
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/sdk/v2_userSchemaAttribute.go
+++ b/sdk/v2_userSchemaAttribute.go
@@ -4,6 +4,7 @@ package sdk
 import "encoding/json"
 
 type UserSchemaAttribute struct {
+	Default           interface{}                      `json:"default,omitempty"`
 	Description       string                           `json:"description,omitempty"`
 	Enum              []interface{}                    `json:"enum,omitempty"`
 	ExternalName      string                           `json:"externalName,omitempty"`


### PR DESCRIPTION
## Summary

Adds a `default` argument to custom user schema property resources so Terraform can send Okta schema API default values and preserve them during refresh/import. The implementation keeps the Terraform input as a string, coerces primitive values into the JSON types Okta expects, and accepts JSON-encoded defaults for array and object schema properties.

## Changes

### User schema properties - default value support
- Add `default` to `okta_user_schema_property` and wire it through create/update payload construction plus read/flatten state refresh.
- Add the Okta schema model `default` JSON field so existing user schema API responses preserve defaults during readback.
- Coerce string, number, integer, and boolean defaults from Terraform strings, and validate JSON-shaped defaults for array/object schema properties.

### App user schema properties - shared default handling
- Reuse the same default handling for `okta_app_user_schema_property` because it shares the custom user schema build/read path.
- Keep historical state upgrader schemas unchanged and avoid exposing the field on group schema property resources.

### Tests and docs
- Add focused unit coverage for default serialization, primitive coercion, zero-like values, JSON defaults, and state flattening.
- Update user/app user schema property examples and resource docs for the new `default` argument.

## Test plan

- [x] `rtk gofmt -w sdk/v2_userSchemaAttribute.go okta/services/idaas/user_schema_property.go okta/services/idaas/resource_okta_user_custom_schema_property.go okta/services/idaas/resource_okta_app_user_custom_schema_property.go okta/services/idaas/user_schema_property_test.go`
- [x] `rtk terraform fmt -recursive ./examples/resources/okta_user_schema_property ./examples/resources/okta_app_user_schema_property`
- [x] `rtk go test ./okta/services/idaas -run 'TestBuildUserCustomSchemaAttributeDefault|TestSyncCustomUserSchemaDefault' -count=1`
- [x] `rtk git diff --check`
- [ ] `rtk go generate` - blocked by existing docs generation issue: `tfplugindocs` reports no file content in `examples/data-sources/okta_api_service_integration/data-source.tf`.
- [ ] Acceptance tests - not run; schema property acceptance tests require real Okta org/API credentials.
