### PR TITLE
Generate new jti when private key used

### DIFF
--- a/okta/api/api.go
+++ b/okta/api/api.go
@@ -27,7 +27,8 @@ func getV6ClientConfig(c *OktaAPIConfig) (*v6okta.Configuration, *v6okta.APIClie
 	var httpClient *http.Client
 	logLevel := strings.ToLower(os.Getenv("TF_LOG"))
 	debugHTTPRequests := (logLevel == "1" || logLevel == "debug" || logLevel == "trace")
-	if c.Backoff {
+	// skip retryablehttp for PrivateKey auth, the SDK's doWithRetries handles DPoP JWT regeneration on retry
+	if c.Backoff && c.PrivateKey == "" {
 		retryableClient := retryablehttp.NewClient()
 		retryableClient.RetryWaitMin = time.Second * time.Duration(c.MinWait)
 		retryableClient.RetryWaitMax = time.Second * time.Duration(c.MaxWait)
@@ -143,7 +144,8 @@ func getV5ClientConfig(c *OktaAPIConfig) (*v5okta.Configuration, *v5okta.APIClie
 	var httpClient *http.Client
 	logLevel := strings.ToLower(os.Getenv("TF_LOG"))
 	debugHttpRequests := (logLevel == "1" || logLevel == "debug" || logLevel == "trace")
-	if c.Backoff {
+	// skip retryablehttp for PrivateKey auth, the SDK's doWithRetries handles DPoP JWT regeneration on retry
+	if c.Backoff && c.PrivateKey == "" {
 		retryableClient := retryablehttp.NewClient()
 		retryableClient.RetryWaitMin = time.Second * time.Duration(c.MinWait)
 		retryableClient.RetryWaitMax = time.Second * time.Duration(c.MaxWait)

--- a/okta/api/api_test.go
+++ b/okta/api/api_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+func TestPrivateKeyAuthSkipsRetryableHTTP(t *testing.T) {
+	tests := []struct {
+		name            string
+		backoff         bool
+		privateKey      string
+		expectRetryable bool
+	}{
+		{"backoff without private key uses retryablehttp", true, "", true},
+		{"backoff with private key skips retryablehttp", true, "fake-private-key", false},
+		{"no backoff without private key skips retryablehttp", false, "", false},
+		{"no backoff with private key skips retryablehttp", false, "fake-private-key", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &OktaAPIConfig{
+				Backoff:    tt.backoff,
+				PrivateKey: tt.privateKey,
+				OrgName:    "test",
+				Domain:     "okta.com",
+				MinWait:    30,
+				MaxWait:    300,
+				RetryCount: 5,
+				Logger:     hclog.NewNullLogger(),
+			}
+
+			config, _, err := GetV3ClientConfig(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertTransport(t, config.HTTPClient, tt.expectRetryable)
+		})
+	}
+}
+
+func assertTransport(t *testing.T, client *http.Client, expectRetryable bool) {
+	t.Helper()
+	_, isRetryable := client.Transport.(*retryablehttp.RoundTripper)
+	if expectRetryable && !isRetryable {
+		t.Error("expected retryablehttp transport, got standard transport")
+	}
+	if !expectRetryable && isRetryable {
+		t.Error("expected standard transport, got retryablehttp transport")
+	}
+}

--- a/okta/api/idaas.go
+++ b/okta/api/idaas.go
@@ -165,7 +165,8 @@ func GetV3ClientConfig(c *OktaAPIConfig) (*okta.Configuration, *okta.APIClient, 
 	var httpClient *http.Client
 	logLevel := strings.ToLower(os.Getenv("TF_LOG"))
 	debugHttpRequests := (logLevel == "1" || logLevel == "debug" || logLevel == "trace")
-	if c.Backoff {
+	// skip retryablehttp for PrivateKey auth, the SDK's doWithRetries handles DPoP JWT regeneration on retry
+	if c.Backoff && c.PrivateKey == "" {
 		retryableClient := retryablehttp.NewClient()
 		retryableClient.RetryWaitMin = time.Second * time.Duration(c.MinWait)
 		retryableClient.RetryWaitMax = time.Second * time.Duration(c.MaxWait)


### PR DESCRIPTION
addresses https://github.com/okta/terraform-provider-okta/issues/2598

This was partially addressed in https://github.com/okta/terraform-provider-okta/pull/2421, but this commit lets the request fall through to actually use that instead of using `retryablehttp`.