### PR TITLE
feat(governance): add okta_resource_owners resource and data source

### DIFF
--- a/docs/data-sources/resource_owners.md
+++ b/docs/data-sources/resource_owners.md
@@ -1,0 +1,36 @@
+---
+page_title: "Data Source: okta_resource_owners"
+description: |-
+  Lists governance resources and their assigned owners.
+---
+
+# Data Source: okta_resource_owners
+
+Lists governance resources and their assigned owners. Supports filtering by `parentResourceOrn` and `resource.orn`.
+
+## Example Usage
+
+```terraform
+data "okta_resource_owners" "by_app" {
+  filter = "parentResourceOrn eq \"orn:okta:idp:00o1234567890abcdef:apps:salesforce:0oa1234567890abcdef\""
+}
+```
+
+## Argument Reference
+
+- `filter` - (Required) A filter expression for listing resource owners. Supports `parentResourceOrn` (eq) and `resource.orn` (eq) filters.
+
+## Attributes Reference
+
+- `id` - Placeholder ID.
+- `resource_owners` - List of resources with their assigned owners. Each element has:
+    - `resource_id` - The ID of the resource.
+    - `resource_type` - The type of the resource (e.g., `entitlement-bundles`).
+    - `resource_orn` - The ORN of the resource.
+    - `resource_name` - The name of the resource.
+    - `parent_resource_orn` - The ORN of the parent resource (typically the app).
+    - `principals` - List of principals (users or groups) that own the resource. Each element has:
+        - `id` - The ID of the principal.
+        - `type` - The type of the principal (`users` or `groups`).
+        - `orn` - The ORN of the principal.
+        - `name` - The display name of the principal.

--- a/docs/resources/resource_owners.md
+++ b/docs/resources/resource_owners.md
@@ -1,0 +1,46 @@
+---
+page_title: "Resource: okta_resource_owners"
+description: |-
+  Manages owners for a governance resource (entitlement bundle, entitlement value, collection, or app).
+---
+
+# Resource: okta_resource_owners
+
+Manages owners for a governance resource (entitlement bundle, entitlement value, collection, or app). Owners are principals (users or groups) authorized to administer the resource. A maximum of 5 principals may be assigned per resource.
+
+## Example Usage
+
+```terraform
+# Assign owners to an entitlement bundle
+resource "okta_resource_owners" "example" {
+  resource_orn = "orn:okta:governance:00o1234567890abcdef:entitlement-bundles:enb1234567890abcdef"
+
+  principal_orns = [
+    "orn:okta:directory:00o1234567890abcdef:users:00u1234567890abcdef",
+    "orn:okta:directory:00o1234567890abcdef:groups:00g1234567890abcdef",
+  ]
+}
+```
+
+## Argument Reference
+
+- `resource_orn` - (Required) The ORN of the resource to manage owners for (e.g., an entitlement bundle, entitlement value, collection, or app).
+- `principal_orns` - (Required) The ORNs of the principals (users or groups) that own the resource. Maximum 5.
+- `parent_resource_orn` - (Optional, Computed) The ORN of the parent resource (typically the app). Required when importing. Can be found from the `target_resource_orn` attribute of `okta_entitlement_bundle`.
+
+## Attributes Reference
+
+- `id` - Resource ID (same as `resource_orn`).
+- `parent_resource_orn` - Set by the API on create / read.
+
+## Import
+
+Import is supported using the format `parent_resource_orn/resource_orn`:
+
+```shell
+terraform import okta_resource_owners.example "orn:okta:idp:00o...:apps:salesforce:0oa.../orn:okta:governance:00o...:entitlement-bundles:enb..."
+```
+
+The `parent_resource_orn` can be found from:
+- The `target_resource_orn` attribute of an `okta_entitlement_bundle` resource or data source
+- The Okta Admin Console under governance settings

--- a/examples/data-sources/okta_resource_owners/data-source.tf
+++ b/examples/data-sources/okta_resource_owners/data-source.tf
@@ -1,0 +1,3 @@
+data "okta_resource_owners" "by_app" {
+  filter = "parentResourceOrn eq \"orn:okta:idp:00o1234567890abcdef:apps:salesforce:0oa1234567890abcdef\""
+}

--- a/examples/data-sources/okta_resource_owners/datasource.tf
+++ b/examples/data-sources/okta_resource_owners/datasource.tf
@@ -1,0 +1,7 @@
+data "okta_resource_owners" "by_app" {
+  filter = "parentResourceOrn eq \"orn:okta:idp:00o1234567890abcdef:apps:salesforce:0oa1234567890abcdef\""
+}
+
+output "resource_owners" {
+  value = data.okta_resource_owners.by_app.resource_owners
+}

--- a/examples/resources/okta_resource_owners/resource.tf
+++ b/examples/resources/okta_resource_owners/resource.tf
@@ -1,0 +1,9 @@
+# Assign owners to an entitlement bundle
+resource "okta_resource_owners" "example" {
+  resource_orn = "orn:okta:governance:00o1234567890abcdef:entitlement-bundles:enb1234567890abcdef"
+
+  principal_orns = [
+    "orn:okta:directory:00o1234567890abcdef:users:00u1234567890abcdef",
+    "orn:okta:directory:00o1234567890abcdef:groups:00g1234567890abcdef",
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lestrrat-go/jwx v1.2.31
-	github.com/okta/okta-governance-sdk-golang v1.0.1
+	github.com/okta/okta-governance-sdk-golang v1.1.0
 	github.com/okta/okta-sdk-golang/v4 v4.1.2
 	github.com/okta/okta-sdk-golang/v5 v5.0.6
 	github.com/okta/okta-sdk-golang/v6 v6.1.6

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/okta/okta-governance-sdk-golang v1.0.1 h1:gUrN6d/ToDONlH5euT24M2rfZH++TC8ZyoTjDOQO1sk=
-github.com/okta/okta-governance-sdk-golang v1.0.1/go.mod h1:1YDtCwP5TL2yFmN2Wd3kSrlR8bc1lI62Hd4X52YoO00=
+github.com/okta/okta-governance-sdk-golang v1.1.0 h1:yJxaz5qbePDVXf+ivtwXlh6AU0DjPxu6ruL6rXOjBWc=
+github.com/okta/okta-governance-sdk-golang v1.1.0/go.mod h1:RoDv9AnjWCdPkJj1KMk1wuc0+6P50re1jrKYeCe0k8k=
 github.com/okta/okta-sdk-golang/v4 v4.1.2 h1:gSycAYWGrvYeXBW8HakMZnNu/ptMuTvTQ/zZ7lgmtPI=
 github.com/okta/okta-sdk-golang/v4 v4.1.2/go.mod h1:01oiHDXvZQHlZo1Uw084VDYwXIqJe19z34b53PBZpUY=
 github.com/okta/okta-sdk-golang/v5 v5.0.6 h1:p7ptDMB1KxQ/7xSh+6FhMSybwl+ubTV4f1oL4N0Bu6U=

--- a/okta/acctest/acctest.go
+++ b/okta/acctest/acctest.go
@@ -203,7 +203,7 @@ func vcrCachedConfigV2(ctx context.Context, d *schema_sdk.ResourceData, configur
 	idaasTestClient := NewVcrIDaaSClient(d)
 	cfg.SetIdaasAPIClient(idaasTestClient)
 
-	idaaSRec, err := newVCRRecorder(mgr, idaasTestClient.Transport())
+	idaaSRec, err := newVCRRecorder(mgr.IdaasCassettePath(), idaasTestClient.Transport(), mgr)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
@@ -213,7 +213,7 @@ func vcrCachedConfigV2(ctx context.Context, d *schema_sdk.ResourceData, configur
 	governanceTestClient := NewVcrGovernanceClient(d)
 	cfg.SetGovernanceAPIClient(governanceTestClient)
 
-	governanceRec, err := newVCRRecorder(mgr, governanceTestClient.Transport())
+	governanceRec, err := newVCRRecorder(mgr.GovernanceCassettePath(), governanceTestClient.Transport(), mgr)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
@@ -226,8 +226,27 @@ func vcrCachedConfigV2(ctx context.Context, d *schema_sdk.ResourceData, configur
 	return cfg, nil
 }
 
-func newVCRRecorder(mgr *vcrManager, transport http.RoundTripper) (rec *recorder.Recorder, err error) {
+func newVCRRecorder(cassettePath string, transport http.RoundTripper, mgr *vcrManager) (rec *recorder.Recorder, err error) {
 	// Defines how VCR will match requests to responses.
+
+	// In playback mode, a test may only exercise one of the two services
+	// (e.g. a governance-only data source test makes no IDaaS calls). The
+	// missing service's cassette won't exist on disk, which would fail
+	// recorder.New with ErrCassetteNotFound. Write a stub empty cassette so
+	// the recorder loads; any actual call to that service during playback
+	// will fail with "interaction not found", which is the correct behavior.
+	if mgr.IsPlaying() {
+		cassetteFile := fmt.Sprintf("%s.yaml", cassettePath)
+		if _, statErr := os.Stat(cassetteFile); os.IsNotExist(statErr) {
+			if mkErr := os.MkdirAll(filepath.Dir(cassetteFile), 0o755); mkErr != nil {
+				return nil, mkErr
+			}
+			if wErr := os.WriteFile(cassetteFile, []byte("---\nversion: 2\ninteractions: []\n"), 0o644); wErr != nil {
+				return nil, wErr
+			}
+			defer os.Remove(cassetteFile)
+		}
+	}
 
 	vcrOpts := []recorder.Option{
 		recorder.WithMatcher(vcrMatcher()),
@@ -236,42 +255,61 @@ func newVCRRecorder(mgr *vcrManager, transport http.RoundTripper) (rec *recorder
 		recorder.WithSkipRequestLatency(true),
 		recorder.WithRealTransport(transport),
 	}
-	rec, err = recorder.New(mgr.CassettePath(), vcrOpts...)
+	rec, err = recorder.New(cassettePath, vcrOpts...)
 
 	return
 }
 
-// closeRecorder closes the VCR recorder to save the cassette file
+// closeRecorder closes the VCR recorder to save the cassette file. Both the
+// IDaaS and Governance recorders are stopped so cross-service tests
+// (e.g. governance tests that also create okta_user resources) have all
+// interactions persisted. Each recorder writes to its own per-service
+// cassette path; cassettes that captured zero interactions are removed so
+// fixture directories don't accumulate empty files.
 func closeRecorder(t *testing.T, vcr *vcrManager) {
 	providerConfigsLock.RLock()
-	config, ok := providerConfigs[vcr.TestAndCassetteNameKey()]
+	cfg, ok := providerConfigs[vcr.TestAndCassetteNameKey()]
 	providerConfigsLock.RUnlock()
-	if ok {
-		// don't record failing test runs (unless explicitly allowed for error response testing)
-		if !t.Failed() || os.Getenv("OKTA_VCR_RECORD_FAILURES") == "true" {
-			// If a test succeeds, write new seed/yaml to files
-			if strings.Contains(strings.ToLower(vcr.CassettePath()), "idaas") {
-				rtIDaasHelper := config.OktaIDaaSClient.(HttpClientHelper)
-				rt := rtIDaasHelper.Transport()
-				err := rt.(*recorder.Recorder).Stop()
-				if err != nil {
-					t.Error(err)
-				}
-			} else {
-				rtGovernanceHelper := config.OktaGovernanceClient.(HttpClientHelper)
-				rtGovernance := rtGovernanceHelper.Transport()
-				err := rtGovernance.(*recorder.Recorder).Stop()
-				if err != nil {
-					t.Error(err)
-				}
-			}
-			fmt.Printf("=== VCR WROTE CASSETTE %s.yaml\n", vcr.CassettePath())
-		}
-		// Clean up test config
-		providerConfigsLock.Lock()
-		delete(providerConfigs, t.Name())
-		providerConfigsLock.Unlock()
+	if !ok {
+		return
 	}
+
+	// don't record failing test runs (unless explicitly allowed for error response testing)
+	shouldWrite := !t.Failed() || os.Getenv("OKTA_VCR_RECORD_FAILURES") == "true"
+	if shouldWrite {
+		stopRecorderForClient(t, cfg.OktaIDaaSClient, vcr.IdaasCassettePath())
+		stopRecorderForClient(t, cfg.OktaGovernanceClient, vcr.GovernanceCassettePath())
+	}
+
+	// Clean up test config
+	providerConfigsLock.Lock()
+	delete(providerConfigs, t.Name())
+	providerConfigsLock.Unlock()
+}
+
+// stopRecorderForClient stops the VCR recorder attached to the given client's
+// transport and prunes the resulting cassette file if it ended up with zero
+// interactions. client may be any type; callers pass the IDaaS or Governance
+// client interface and we type-assert it down to HttpClientHelper.
+func stopRecorderForClient(t *testing.T, client any, cassettePath string) {
+	helper, ok := client.(HttpClientHelper)
+	if !ok {
+		return
+	}
+	rec, ok := helper.Transport().(*recorder.Recorder)
+	if !ok {
+		return
+	}
+	if err := rec.Stop(); err != nil {
+		t.Error(err)
+		return
+	}
+	cassetteFile := fmt.Sprintf("%s.yaml", cassettePath)
+	if c, err := cassette.Load(cassettePath); err == nil && len(c.Interactions) == 0 {
+		_ = os.Remove(cassetteFile)
+		return
+	}
+	fmt.Printf("=== VCR WROTE CASSETTE %s\n", cassetteFile)
 }
 
 func (m *vcrManager) SetCurrentCassette(name string) {
@@ -316,20 +354,41 @@ func (m *vcrManager) HasGovernanceCassettesToPlay() bool {
 	return m.VCRModeName == "play" && len(files) > 0
 }
 
-// CassettePath the path to what would be the current cassette.
+// CassettePath the path to what would be the current cassette for the package
+// where the test lives (idaas vs governance). Kept for callers that need a
+// single "primary" path; transports should use IdaasCassettePath /
+// GovernanceCassettePath so each service writes to its own fixture dir.
 func (m *vcrManager) CassettePath() string {
 	wd, _ := os.Getwd()
 	if strings.Contains(strings.ToLower(wd), "governance") {
-		return path.Join(m.GovernanceCassettesPath, m.CurrentCassette)
+		return m.GovernanceCassettePath()
 	}
+	return m.IdaasCassettePath()
+}
+
+// IdaasCassettePath is the cassette path for IDaaS API interactions.
+func (m *vcrManager) IdaasCassettePath() string {
 	return path.Join(m.IdaaSCassettesPath, m.CurrentCassette)
 }
 
+// GovernanceCassettePath is the cassette path for Governance API interactions.
+func (m *vcrManager) GovernanceCassettePath() string {
+	return path.Join(m.GovernanceCassettesPath, m.CurrentCassette)
+}
+
 // AttemptedWriteOfExistingCassette given a vcr mode of record the current
-// cassette file exists.
+// cassette file exists in either the IDaaS or Governance fixture dir.
+// A re-record requires the existing cassette(s) to be removed first.
 func (m *vcrManager) AttemptedWriteOfExistingCassette() bool {
-	_, err := os.Stat(fmt.Sprintf("%s.yaml", m.CassettePath()))
-	return m.VCRModeName == "record" && err == nil
+	if m.VCRModeName != "record" {
+		return false
+	}
+	for _, p := range []string{m.IdaasCassettePath(), m.GovernanceCassettePath()} {
+		if _, err := os.Stat(fmt.Sprintf("%s.yaml", p)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // AttemptedWriteIsMissingCassetteName Tests if cassette name is present for recording
@@ -362,27 +421,24 @@ func (m *vcrManager) Cassettes() []string {
 		return []string{os.Getenv("OKTA_VCR_CASSETTE")}
 	}
 
+	seen := map[string]struct{}{}
 	cassettes := []string{}
-	idaasFiles, err := os.ReadDir(path.Join(m.IdaaSCassettesPath))
-	if err != nil {
-		return cassettes
-	}
-	cassettes = append(cassettes, m.getCassettes(idaasFiles, cassettes)...)
-	governanceFiles, err := os.ReadDir(path.Join(m.GovernanceCassettesPath))
-	if err != nil {
-		return cassettes
-	}
-	cassettes = append(cassettes, m.getCassettes(governanceFiles, cassettes)...)
-	return cassettes
-}
-
-func (m *vcrManager) getCassettes(files []os.DirEntry, cassettes []string) []string {
-	for _, file := range files {
-		if strings.HasPrefix(file.Name(), ".") {
+	for _, dir := range []string{m.IdaaSCassettesPath, m.GovernanceCassettesPath} {
+		files, err := os.ReadDir(dir)
+		if err != nil {
 			continue
 		}
-		parts := strings.Split(file.Name(), ".")
-		cassettes = append(cassettes, parts[0])
+		for _, file := range files {
+			if strings.HasPrefix(file.Name(), ".") {
+				continue
+			}
+			name := strings.Split(file.Name(), ".")[0]
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			cassettes = append(cassettes, name)
+		}
 	}
 	return cassettes
 }

--- a/okta/api/governance.go
+++ b/okta/api/governance.go
@@ -13,7 +13,7 @@ type OktaGovernanceClient interface {
 }
 
 func oktaGovernanceSDKClient(c *OktaAPIConfig) (client *governance.OktaGovernanceAPIClient, err error) {
-	config, _, _ := getV5ClientConfig(c)
+	config, _, _ := getV6ClientConfig(c)
 	client = governance.NewAPIClient(config)
 	return client, nil
 }

--- a/okta/resources/resources.go
+++ b/okta/resources/resources.go
@@ -167,6 +167,7 @@ const (
 	OktaGovernanceCatalogEntryDefault                 = "okta_catalog_entry_default"
 	OktaGovernanceCatalogEntryUserAccessRequestFields = "okta_catalog_entry_user_access_request_fields"
 	OktaGovernanceEndUserMyRequests                   = "okta_end_user_my_requests"
+	OktaGovernanceResourceOwners                     = "okta_resource_owners"
 	OktaIDaaSPushGroup                                = "okta_push_group"
 	OktaIDaaSPushGroups                               = "okta_push_groups"
 	OktaIDaaSAuthenticatorWebauthnCustomAAGUID        = "okta_authenticator_webauthn_custom_aaguid"

--- a/okta/services/governance/data_source_entitlement_bundle.go
+++ b/okta/services/governance/data_source_entitlement_bundle.go
@@ -186,7 +186,7 @@ func (d *entitlementBundleDataSource) Read(ctx context.Context, req datasource.R
 		resp.Diagnostics.AddError("Missing entitlement Id", "The 'id' attribute must be set in the configuration.")
 		return
 	}
-	readEntitlementBundleResp, _, err := d.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetentitlementBundle(ctx, entitlementId).Execute()
+	readEntitlementBundleResp, _, err := d.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetEntitlementBundle(ctx, entitlementId).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read entitlement bundle",

--- a/okta/services/governance/data_source_request_v2.go
+++ b/okta/services/governance/data_source_request_v2.go
@@ -160,7 +160,7 @@ func (d *requestV2DataSource) Read(ctx context.Context, req datasource.ReadReque
 	data.LastUpdated = types.StringValue(getRequestV2Resp.GetLastUpdated().Format(time.RFC3339))
 	data.LastUpdatedBy = types.StringValue(getRequestV2Resp.GetLastUpdatedBy())
 	data.Requested = setRequested(getRequestV2Resp.GetRequested())
-	data.RequestedBy = setRequestedBy(getRequestV2Resp.GetRequestedBy())
+	data.RequestedBy = setRequestedByFromClientCredential(getRequestV2Resp.GetRequestedBy())
 	data.RequestedFor = setRequestedBy(getRequestV2Resp.GetRequestedFor())
 	// Save Data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/okta/services/governance/data_source_resource_owners.go
+++ b/okta/services/governance/data_source_resource_owners.go
@@ -1,0 +1,189 @@
+package governance
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/okta/terraform-provider-okta/okta/config"
+)
+
+var _ datasource.DataSource = (*resourceOwnersDataSource)(nil)
+
+func newResourceOwnersDataSource() datasource.DataSource {
+	return &resourceOwnersDataSource{}
+}
+
+type resourceOwnersDataSource struct {
+	*config.Config
+}
+
+type resourceOwnersDataSourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	Filter         types.String `tfsdk:"filter"`
+	ResourceOwners types.List   `tfsdk:"resource_owners"`
+}
+
+var principalObjectAttrTypes = map[string]attr.Type{
+	"id":   types.StringType,
+	"type": types.StringType,
+	"orn":  types.StringType,
+	"name": types.StringType,
+}
+
+var resourceOwnerDSObjectAttrTypes = map[string]attr.Type{
+	"resource_id":        types.StringType,
+	"resource_type":      types.StringType,
+	"resource_orn":       types.StringType,
+	"resource_name":      types.StringType,
+	"parent_resource_orn": types.StringType,
+	"principals": types.ListType{
+		ElemType: types.ObjectType{AttrTypes: principalObjectAttrTypes},
+	},
+}
+
+func (d *resourceOwnersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_resource_owners"
+}
+
+func (d *resourceOwnersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	d.Config = dataSourceConfiguration(req, resp)
+}
+
+func (d *resourceOwnersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists governance resources and their assigned owners.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Placeholder ID.",
+				Computed:    true,
+			},
+			"filter": schema.StringAttribute{
+				Description: "A filter expression for listing resource owners. " +
+					"Supports parentResourceOrn (eq) and resource.orn (eq) filters.",
+				Required: true,
+			},
+			"resource_owners": schema.ListAttribute{
+				Description: "List of resources with their assigned owners.",
+				Computed:    true,
+				ElementType: types.ObjectType{AttrTypes: resourceOwnerDSObjectAttrTypes},
+			},
+		},
+	}
+}
+
+func (d *resourceOwnersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data resourceOwnersDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	filter := data.Filter.ValueString()
+	if filter == "" {
+		resp.Diagnostics.AddError("Missing filter", "The 'filter' attribute must be set.")
+		return
+	}
+
+	// Collect all pages. Initialize to empty (not nil) to avoid null vs empty list in state.
+	allElements := make([]attr.Value, 0)
+	var after string
+
+	for {
+		listReq := d.OktaGovernanceClient.OktaGovernanceSDKClient().ResourceOwnersAPI.
+			ListResourceOwners(ctx).
+			Filter(filter)
+		if after != "" {
+			listReq = listReq.After(after)
+		}
+
+		listResp, _, err := listReq.Execute()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error listing resource owners",
+				fmt.Sprintf("Could not list resource owners: %s", err.Error()),
+			)
+			return
+		}
+
+		for _, ro := range listResp.GetData() {
+			res := ro.GetResource()
+
+			// Build principals list
+			principalElements := make([]attr.Value, 0, len(ro.GetPrincipals()))
+			for _, p := range ro.GetPrincipals() {
+				profile := p.GetProfile()
+				principalElements = append(principalElements, types.ObjectValueMust(
+					principalObjectAttrTypes,
+					map[string]attr.Value{
+						"id":   types.StringValue(p.GetId()),
+						"type": types.StringValue(p.GetType()),
+						"orn":  types.StringValue(p.GetOrn()),
+						"name": types.StringValue(profile.GetName()),
+					},
+				))
+			}
+			principalsList, diags := types.ListValue(
+				types.ObjectType{AttrTypes: principalObjectAttrTypes},
+				principalElements,
+			)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			profile := res.GetProfile()
+			allElements = append(allElements, types.ObjectValueMust(
+				resourceOwnerDSObjectAttrTypes,
+				map[string]attr.Value{
+					"resource_id":        types.StringValue(res.GetId()),
+					"resource_type":      types.StringValue(res.GetType()),
+					"resource_orn":       types.StringValue(res.GetOrn()),
+					"resource_name":      types.StringValue(profile.GetName()),
+					"parent_resource_orn": types.StringValue(ro.GetParentResourceOrn()),
+					"principals":         principalsList,
+				},
+			))
+		}
+
+		// Handle pagination
+		links, hasLinks := listResp.GetLinksOk()
+		if !hasLinks || links == nil {
+			break
+		}
+		nextLink, hasNext := links.GetNextOk()
+		if !hasNext || nextLink == nil {
+			break
+		}
+		nextHref := nextLink.GetHref()
+		if nextHref == "" {
+			break
+		}
+		u, err := url.Parse(nextHref)
+		if err != nil {
+			break
+		}
+		afterParam := u.Query().Get("after")
+		if afterParam == "" {
+			break
+		}
+		after = afterParam
+	}
+
+	resourceOwnersList, diags := types.ListValue(
+		types.ObjectType{AttrTypes: resourceOwnerDSObjectAttrTypes},
+		allElements,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ResourceOwners = resourceOwnersList
+	data.ID = types.StringValue("resource_owners")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/okta/services/governance/data_source_resource_owners_test.go
+++ b/okta/services/governance/data_source_resource_owners_test.go
@@ -1,0 +1,38 @@
+package governance_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+)
+
+func TestAccDataSourceOktaResourceOwners_read(t *testing.T) {
+	_ = newFixtureManager("data-sources", resources.OktaGovernanceResourceOwners, t.Name())
+
+	_, parentOrn := discoverEntitlementBundleORN(t)
+
+	config := fmt.Sprintf(`
+data "okta_resource_owners" "test" {
+  filter = "parentResourceOrn eq \"%s\""
+}
+`, parentOrn)
+
+	acctest.OktaResourceTest(
+		t, resource.TestCase{
+			PreCheck:                 acctest.AccPreCheck(t),
+			ErrorCheck:               testAccErrorChecks(t),
+			ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.okta_resource_owners.test", "id"),
+						resource.TestCheckResourceAttrSet("data.okta_resource_owners.test", "resource_owners.#"),
+					),
+				},
+			},
+		})
+}

--- a/okta/services/governance/data_source_review.go
+++ b/okta/services/governance/data_source_review.go
@@ -338,13 +338,15 @@ func buildReviewerGroupProfile(profile *governance.ReviewerGroupProfile) groupPr
 	}
 }
 
-func buildUserProfileModel(profile *governance.PrincipalProfile) userProfileModel {
+func buildUserProfileModel(profile *governance.PrincipalProfileEnriched) userProfileModel {
 	userProfile := userProfileModel{}
 	if profile == nil {
 		return userProfileModel{}
 	}
 	userProfile.Id = types.StringValue(profile.Id)
-	userProfile.Email = types.StringValue(profile.Email)
+	if profile.Email != nil {
+		userProfile.Email = types.StringValue(*profile.Email)
+	}
 	if profile.FirstName != nil {
 		userProfile.FirstName = types.StringValue(*profile.FirstName)
 	}
@@ -373,14 +375,19 @@ func convertLinks(links *governance.ReviewLinks) *linksModel {
 	}
 }
 
-func convertPrincipalProfile(p *governance.PrincipalProfile) *principalProfileModel {
+func convertPrincipalProfile(p *governance.PrincipalProfileEnriched) *principalProfileModel {
 	if p == nil {
 		return nil
 	}
 
+	email := ""
+	if p.Email != nil {
+		email = *p.Email
+	}
+
 	return &principalProfileModel{
 		Id:        p.GetId(),
-		Email:     p.GetEmail(),
+		Email:     email,
 		FirstName: p.FirstName,
 		LastName:  p.LastName,
 		Login:     p.Login,

--- a/okta/services/governance/governance.go
+++ b/okta/services/governance/governance.go
@@ -21,6 +21,7 @@ func FWProviderResources() []func() resource.Resource {
 		newRequestV2Resource,
 		newEndUserMyRequestsResource,
 		newEntitlementBundleResource,
+		newResourceOwnersResource,
 	}
 	// Wrap all resources with SafeResource for panic recovery
 	return resources.WrapResources(rawResources)
@@ -41,6 +42,7 @@ func FWProviderDataSources() []func() datasource.DataSource {
 		newCatalogEntryUserAccessRequestFieldsDataSource,
 		newEndUserMyRequestsDataSource,
 		newEntitlementBundleDataSource,
+		newResourceOwnersDataSource,
 	}
 }
 

--- a/okta/services/governance/governance_test.go
+++ b/okta/services/governance/governance_test.go
@@ -1,7 +1,10 @@
 package governance_test
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	schema_sdk "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -32,12 +35,35 @@ func init() {
 	// calling Fatalf on a bare testing.T{}.
 	if os.Getenv("TF_ACC") != "" {
 		t := &testing.T{}
-		governanceAPIClientForTestUtil = GovernanceClientForTest(t)
+		cfg := configForTest(t)
+		governanceAPIClientForTestUtil = cfg.OktaGovernanceClient
+
+		// Expose org ID and ORN domain as TF variables so fixtures can construct ORNs.
+		// ORN format: orn:{domain}:{service}:{orgId}:{resourceType}:{appName}:{resourceId}
+		// Domain is derived from OKTA_BASE_URL (e.g., "oktapreview.com" → "oktapreview")
+		if os.Getenv("OKTA_VCR_TF_ACC") == "play" {
+			os.Setenv("TF_VAR_org_id", "00o_vcr_placeholder")
+			os.Setenv("TF_VAR_orn_domain", "oktapreview")
+		} else {
+			orgSettings, _, err := cfg.OktaIDaaSClient.OktaSDKClientV3().OrgSettingAPI.GetOrgSettings(context.Background()).Execute()
+			if err != nil {
+				// Log but don't fatal — tests that need org_id will fail
+				// with a clear error from the Okta API rather than a panic here.
+				fmt.Printf("WARNING: failed to fetch org settings for TF_VAR_org_id: %v\n", err)
+			} else if orgSettings != nil {
+				os.Setenv("TF_VAR_org_id", orgSettings.GetId())
+			}
+			// Derive ORN domain from base URL (strip ".com" suffix)
+			baseURL := os.Getenv("OKTA_BASE_URL")
+			if baseURL != "" {
+				os.Setenv("TF_VAR_orn_domain", strings.TrimSuffix(baseURL, ".com"))
+			}
+		}
 	}
 }
 
-// GovernanceClientForTest creates a governance API client for testing
-func GovernanceClientForTest(t *testing.T) api.OktaGovernanceClient {
+// configForTest creates a full Config with both IDaaS and Governance clients for testing.
+func configForTest(t *testing.T) *config.Config {
 	p := provider.Provider()
 	d := resourceDataForTest(t, p.Schema)
 	cfg := config.NewConfig(d)
@@ -45,7 +71,12 @@ func GovernanceClientForTest(t *testing.T) api.OktaGovernanceClient {
 	if err != nil {
 		t.Fatalf("Failed to load API client: %v", err)
 	}
-	return cfg.OktaGovernanceClient
+	return cfg
+}
+
+// GovernanceClientForTest creates a governance API client for testing
+func GovernanceClientForTest(t *testing.T) api.OktaGovernanceClient {
+	return configForTest(t).OktaGovernanceClient
 }
 
 // resourceDataForTest creates a ResourceData for testing with config values from environment

--- a/okta/services/governance/resource_campaign.go
+++ b/okta/services/governance/resource_campaign.go
@@ -1075,9 +1075,9 @@ func buildCampaign(d campaignResourceModel) governance.CampaignMutable {
 	ExcludedResources := make([]governance.ResourceSettingsMutableExcludedResourcesInner, 0, len(d.ResourceSettings.ExcludedResources))
 	for _, ex := range d.ResourceSettings.ExcludedResources {
 		x := ex.ResourceId.ValueString()
-		var resourceType *governance.ResourceType
+		var resourceType *governance.ResourceTypeExclude
 		if !ex.ResourceType.IsNull() && ex.ResourceType.ValueString() != "" {
-			rt := governance.ResourceType(ex.ResourceType.ValueString())
+			rt := governance.ResourceTypeExclude(ex.ResourceType.ValueString())
 			resourceType = &rt
 		}
 		excludedRes := governance.ResourceSettingsMutableExcludedResourcesInner{

--- a/okta/services/governance/resource_entitlement_bundle.go
+++ b/okta/services/governance/resource_entitlement_bundle.go
@@ -166,7 +166,7 @@ func (r *entitlementBundleResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	// Read API call logic
-	getEntitlementBundleResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetentitlementBundle(ctx, data.Id.ValueString()).Execute()
+	getEntitlementBundleResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.GetEntitlementBundle(ctx, data.Id.ValueString()).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading campaign",

--- a/okta/services/governance/resource_request_v2.go
+++ b/okta/services/governance/resource_request_v2.go
@@ -393,6 +393,13 @@ func setRequestedBy(by governance.TargetPrincipal) *entitlementParentModel {
 	}
 }
 
+func setRequestedByFromClientCredential(by governance.ClientCredentialPrincipal) *entitlementParentModel {
+	return &entitlementParentModel{
+		Type:       types.StringValue(by.GetType()),
+		ExternalID: types.StringValue(by.GetExternalId()),
+	}
+}
+
 func setRequested(getRequested governance.Requested) *requested {
 	var reqResource requested
 	reqResource.EntryId = types.StringValue(getRequested.GetEntryId())
@@ -406,11 +413,9 @@ func setRequested(getRequested governance.Requested) *requested {
 
 func createRequestReq(data requestV2ResourceModel) governance.RequestCreatable2 {
 	var reqCreatable governance.RequestCreatable2
-	reqCreatable.Requested = governance.RequestResourceCreatable{
-		RequestResourceCatalogEntryCreatable: &governance.RequestResourceCatalogEntryCreatable{
-			Type:    data.Requested.Type.ValueString(),
-			EntryId: data.Requested.EntryId.ValueString(),
-		},
+	reqCreatable.Requested = governance.RequestResourceCatalogEntryCreatable{
+		Type:    data.Requested.Type.ValueString(),
+		EntryId: data.Requested.EntryId.ValueString(),
 	}
 	reqCreatable.RequestedFor = governance.TargetPrincipal{
 		ExternalId: data.RequestedFor.ExternalID.ValueString(),

--- a/okta/services/governance/resource_resource_owners.go
+++ b/okta/services/governance/resource_resource_owners.go
@@ -1,0 +1,373 @@
+package governance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/okta/okta-governance-sdk-golang/governance"
+	"github.com/okta/terraform-provider-okta/okta/config"
+)
+
+var (
+	_ resource.Resource                = &resourceOwnersResource{}
+	_ resource.ResourceWithConfigure   = &resourceOwnersResource{}
+	_ resource.ResourceWithImportState = &resourceOwnersResource{}
+)
+
+var errResourceNotFound = errors.New("resource not found")
+
+func newResourceOwnersResource() resource.Resource {
+	return &resourceOwnersResource{}
+}
+
+type resourceOwnersResource struct {
+	*config.Config
+}
+
+type resourceOwnersResourceModel struct {
+	ID                types.String `tfsdk:"id"`
+	ResourceOrn       types.String `tfsdk:"resource_orn"`
+	ParentResourceOrn types.String `tfsdk:"parent_resource_orn"`
+	PrincipalOrns     types.Set    `tfsdk:"principal_orns"`
+}
+
+func (r *resourceOwnersResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_resource_owners"
+}
+
+func (r *resourceOwnersResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages owners for a governance resource (entitlement bundle, entitlement value, collection, or app). " +
+			"The resource is authoritative: any owners not declared in configuration will be removed.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Resource ID (same as resource_orn).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"resource_orn": schema.StringAttribute{
+				Description: "The ORN of the resource to manage owners for (e.g., an entitlement bundle, entitlement value, collection, or app).",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"parent_resource_orn": schema.StringAttribute{
+				Description: "The ORN of the parent resource (typically the app). " +
+					"Automatically populated on create from the API response. " +
+					"Required when importing. Can be found from the target_resource_orn attribute of okta_entitlement_bundle.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"principal_orns": schema.SetAttribute{
+				Description: "The ORNs of the principals (users or groups) that own the resource. Maximum 5.",
+				Required:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (r *resourceOwnersResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.Config = resourceConfiguration(req, resp)
+}
+
+func (r *resourceOwnersResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan resourceOwnersResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceOrn := plan.ResourceOrn.ValueString()
+	principalOrns, diags := expandStringSet(ctx, plan.PrincipalOrns)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Set ID early so partial failures still write state.
+	plan.ID = types.StringValue(resourceOrn)
+
+	configureReq := governance.ResourceOwnersUpdatable{
+		ResourceOrns:  []string{resourceOrn},
+		PrincipalOrns: principalOrns,
+	}
+	configureResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().ResourceOwnersAPI.
+		ConfigureResourceOwners(ctx).
+		ResourceOwnersUpdatable(configureReq).
+		Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error configuring resource owners",
+			fmt.Sprintf("Could not configure owners for resource %s: %s", resourceOrn, err.Error()),
+		)
+		// Don't write state on Create error — the resource may not exist,
+		// and writing Unknown values (e.g., parent_resource_orn) would
+		// cause a secondary framework error.
+		return
+	}
+
+	// Capture parentResourceOrn from the response. We send exactly one
+	// resourceOrn, so the first entry with a parentResourceOrn is ours.
+	if configureResp != nil {
+		for _, ro := range configureResp.GetData() {
+			if pOrn := ro.GetParentResourceOrn(); pOrn != "" {
+				plan.ParentResourceOrn = types.StringValue(pOrn)
+				break
+			}
+		}
+	}
+	// Ensure parentResourceOrn is never Unknown in state (the framework
+	// rejects Unknown values). This can happen if the user didn't set it
+	// in config and the API response didn't include it (e.g., collections).
+	if plan.ParentResourceOrn.IsUnknown() {
+		plan.ParentResourceOrn = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceOwnersResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state resourceOwnersResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceOrn := state.ResourceOrn.ValueString()
+	parentOrn := state.ParentResourceOrn.ValueString()
+
+	ro, err := r.findResourceOwner(ctx, resourceOrn, parentOrn)
+	if err != nil {
+		if errors.Is(err, errResourceNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading resource owners", err.Error())
+		return
+	}
+
+	// Update state from API response
+	state.ID = types.StringValue(resourceOrn)
+	if ro.GetParentResourceOrn() != "" {
+		state.ParentResourceOrn = types.StringValue(ro.GetParentResourceOrn())
+	}
+
+	principalOrns := make([]string, 0, len(ro.GetPrincipals()))
+	for _, p := range ro.GetPrincipals() {
+		principalOrns = append(principalOrns, p.GetOrn())
+	}
+	setVal, diags := flattenStringSet(principalOrns)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.PrincipalOrns = setVal
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceOwnersResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state resourceOwnersResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceOrn := plan.ResourceOrn.ValueString()
+	newPrincipalOrns, diags := expandStringSet(ctx, plan.PrincipalOrns)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Use ConfigureResourceOwners for full replacement — simpler and more
+	// reliable than PATCH since the API treats it as an authoritative set.
+	configureReq := governance.ResourceOwnersUpdatable{
+		ResourceOrns:  []string{resourceOrn},
+		PrincipalOrns: newPrincipalOrns,
+	}
+	configureResp, _, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().ResourceOwnersAPI.
+		ConfigureResourceOwners(ctx).
+		ResourceOwnersUpdatable(configureReq).
+		Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating resource owners",
+			fmt.Sprintf("Could not update owners for resource %s: %s", resourceOrn, err.Error()),
+		)
+		plan.ID = state.ID
+		plan.ParentResourceOrn = state.ParentResourceOrn
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
+
+	plan.ID = types.StringValue(resourceOrn)
+	// Preserve or update parentResourceOrn from response
+	plan.ParentResourceOrn = state.ParentResourceOrn
+	if configureResp != nil {
+		for _, ro := range configureResp.GetData() {
+			if ro.GetParentResourceOrn() != "" {
+				plan.ParentResourceOrn = types.StringValue(ro.GetParentResourceOrn())
+				break
+			}
+		}
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceOwnersResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state resourceOwnersResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceOrn := state.ResourceOrn.ValueString()
+
+	// Empty PrincipalOrns removes all owners.
+	configureReq := governance.ResourceOwnersUpdatable{
+		ResourceOrns:  []string{resourceOrn},
+		PrincipalOrns: []string{},
+	}
+	_, apiResp, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().ResourceOwnersAPI.
+		ConfigureResourceOwners(ctx).
+		ResourceOwnersUpdatable(configureReq).
+		Execute()
+	if err != nil {
+		if isHTTPNotFound(apiResp) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error removing resource owners",
+			fmt.Sprintf("Could not remove owners for resource %s: %s", resourceOrn, err.Error()),
+		)
+	}
+}
+
+func (r *resourceOwnersResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import ID format: parent_resource_orn/resource_orn
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Import ID must be in the format: parent_resource_orn/resource_orn",
+		)
+		return
+	}
+	parentOrn := parts[0]
+	resourceOrn := parts[1]
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), resourceOrn)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("resource_orn"), resourceOrn)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("parent_resource_orn"), parentOrn)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Hydrate principal_orns from the API.
+	ro, err := r.findResourceOwner(ctx, resourceOrn, parentOrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading resource owners during import", err.Error())
+		return
+	}
+
+	principalOrns := make([]string, 0, len(ro.GetPrincipals()))
+	for _, p := range ro.GetPrincipals() {
+		principalOrns = append(principalOrns, p.GetOrn())
+	}
+	setVal, diags := flattenStringSet(principalOrns)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("principal_orns"), setVal)...)
+}
+
+// findResourceOwner looks up a specific resource owner entry by its ORN.
+// It uses the parentResourceOrn filter combined with resource.orn when the parent is known,
+// or falls back to resource.orn alone (works for collections and potentially other types).
+func (r *resourceOwnersResource) findResourceOwner(ctx context.Context, resourceOrn, parentOrn string) (*governance.ResourceOwner, error) {
+	var filter string
+	if parentOrn != "" {
+		filter = fmt.Sprintf("parentResourceOrn eq \"%s\" AND resource.orn eq \"%s\"", parentOrn, resourceOrn)
+	} else {
+		filter = fmt.Sprintf("resource.orn eq \"%s\"", resourceOrn)
+	}
+
+	listResp, apiResp, err := r.OktaGovernanceClient.OktaGovernanceSDKClient().ResourceOwnersAPI.
+		ListResourceOwners(ctx).
+		Filter(filter).
+		Execute()
+	if err != nil {
+		if isHTTPNotFound(apiResp) {
+			return nil, errResourceNotFound
+		}
+		return nil, fmt.Errorf("error listing resource owners for %s: %w", resourceOrn, err)
+	}
+
+	// Find the matching resource in the response.
+	data := listResp.GetData()
+	for i := range data {
+		res := data[i].GetResource()
+		if res.GetOrn() == resourceOrn {
+			return &data[i], nil
+		}
+	}
+
+	return nil, errResourceNotFound
+}
+
+// isHTTPNotFound returns true if the API response indicates a 404.
+func isHTTPNotFound(apiResp *governance.APIResponse) bool {
+	return apiResp != nil && apiResp.Response != nil && apiResp.StatusCode == http.StatusNotFound
+}
+
+// expandStringSet converts a types.Set of strings to a []string.
+func expandStringSet(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {
+	if set.IsNull() || set.IsUnknown() {
+		return []string{}, nil
+	}
+	var elements []types.String
+	diags := set.ElementsAs(ctx, &elements, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+	result := make([]string, 0, len(elements))
+	for _, e := range elements {
+		if !e.IsNull() && !e.IsUnknown() {
+			result = append(result, e.ValueString())
+		}
+	}
+	return result, nil
+}
+
+// flattenStringSet converts a []string to a types.Set of strings.
+func flattenStringSet(values []string) (types.Set, diag.Diagnostics) {
+	elements := make([]attr.Value, 0, len(values))
+	for _, v := range values {
+		elements = append(elements, types.StringValue(v))
+	}
+	return types.SetValue(types.StringType, elements)
+}

--- a/okta/services/governance/resource_resource_owners_test.go
+++ b/okta/services/governance/resource_resource_owners_test.go
@@ -1,0 +1,218 @@
+package governance_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+)
+
+// recordedOrgID is the org ID captured during VCR recording. Used during
+// playback so request bodies match the recorded cassette.
+const (
+	recordedOrgID     = "00o3q4zilpjjJlLLu1d7"
+	recordedOrnDomain = "oktapreview"
+)
+
+// orgIDForTest returns the org ID to use in test ORNs. During VCR playback,
+// returns the recorded org ID so request bodies match the cassette.
+func orgIDForTest() string {
+	if os.Getenv("OKTA_VCR_TF_ACC") == "play" {
+		return recordedOrgID
+	}
+	return os.Getenv("TF_VAR_org_id")
+}
+
+// ornDomainForTest returns the ORN domain to use in test ORNs.
+func ornDomainForTest() string {
+	if os.Getenv("OKTA_VCR_TF_ACC") == "play" {
+		return recordedOrnDomain
+	}
+	return os.Getenv("TF_VAR_orn_domain")
+}
+
+// discoverEntitlementBundleORN uses the governance API to find an entitlement
+// bundle in the sandbox that we can use for resource_owners testing.
+// It also returns the parentResourceOrn (the app ORN).
+// During VCR playback, returns hardcoded values from the recorded cassette
+// since the API is not reachable.
+func discoverEntitlementBundleORN(t *testing.T) (bundleOrn, parentOrn string) {
+	t.Helper()
+
+	// During VCR playback, the API is not reachable (fake credentials).
+	// Use the values captured during VCR recording.
+	if os.Getenv("OKTA_VCR_TF_ACC") == "play" {
+		return "orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6",
+			"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7"
+	}
+
+	cfg := configForTest(t)
+
+	// List entitlement bundles to find one we can use
+	resp, _, err := cfg.OktaGovernanceClient.OktaGovernanceSDKClient().EntitlementBundlesAPI.
+		ListEntitlementBundles(context.Background()).
+		Execute()
+	if err != nil {
+		t.Fatalf("Failed to list entitlement bundles: %v", err)
+	}
+
+	bundles := resp.GetData()
+	if len(bundles) == 0 {
+		t.Skip("No entitlement bundles found in sandbox — cannot test resource_owners")
+	}
+
+	bundle := bundles[0]
+	return bundle.GetOrn(), bundle.GetTargetResourceOrn()
+}
+
+func TestAccResourceOktaResourceOwners_basicCreateDestroy(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceResourceOwners, t.Name())
+
+	bundleOrn, _ := discoverEntitlementBundleORN(t)
+	orgID := orgIDForTest()
+	ornDomain := ornDomainForTest()
+
+	config := fmt.Sprintf(`
+resource "okta_user" "owner1" {
+  first_name = "TestAcc"
+  last_name  = "ResourceOwner1"
+  login      = "testAcc-resource-owner1-%s@example.com"
+  email      = "testAcc-resource-owner1-%s@example.com"
+}
+
+resource "okta_resource_owners" "test" {
+  resource_orn = "%s"
+
+  principal_orns = [
+    "orn:%s:directory:%s:users:${okta_user.owner1.id}",
+  ]
+}
+`, mgr.SeedStr(), mgr.SeedStr(), bundleOrn, ornDomain, orgID)
+
+	acctest.OktaResourceTest(
+		t, resource.TestCase{
+			PreCheck:                 acctest.AccPreCheck(t),
+			ErrorCheck:               testAccErrorChecks(t),
+			ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("okta_resource_owners.test", "id"),
+						resource.TestCheckResourceAttr("okta_resource_owners.test", "resource_orn", bundleOrn),
+						resource.TestCheckResourceAttrSet("okta_resource_owners.test", "parent_resource_orn"),
+						resource.TestCheckResourceAttr("okta_resource_owners.test", "principal_orns.#", "1"),
+					),
+				},
+			},
+		})
+}
+
+func TestAccResourceOktaResourceOwners_crudAndUpdate(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaGovernanceResourceOwners, t.Name())
+
+	bundleOrn, _ := discoverEntitlementBundleORN(t)
+	orgID := orgIDForTest()
+	ornDomain := ornDomainForTest()
+
+	configCreate := fmt.Sprintf(`
+resource "okta_user" "owner1" {
+  first_name = "TestAcc"
+  last_name  = "ResourceOwner1"
+  login      = "testAcc-resource-owner1-%s@example.com"
+  email      = "testAcc-resource-owner1-%s@example.com"
+}
+
+resource "okta_user" "owner2" {
+  first_name = "TestAcc"
+  last_name  = "ResourceOwner2"
+  login      = "testAcc-resource-owner2-%s@example.com"
+  email      = "testAcc-resource-owner2-%s@example.com"
+}
+
+resource "okta_resource_owners" "test" {
+  resource_orn = "%s"
+
+  principal_orns = [
+    "orn:%s:directory:%s:users:${okta_user.owner1.id}",
+    "orn:%s:directory:%s:users:${okta_user.owner2.id}",
+  ]
+}
+`, mgr.SeedStr(), mgr.SeedStr(), mgr.SeedStr(), mgr.SeedStr(),
+		bundleOrn, ornDomain, orgID, ornDomain, orgID)
+
+	configUpdate := fmt.Sprintf(`
+resource "okta_user" "owner1" {
+  first_name = "TestAcc"
+  last_name  = "ResourceOwner1"
+  login      = "testAcc-resource-owner1-%s@example.com"
+  email      = "testAcc-resource-owner1-%s@example.com"
+}
+
+resource "okta_user" "owner2" {
+  first_name = "TestAcc"
+  last_name  = "ResourceOwner2"
+  login      = "testAcc-resource-owner2-%s@example.com"
+  email      = "testAcc-resource-owner2-%s@example.com"
+}
+
+resource "okta_user" "owner3" {
+  first_name = "TestAcc"
+  last_name  = "ResourceOwner3"
+  login      = "testAcc-resource-owner3-%s@example.com"
+  email      = "testAcc-resource-owner3-%s@example.com"
+}
+
+resource "okta_resource_owners" "test" {
+  resource_orn = "%s"
+
+  principal_orns = [
+    "orn:%s:directory:%s:users:${okta_user.owner1.id}",
+    "orn:%s:directory:%s:users:${okta_user.owner3.id}",
+  ]
+}
+`, mgr.SeedStr(), mgr.SeedStr(), mgr.SeedStr(), mgr.SeedStr(), mgr.SeedStr(), mgr.SeedStr(),
+		bundleOrn, ornDomain, orgID, ornDomain, orgID)
+
+	acctest.OktaResourceTest(
+		t, resource.TestCase{
+			PreCheck:                 acctest.AccPreCheck(t),
+			ErrorCheck:               testAccErrorChecks(t),
+			ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+			Steps: []resource.TestStep{
+				{
+					Config: configCreate,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("okta_resource_owners.test", "id"),
+						resource.TestCheckResourceAttr("okta_resource_owners.test", "resource_orn", bundleOrn),
+						resource.TestCheckResourceAttr("okta_resource_owners.test", "principal_orns.#", "2"),
+					),
+				},
+				{
+					// Update: remove owner2, add owner3
+					Config: configUpdate,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("okta_resource_owners.test", "principal_orns.#", "2"),
+						resource.TestCheckResourceAttrSet("okta_resource_owners.test", "parent_resource_orn"),
+					),
+				},
+				{
+					ResourceName:      "okta_resource_owners.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+					ImportStateIdFunc: func(s *terraform.State) (string, error) {
+						rs := s.RootModule().Resources["okta_resource_owners.test"]
+						pOrn := rs.Primary.Attributes["parent_resource_orn"]
+						rOrn := rs.Primary.Attributes["resource_orn"]
+						return fmt.Sprintf("%s/%s", pOrn, rOrn), nil
+					},
+				},
+			},
+		})
+
+}

--- a/templates/data-sources/resource_owners.md.tmpl
+++ b/templates/data-sources/resource_owners.md.tmpl
@@ -1,0 +1,19 @@
+---
+page_title: "{{.Type}}: {{.Name}}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Type}}: {{.Name}}
+
+{{ .Description | trimspace }}
+
+{{ if .HasExample -}}
+
+## Example Usage
+
+{{ tffile .ExampleFile }}
+
+{{- end }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/resource_owners.md.tmpl
+++ b/templates/resources/resource_owners.md.tmpl
@@ -1,0 +1,31 @@
+---
+page_title: "{{.Type}}: {{.Name}}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Type}}: {{.Name}}
+
+{{ .Description | trimspace }}
+
+{{ if .HasExample -}}
+
+## Example Usage
+
+{{ tffile .ExampleFile }}
+
+{{- end }}
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import is supported using the format `parent_resource_orn/resource_orn`:
+
+```shell
+terraform import okta_resource_owners.example "orn:okta:idp:00o...:apps:salesforce:0oa.../orn:okta:governance:00o...:entitlement-bundles:enb..."
+```
+
+The `parent_resource_orn` can be found from:
+- The `target_resource_orn` attribute of an `okta_entitlement_bundle` resource or data source
+- The Okta Admin Console under governance settings

--- a/test/fixtures/vcr/governance/TestAccDataSourceOktaResourceOwners_read/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccDataSourceOktaResourceOwners_read/oie-00.yaml
@@ -1,0 +1,193 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20","hints":{}}},"metadata":{"total":0}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 19 May 2026 01:48:17 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 853.111209ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20","hints":{}}},"metadata":{"total":0}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 19 May 2026 01:48:18 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 901.600666ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20","hints":{}}},"metadata":{"total":0}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 19 May 2026 01:48:20 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 864.782958ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20","hints":{}}},"metadata":{"total":0}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 19 May 2026 01:48:21 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 916.66875ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20","hints":{}}},"metadata":{"total":0}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 19 May 2026 01:48:22 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 867.354916ms

--- a/test/fixtures/vcr/governance/TestAccResourceOktaResourceOwners_basicCreateDestroy/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccResourceOktaResourceOwners_basicCreateDestroy/oie-00.yaml
@@ -1,0 +1,116 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 204
+        host: oie-00.dne-okta.com
+        body: |
+            {"principalOrns":["orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvt5eolDcxFG3s1d7"],"resourceOrns":["orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z3HjvF9Q91d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvt5eolDcxFG3s1d7","profile":{"id":"00uyvt5eolDcxFG3s1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-966524992@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvt5eolDcxFG3s1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:08:54 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.3338145s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7" AND resource.orn eq "orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22+AND+resource.orn+eq+%22orn%3Aoktapreview%3Agovernance%3A00o3q4zilpjjJlLLu1d7%3Aentitlement-bundles%3Aenbe1l39ckVceLqn11d6%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z3HjvF9Q91d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvt5eolDcxFG3s1d7","profile":{"id":"00uyvt5eolDcxFG3s1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-966524992@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvt5eolDcxFG3s1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20","hints":{}}},"metadata":{"total":1}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:08:57 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 878.136166ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 129
+        host: oie-00.dne-okta.com
+        body: |
+            {"principalOrns":[],"resourceOrns":["orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 11
+        body: '{"data":[]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "11"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:08:58 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 730.553208ms

--- a/test/fixtures/vcr/governance/TestAccResourceOktaResourceOwners_crudAndUpdate/oie-00.yaml
+++ b/test/fixtures/vcr/governance/TestAccResourceOktaResourceOwners_crudAndUpdate/oie-00.yaml
@@ -1,0 +1,305 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 280
+        host: oie-00.dne-okta.com
+        body: |
+            {"principalOrns":["orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvt2l73tZpHECT1d7"],"resourceOrns":["orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z5103j9js1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","profile":{"id":"00uyvsuyidvzXszku1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsuyidvzXszku1d7","hints":{}}}}},{"id":"pri1c018z6KNpdtP61d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvt2l73tZpHECT1d7","profile":{"id":"00uyvt2l73tZpHECT1d7","name":"TestAcc ResourceOwner2","email":"testAcc-resource-owner2-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvt2l73tZpHECT1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:26 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 757.39475ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7" AND resource.orn eq "orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22+AND+resource.orn+eq+%22orn%3Aoktapreview%3Agovernance%3A00o3q4zilpjjJlLLu1d7%3Aentitlement-bundles%3Aenbe1l39ckVceLqn11d6%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z5103j9js1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","profile":{"id":"00uyvsuyidvzXszku1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsuyidvzXszku1d7","hints":{}}}}},{"id":"pri1c018z6KNpdtP61d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvt2l73tZpHECT1d7","profile":{"id":"00uyvt2l73tZpHECT1d7","name":"TestAcc ResourceOwner2","email":"testAcc-resource-owner2-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvt2l73tZpHECT1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20","hints":{}}},"metadata":{"total":1}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:28 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 713.390792ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7" AND resource.orn eq "orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22+AND+resource.orn+eq+%22orn%3Aoktapreview%3Agovernance%3A00o3q4zilpjjJlLLu1d7%3Aentitlement-bundles%3Aenbe1l39ckVceLqn11d6%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z5103j9js1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","profile":{"id":"00uyvsuyidvzXszku1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsuyidvzXszku1d7","hints":{}}}}},{"id":"pri1c018z6KNpdtP61d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvt2l73tZpHECT1d7","profile":{"id":"00uyvt2l73tZpHECT1d7","name":"TestAcc ResourceOwner2","email":"testAcc-resource-owner2-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvt2l73tZpHECT1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20","hints":{}}},"metadata":{"total":1}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:30 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 769.746916ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 280
+        host: oie-00.dne-okta.com
+        body: |
+            {"principalOrns":["orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsz2qbEO4msQx1d7"],"resourceOrns":["orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z5103j9js1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","profile":{"id":"00uyvsuyidvzXszku1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsuyidvzXszku1d7","hints":{}}}}},{"id":"pri1c018z9qydGHkY1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsz2qbEO4msQx1d7","profile":{"id":"00uyvsz2qbEO4msQx1d7","name":"TestAcc ResourceOwner3","email":"testAcc-resource-owner3-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsz2qbEO4msQx1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:34 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 735.700167ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7" AND resource.orn eq "orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22+AND+resource.orn+eq+%22orn%3Aoktapreview%3Agovernance%3A00o3q4zilpjjJlLLu1d7%3Aentitlement-bundles%3Aenbe1l39ckVceLqn11d6%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z5103j9js1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","profile":{"id":"00uyvsuyidvzXszku1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsuyidvzXszku1d7","hints":{}}}}},{"id":"pri1c018z9qydGHkY1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsz2qbEO4msQx1d7","profile":{"id":"00uyvsz2qbEO4msQx1d7","name":"TestAcc ResourceOwner3","email":"testAcc-resource-owner3-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsz2qbEO4msQx1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20","hints":{}}},"metadata":{"total":1}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:36 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 708.204875ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7" AND resource.orn eq "orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22+AND+resource.orn+eq+%22orn%3Aoktapreview%3Agovernance%3A00o3q4zilpjjJlLLu1d7%3Aentitlement-bundles%3Aenbe1l39ckVceLqn11d6%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z5103j9js1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","profile":{"id":"00uyvsuyidvzXszku1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsuyidvzXszku1d7","hints":{}}}}},{"id":"pri1c018z9qydGHkY1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsz2qbEO4msQx1d7","profile":{"id":"00uyvsz2qbEO4msQx1d7","name":"TestAcc ResourceOwner3","email":"testAcc-resource-owner3-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsz2qbEO4msQx1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20","hints":{}}},"metadata":{"total":1}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:37 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 726.662ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            filter:
+                - parentResourceOrn eq "orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7" AND resource.orn eq "orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn+eq+%22orn%3Aoktapreview%3Aidp%3A00o3q4zilpjjJlLLu1d7%3Aapps%3Asaasure%3A0oa3q4zilxagApEOW1d7%22+AND+resource.orn+eq+%22orn%3Aoktapreview%3Agovernance%3A00o3q4zilpjjJlLLu1d7%3Aentitlement-bundles%3Aenbe1l39ckVceLqn11d6%22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"parentResourceOrn":"orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7","principals":[{"id":"pri1c018z5103j9js1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsuyidvzXszku1d7","profile":{"id":"00uyvsuyidvzXszku1d7","name":"TestAcc ResourceOwner1","email":"testAcc-resource-owner1-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsuyidvzXszku1d7","hints":{}}}}},{"id":"pri1c018z9qydGHkY1d7","type":"users","orn":"orn:oktapreview:directory:00o3q4zilpjjJlLLu1d7:users:00uyvsz2qbEO4msQx1d7","profile":{"id":"00uyvsz2qbEO4msQx1d7","name":"TestAcc ResourceOwner3","email":"testAcc-resource-owner3-3185324308@example.com","logo":[],"_links":{"self":{"href":"https://oie-00.dne-okta.com/admin/user/profile/view/00uyvsz2qbEO4msQx1d7","hints":{}}}}}],"resource":{"id":"enbe1l39ckVceLqn11d6","type":"entitlement-bundles","orn":"orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6","profile":{"id":"enbe1l39ckVceLqn11d6","name":"Read Only - Test bundle","description":"Read Only - Test bundle","logo":[]}}}],"_links":{"self":{"href":"https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20","hints":{}}},"metadata":{"total":1}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:38 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/governance/api/v1/resource-owners?filter=parentResourceOrn%20eq%20%22orn:oktapreview:idp:00o3q4zilpjjJlLLu1d7:apps:saasure:0oa3q4zilxagApEOW1d7%22%20AND%20resource.orn%20eq%20%22orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6%22&limit=20>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 696.54525ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 129
+        host: oie-00.dne-okta.com
+        body: |
+            {"principalOrns":[],"resourceOrns":["orn:oktapreview:governance:00o3q4zilpjjJlLLu1d7:entitlement-bundles:enbe1l39ckVceLqn11d6"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/governance/api/v1/resource-owners
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 11
+        body: '{"data":[]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "11"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:39 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 684.977458ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaResourceOwners_basicCreateDestroy/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaResourceOwners_basicCreateDestroy/oie-00.yaml
@@ -1,0 +1,170 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 227
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc-resource-owner1-966524992@example.com","firstName":"TestAcc","lastName":"ResourceOwner1","login":"testAcc-resource-owner1-966524992@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt5eolDcxFG3s1d7","status":"PROVISIONED","created":"2026-05-18T14:08:52.000Z","activated":"2026-05-18T14:08:52.000Z","statusChanged":"2026-05-18T14:08:52.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:08:52.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-966524992@example.com","email":"testAcc-resource-owner1-966524992@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:08:52 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 993.980167ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt5eolDcxFG3s1d7","status":"PROVISIONED","created":"2026-05-18T14:08:52.000Z","activated":"2026-05-18T14:08:52.000Z","statusChanged":"2026-05-18T14:08:52.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:08:52.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-966524992@example.com","email":"testAcc-resource-owner1-966524992@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:08:53 GMT
+            Etag:
+                - W/"4e0542b13859918f68bfd5bc2780be5d0f198fa52f387de0bd3a3ae12ee077e9"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 875.804459ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt5eolDcxFG3s1d7","status":"PROVISIONED","created":"2026-05-18T14:08:52.000Z","activated":"2026-05-18T14:08:52.000Z","statusChanged":"2026-05-18T14:08:52.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:08:52.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-966524992@example.com","email":"testAcc-resource-owner1-966524992@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:08:56 GMT
+            Etag:
+                - W/"4e0542b13859918f68bfd5bc2780be5d0f198fa52f387de0bd3a3ae12ee077e9"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 837.074416ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:08:59 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 887.66925ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt5eolDcxFG3s1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:09:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.006104917s

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaResourceOwners_crudAndUpdate/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaResourceOwners_crudAndUpdate/oie-00.yaml
@@ -1,0 +1,644 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 229
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc-resource-owner1-3185324308@example.com","firstName":"TestAcc","lastName":"ResourceOwner1","login":"testAcc-resource-owner1-3185324308@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsuyidvzXszku1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-3185324308@example.com","email":"testAcc-resource-owner1-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 993.82275ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 229
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc-resource-owner2-3185324308@example.com","firstName":"TestAcc","lastName":"ResourceOwner2","login":"testAcc-resource-owner2-3185324308@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt2l73tZpHECT1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner2","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner2-3185324308@example.com","email":"testAcc-resource-owner2-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.152047625s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsuyidvzXszku1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-3185324308@example.com","email":"testAcc-resource-owner1-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:25 GMT
+            Etag:
+                - W/"f3424ea1a88246e16719fe7858a2ffc82515173d398a8c03dd8b7c12f7f9347a"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 834.516333ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt2l73tZpHECT1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner2","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner2-3185324308@example.com","email":"testAcc-resource-owner2-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:25 GMT
+            Etag:
+                - W/"857f08aab5ae9ad46fcd7246a08abf025db0a9f9c352e65f3e3415f96a58d355"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 902.365625ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsuyidvzXszku1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-3185324308@example.com","email":"testAcc-resource-owner1-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:27 GMT
+            Etag:
+                - W/"f3424ea1a88246e16719fe7858a2ffc82515173d398a8c03dd8b7c12f7f9347a"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 830.724709ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt2l73tZpHECT1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner2","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner2-3185324308@example.com","email":"testAcc-resource-owner2-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:27 GMT
+            Etag:
+                - W/"857f08aab5ae9ad46fcd7246a08abf025db0a9f9c352e65f3e3415f96a58d355"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 833.640625ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt2l73tZpHECT1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner2","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner2-3185324308@example.com","email":"testAcc-resource-owner2-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:29 GMT
+            Etag:
+                - W/"857f08aab5ae9ad46fcd7246a08abf025db0a9f9c352e65f3e3415f96a58d355"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 700.333458ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsuyidvzXszku1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-3185324308@example.com","email":"testAcc-resource-owner1-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:30 GMT
+            Etag:
+                - W/"f3424ea1a88246e16719fe7858a2ffc82515173d398a8c03dd8b7c12f7f9347a"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.362552875s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 229
+        host: oie-00.dne-okta.com
+        body: |
+            {"credentials":{"password":{}},"profile":{"email":"testAcc-resource-owner3-3185324308@example.com","firstName":"TestAcc","lastName":"ResourceOwner3","login":"testAcc-resource-owner3-3185324308@example.com","postalAddress":null}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsz2qbEO4msQx1d7","status":"PROVISIONED","created":"2026-05-18T14:09:32.000Z","activated":"2026-05-18T14:09:32.000Z","statusChanged":"2026-05-18T14:09:32.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:32.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner3","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner3-3185324308@example.com","email":"testAcc-resource-owner3-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:32 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.127736333s
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsz2qbEO4msQx1d7","status":"PROVISIONED","created":"2026-05-18T14:09:32.000Z","activated":"2026-05-18T14:09:32.000Z","statusChanged":"2026-05-18T14:09:32.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:32.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner3","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner3-3185324308@example.com","email":"testAcc-resource-owner3-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:33 GMT
+            Etag:
+                - W/"ce400e9e877fa72b45bd9222019a9fad73513852f79cd12da2f82f1cfbfde555"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 837.43025ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvt2l73tZpHECT1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner2","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner2-3185324308@example.com","email":"testAcc-resource-owner2-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:35 GMT
+            Etag:
+                - W/"857f08aab5ae9ad46fcd7246a08abf025db0a9f9c352e65f3e3415f96a58d355"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 660.995458ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsuyidvzXszku1d7","status":"PROVISIONED","created":"2026-05-18T14:09:24.000Z","activated":"2026-05-18T14:09:24.000Z","statusChanged":"2026-05-18T14:09:24.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:24.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner1","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner1-3185324308@example.com","email":"testAcc-resource-owner1-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:35 GMT
+            Etag:
+                - W/"f3424ea1a88246e16719fe7858a2ffc82515173d398a8c03dd8b7c12f7f9347a"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 854.094083ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00uyvsz2qbEO4msQx1d7","status":"PROVISIONED","created":"2026-05-18T14:09:32.000Z","activated":"2026-05-18T14:09:32.000Z","statusChanged":"2026-05-18T14:09:32.000Z","lastLogin":null,"lastUpdated":"2026-05-18T14:09:32.000Z","passwordChanged":null,"realmId":"guokczn0ol2EdhWqn1d7","type":{"id":"oty3q4zimhtFGKJrN1d7"},"profile":{"firstName":"TestAcc","lastName":"ResourceOwner3","mobilePhone":null,"secondEmail":null,"login":"testAcc-resource-owner3-3185324308@example.com","email":"testAcc-resource-owner3-3185324308@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/suspend","method":"POST"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osc3q4zimhtFGKJrN1d7"},"resetPassword":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reset_password","method":"POST"},"reactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reactivate","method":"POST"},"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7"},"resetFactors":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/reset_factors","method":"POST"},"type":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/oty3q4zimhtFGKJrN1d7"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7/lifecycle/deactivate","method":"POST"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 18 May 2026 14:09:35 GMT
+            Etag:
+                - W/"ce400e9e877fa72b45bd9222019a9fad73513852f79cd12da2f82f1cfbfde555"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 861.412333ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:09:39 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 905.184875ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:09:40 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 730.802041ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:09:40 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 892.9445ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvt2l73tZpHECT1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:09:40 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 975.936292ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsuyidvzXszku1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:09:41 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.040086625s
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/users/00uyvsz2qbEO4msQx1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 18 May 2026 14:09:41 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.074509584s


### PR DESCRIPTION
## Summary

- Adds `okta_resource_owners` resource.
  - Manages up to 5 principal ORNs (users or groups) authorized to
    administer a governance resource (entitlement bundle, value,
    collection, or app).
  - Import format: `parent_resource_orn/resource_orn`.
- Adds `okta_resource_owners` data source.
  - Lists resources and owners filtered by `parentResourceOrn` or
    `resource.orn`.
- Bumps `okta-governance-sdk-golang` from `v1.0.1` to `v1.1.0`.
  - Required for the new resource-owners API.
  - The upgrade renames a few existing types/methods; call sites are
    adapted accordingly:
    - `GetentitlementBundle` → `GetEntitlementBundle`
    - `ResourceType` → `ResourceTypeExclude` (campaign exclusions)
    - `PrincipalProfile` → `PrincipalProfileEnriched` (reviews)
    - New `ClientCredentialPrincipal` on request v2 requesters

> **Stacked on #2825** — please review/merge that first. The cross-service
> VCR fix is required to record/play back the `resource_owners` tests
> (which exercise both the governance and idaas APIs).