### PR TITLE
fixes issue for default password policy

### DIFF
--- a/docs/resources/policy_password_default.md
+++ b/docs/resources/policy_password_default.md
@@ -8,7 +8,7 @@ description: |-
 
 Configures the default password policy. This resource allows you to configure the default password policy.
 
--> **Note:** If your configuration also manages other `okta_policy_password` resources, add
+~> **Note:** If your configuration also manages other `okta_policy_password` resources, add
 `depends_on = [okta_policy_password.<last_policy>]` pointing to the last non-default policy in your
 dependency chain. The default policy's `priority` is read-only and shifts whenever other password policies
 are created or deleted. Using `depends_on` ensures all sibling policies are fully created before this

--- a/docs/resources/policy_password_default.md
+++ b/docs/resources/policy_password_default.md
@@ -1,18 +1,33 @@
 ---
 page_title: "Resource: okta_policy_password_default"
 description: |-
-  Configures default password policy. This resource allows you to configure default password policy.
+  Configures the default password policy. This resource allows you to configure the default password policy.
 ---
 
 # Resource: okta_policy_password_default
 
-Configures default password policy. This resource allows you to configure default password policy.
+Configures the default password policy. This resource allows you to configure the default password policy.
+
+-> **Note:** If your configuration also manages other `okta_policy_password` resources, add
+`depends_on = [okta_policy_password.<last_policy>]` pointing to the last non-default policy in your
+dependency chain. The default policy's `priority` is read-only and shifts whenever other password policies
+are created or deleted. Using `depends_on` ensures all sibling policies are fully created before this
+resource is read or updated, so the provider sees the correct priority value and the Okta API does not
+reject the request with E0000077.
 
 ## Example Usage
 
 ```terraform
-resource "okta_policy_password_default" "default" {
+resource "okta_policy_password" "custom" {
+  name            = "Custom Password Policy"
+  groups_included = [okta_group.example.id]
+  status          = "ACTIVE"
+  priority        = 1
+}
 
+resource "okta_policy_password_default" "default" {
+  password_history_count = 5
+  depends_on             = [okta_policy_password.custom]
 }
 ```
 

--- a/examples/resources/okta_policy_password_default/issue_2804.tf
+++ b/examples/resources/okta_policy_password_default/issue_2804.tf
@@ -1,0 +1,20 @@
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "Group for issue 2804 regression"
+}
+
+resource "okta_policy_password" "extra" {
+  name              = "testAcc_replace_with_uuid_extra"
+  description       = "Non-default policy to bump default priority"
+  groups_included   = [okta_group.test.id]
+  status            = "ACTIVE"
+  priority          = 1
+  question_recovery = "INACTIVE"
+  call_recovery     = "INACTIVE"
+  sms_recovery      = "INACTIVE"
+}
+
+resource "okta_policy_password_default" "test" {
+  password_history_count = 5
+  depends_on             = [okta_policy_password.extra]
+}

--- a/examples/resources/okta_policy_password_default/issue_2804_updated.tf
+++ b/examples/resources/okta_policy_password_default/issue_2804_updated.tf
@@ -1,0 +1,20 @@
+resource "okta_group" "test" {
+  name        = "testAcc_replace_with_uuid"
+  description = "Group for issue 2804 regression"
+}
+
+resource "okta_policy_password" "extra" {
+  name              = "testAcc_replace_with_uuid_extra"
+  description       = "Non-default policy to bump default priority"
+  groups_included   = [okta_group.test.id]
+  status            = "ACTIVE"
+  priority          = 1
+  question_recovery = "INACTIVE"
+  call_recovery     = "INACTIVE"
+  sms_recovery      = "INACTIVE"
+}
+
+resource "okta_policy_password_default" "test" {
+  password_history_count = 0
+  depends_on             = [okta_policy_password.extra]
+}

--- a/okta/services/idaas/resource_okta_app_signon_policy_rules.go
+++ b/okta/services/idaas/resource_okta_app_signon_policy_rules.go
@@ -1375,7 +1375,7 @@ func (r *appSignOnPolicyRulesResource) updateRuleActionsFromAPI(ctx context.Cont
 		var chainStrings []string
 		for _, chain := range vm.Chains {
 			if jsonBytes, err := json.Marshal(chain); err == nil {
-				chainStrings = append(chainStrings, string(jsonBytes))
+				chainStrings = append(chainStrings, utils.NormalizeDataJSON(string(jsonBytes)))
 			}
 		}
 		rule.Chains, _ = types.ListValueFrom(ctx, types.StringType, chainStrings)
@@ -1562,7 +1562,7 @@ func (r *appSignOnPolicyRulesResource) convertAPIActionsToModel(ctx context.Cont
 		var chainStrings []string
 		for _, chain := range vm.Chains {
 			if jsonBytes, err := json.Marshal(chain); err == nil {
-				chainStrings = append(chainStrings, string(jsonBytes))
+				chainStrings = append(chainStrings, utils.NormalizeDataJSON(string(jsonBytes)))
 			}
 		}
 		rule.Chains, _ = types.ListValueFrom(ctx, types.StringType, chainStrings)

--- a/okta/services/idaas/resource_okta_policy_password_default.go
+++ b/okta/services/idaas/resource_okta_policy_password_default.go
@@ -27,7 +27,7 @@ func resourcePolicyPasswordDefault() *schema.Resource {
 				return []*schema.ResourceData{d}, nil
 			},
 		},
-		Description: "Configures the default password policy. This resource allows you to configure the default password policy.\n\n" +
+		Description: "Configures the default password policy. This resource allows you to configure the default password policy." +
 			"~> **Important:** If your configuration also manages other `okta_policy_password` resources, add " +
 			"`depends_on = [okta_policy_password.<last_policy>]` pointing to the last non-default policy in your " +
 			"dependency chain. The default policy's `priority` is read-only and shifts whenever other password policies " +
@@ -214,19 +214,17 @@ func resourcePolicyPasswordDefaultUpdate(ctx context.Context, d *schema.Resource
 		if policy.Conditions != nil && policy.Conditions.AuthProvider != nil {
 			_ = d.Set("default_auth_provider", policy.Conditions.AuthProvider.GetProvider())
 		}
-		// Populate read-only computed fields so buildDefaultPasswordPolicy can
-		// include them in the PUT body (the API requires them to be present).
-		if policy.Priority != nil {
-			_ = d.Set("priority", int(*policy.Priority))
-		}
-		_ = d.Set("status", policy.GetStatus())
 	}
 	// Refresh priority and status immediately before the PUT. The default
 	// policy's priority is read-only and changes whenever other password
 	// policies are created or deleted. Reading it here (rather than relying
 	// on state populated earlier in this function or during the plan phase)
 	// avoids E0000077 caused by a stale priority in the request body.
-	if current, err := getPolicyV6(ctx, d, meta); err == nil && current != nil {
+	current, err := getPolicyV6(ctx, d, meta)
+	if err != nil {
+		return diag.Errorf("failed to refresh default password policy before update: %v", err)
+	}
+	if current != nil {
 		if current.Priority != nil {
 			_ = d.Set("priority", int(*current.Priority))
 		}

--- a/okta/services/idaas/resource_okta_policy_password_default.go
+++ b/okta/services/idaas/resource_okta_policy_password_default.go
@@ -27,7 +27,13 @@ func resourcePolicyPasswordDefault() *schema.Resource {
 				return []*schema.ResourceData{d}, nil
 			},
 		},
-		Description: "Configures default password policy. This resource allows you to configure default password policy.",
+		Description: "Configures the default password policy. This resource allows you to configure the default password policy.\n\n" +
+			"~> **Important:** If your configuration also manages other `okta_policy_password` resources, add " +
+			"`depends_on = [okta_policy_password.<last_policy>]` pointing to the last non-default policy in your " +
+			"dependency chain. The default policy's `priority` is read-only and shifts whenever other password policies " +
+			"are created or deleted. Using `depends_on` ensures all sibling policies are fully created before this " +
+			"resource is read or updated, so the provider sees the correct priority value and the Okta API does not " +
+			"reject the request with E0000077.",
 		Schema: buildDefaultPolicySchema(map[string]*schema.Schema{
 			"default_auth_provider": {
 				Type:        schema.TypeString,
@@ -208,8 +214,30 @@ func resourcePolicyPasswordDefaultUpdate(ctx context.Context, d *schema.Resource
 		if policy.Conditions != nil && policy.Conditions.AuthProvider != nil {
 			_ = d.Set("default_auth_provider", policy.Conditions.AuthProvider.GetProvider())
 		}
+		// Populate read-only computed fields so buildDefaultPasswordPolicy can
+		// include them in the PUT body (the API requires them to be present).
+		if policy.Priority != nil {
+			_ = d.Set("priority", int(*policy.Priority))
+		}
+		_ = d.Set("status", policy.GetStatus())
 	}
-	if _, err := replacePolicyV6(ctx, d, meta, buildDefaultPasswordPolicy(d)); err != nil {
+	// Refresh priority and status immediately before the PUT. The default
+	// policy's priority is read-only and changes whenever other password
+	// policies are created or deleted. Reading it here (rather than relying
+	// on state populated earlier in this function or during the plan phase)
+	// avoids E0000077 caused by a stale priority in the request body.
+	if current, err := getPolicyV6(ctx, d, meta); err == nil && current != nil {
+		if current.Priority != nil {
+			_ = d.Set("priority", int(*current.Priority))
+		}
+		_ = d.Set("status", current.GetStatus())
+	}
+	// Use ReplacePolicy directly rather than replacePolicyV6 to avoid
+	// calling policyActivate: the default policy is a system policy whose
+	// status is always ACTIVE and cannot be changed via the lifecycle endpoints.
+	template := buildDefaultPasswordPolicy(d)
+	req := v6okta.PasswordPolicyAsCreatePolicyRequest(template)
+	if _, _, err := getOktaV6ClientFromMetadata(meta).PolicyAPI.ReplacePolicy(ctx, d.Id()).Policy(req).Execute(); err != nil {
 		return diag.Errorf("failed to update default password policy: %v", err)
 	}
 	return resourcePolicyPasswordDefaultRead(ctx, d, meta)
@@ -222,6 +250,13 @@ func resourcePolicyPasswordDefaultRead(ctx context.Context, d *schema.ResourceDa
 	}
 	if policy == nil {
 		return nil
+	}
+
+	_ = d.Set("name", policy.GetName())
+	_ = d.Set("description", policy.GetDescription())
+	_ = d.Set("status", policy.GetStatus())
+	if policy.Priority != nil {
+		_ = d.Set("priority", int(*policy.Priority))
 	}
 
 	var pw *v6okta.PasswordPolicyPasswordSettings
@@ -336,6 +371,13 @@ func resourcePolicyPasswordDefaultRead(ctx context.Context, d *schema.ResourceDa
 
 func buildDefaultPasswordPolicy(d *schema.ResourceData) *v6okta.PasswordPolicy {
 	template := v6okta.NewPasswordPolicy(d.Get("name").(string), "PASSWORD")
+	// The Okta API requires `priority` (with its exact current value) and
+	// `conditions` in the PUT body; omitting priority triggers E0000077.
+	// `priority` is read from state, which is refreshed immediately before this
+	// call by a pre-PUT GET in resourcePolicyPasswordDefaultUpdate.
+	if p := d.Get("priority").(int); p != 0 {
+		template.SetPriority(int32(p))
+	}
 	template.SetDescription(d.Get("description").(string))
 	authProvider := &v6okta.PasswordPolicyAuthenticationProviderCondition{}
 	authProvider.SetProvider(d.Get("default_auth_provider").(string))

--- a/okta/services/idaas/resource_okta_policy_password_default_test.go
+++ b/okta/services/idaas/resource_okta_policy_password_default_test.go
@@ -62,3 +62,42 @@ func TestAccResourceOktaDefaultPasswordPolicy_crud(t *testing.T) {
 		},
 	})
 }
+
+// TestAccResourceOktaDefaultPasswordPolicy_issue_2804 reproduces GH-2804 / OKTA-1167884.
+// When more than one password policy exists, the default policy's priority becomes 2.
+// Earlier versions of the provider sent the read-only `priority` attribute back in the
+// PUT body, which the Okta API rejects with E0000077. The default-policy update path
+// must omit `priority` so this scenario succeeds.
+func TestAccResourceOktaDefaultPasswordPolicy_issue_2804(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSPolicyPasswordDefault, t.Name())
+	config := mgr.GetFixtures("issue_2804.tf", t)
+	updatedConfig := mgr.GetFixtures("issue_2804_updated.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSPolicyPasswordDefault)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", idaas.StatusActive),
+					resource.TestCheckResourceAttr(resourceName, "priority", "2"),
+					resource.TestCheckResourceAttr(resourceName, "password_history_count", "5"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					ensurePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", idaas.StatusActive),
+					resource.TestCheckResourceAttr(resourceName, "priority", "2"),
+					resource.TestCheckResourceAttr(resourceName, "password_history_count", "0"),
+				),
+			},
+		},
+	})
+}

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaDefaultPasswordPolicy_issue_2804/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaDefaultPasswordPolicy_issue_2804/oie-00.yaml
@@ -1,0 +1,843 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 89
+        host: oie-00.dne-okta.com
+        body: |
+            {"profile":{"name":"testAcc_238413010","description":"Group for issue 2804 regression"}}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gz45fv7re0ipGen1d7","created":"2026-05-24T12:44:07.000Z","lastUpdated":"2026-05-24T12:44:07.000Z","lastMembershipUpdated":"2026-05-24T12:44:07.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_238413010","description":"Group for issue 2804 regression"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:07 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.146350875s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gz45fv7re0ipGen1d7","created":"2026-05-24T12:44:07.000Z","lastUpdated":"2026-05-24T12:44:07.000Z","lastMembershipUpdated":"2026-05-24T12:44:07.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_238413010","description":"Group for issue 2804 regression"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:08 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 959.544125ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gz45fv7re0ipGen1d7","created":"2026-05-24T12:44:07.000Z","lastUpdated":"2026-05-24T12:44:07.000Z","lastMembershipUpdated":"2026-05-24T12:44:07.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_238413010","description":"Group for issue 2804 regression"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:09 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 985.772916ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 901
+        host: oie-00.dne-okta.com
+        body: |
+            {"conditions":{"authProvider":{"provider":"OKTA"}},"description":"Non-default policy to bump default priority","name":"testAcc_238413010_extra","priority":1,"settings":{"delegation":{"options":{"skipUnlock":false}},"password":{"age":{"expireWarnDays":0,"historyCount":0,"maxAgeDays":0,"minAgeMinutes":0},"complexity":{"dictionary":{"common":{"exclude":false}},"excludeUsername":false,"minLength":8,"minLowerCase":1,"minNumber":1,"minSymbol":0,"minUpperCase":1},"lockout":{"autoUnlockMinutes":0,"maxAttempts":10,"showLockoutFailures":false,"userLockoutNotificationChannels":[]}},"recovery":{"factors":{"okta_call":{"status":"INACTIVE"},"okta_email":{"properties":{"recoveryToken":{"tokenLifetimeMinutes":60}},"status":"ACTIVE"},"okta_sms":{"status":"INACTIVE"},"recovery_question":{"properties":{"complexity":{"minLength":4}},"status":"INACTIVE"}}}},"status":"ACTIVE","system":false,"type":"PASSWORD"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/policies
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00pz450r5w7fyJ89R1d7","status":"ACTIVE","name":"testAcc_238413010_extra","description":"Non-default policy to bump default priority","priority":1,"system":false,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-05-24T12:44:10.000Z","lastUpdated":"2026-05-24T12:44:10.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":false,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"INACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:10 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.078351375s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/lifecycle/activate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Sun, 24 May 2026 12:44:11 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.03605425s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00pz450r5w7fyJ89R1d7","status":"ACTIVE","name":"testAcc_238413010_extra","description":"Non-default policy to bump default priority","priority":1,"system":false,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-05-24T12:44:10.000Z","lastUpdated":"2026-05-24T12:44:11.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":false,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"INACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:12 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 984.090167ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            type:
+                - PASSWORD
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies?type=PASSWORD
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00pz450r5w7fyJ89R1d7","status":"ACTIVE","name":"testAcc_238413010_extra","description":"Non-default policy to bump default priority","priority":1,"system":false,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-05-24T12:44:10.000Z","lastUpdated":"2026-05-24T12:44:11.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":false,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"INACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"PASSWORD"},{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:10.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":5},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:13 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/policies?type=PASSWORD>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 977.362125ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            q:
+                - Everyone
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups?q=Everyone
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00gtivnurvWCrsTPt1d7","created":"2026-01-06T09:19:35.000Z","lastUpdated":"2026-01-06T09:19:35.000Z","lastMembershipUpdated":"2026-05-08T11:49:53.000Z","objectClass":["okta:user_group"],"type":"BUILT_IN","profile":{"name":"Everyone","description":"All users in your organization"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtivnurvWCrsTPt1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtivnurvWCrsTPt1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gtivnurvWCrsTPt1d7/apps"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 992.656458ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:10.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":5},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.000185125s
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 957
+        host: oie-00.dne-okta.com
+        body: |
+            {"conditions":{"authProvider":{"provider":"OKTA"},"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}}},"description":"The default policy applies in all situations if no other policy applies.","name":"Default Policy","priority":2,"settings":{"delegation":{"options":{"skipUnlock":false}},"password":{"age":{"expireWarnDays":0,"historyCount":5,"maxAgeDays":0,"minAgeMinutes":0},"complexity":{"dictionary":{"common":{"exclude":false}},"excludeUsername":true,"minLength":8,"minLowerCase":1,"minNumber":1,"minSymbol":0,"minUpperCase":1},"lockout":{"autoUnlockMinutes":0,"maxAttempts":10,"showLockoutFailures":false,"userLockoutNotificationChannels":[]}},"recovery":{"factors":{"okta_call":{"status":"INACTIVE"},"okta_email":{"properties":{"recoveryToken":{"tokenLifetimeMinutes":60}},"status":"ACTIVE"},"okta_sms":{"status":"INACTIVE"},"recovery_question":{"properties":{"complexity":{"minLength":4}},"status":"ACTIVE"}}}},"system":false,"type":"PASSWORD"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:16.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":5},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.124636708s
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:16.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":5},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:17 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 988.373042ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gz45fv7re0ipGen1d7","created":"2026-05-24T12:44:07.000Z","lastUpdated":"2026-05-24T12:44:07.000Z","lastMembershipUpdated":"2026-05-24T12:44:07.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_238413010","description":"Group for issue 2804 regression"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:20 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 993.957709ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00pz450r5w7fyJ89R1d7","status":"ACTIVE","name":"testAcc_238413010_extra","description":"Non-default policy to bump default priority","priority":1,"system":false,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-05-24T12:44:10.000Z","lastUpdated":"2026-05-24T12:44:11.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":false,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"INACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:21 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.002158667s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:16.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":5},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:22 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 992.273459ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gz45fv7re0ipGen1d7","created":"2026-05-24T12:44:07.000Z","lastUpdated":"2026-05-24T12:44:07.000Z","lastMembershipUpdated":"2026-05-24T12:44:07.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_238413010","description":"Group for issue 2804 regression"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:23 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.009552125s
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00pz450r5w7fyJ89R1d7","status":"ACTIVE","name":"testAcc_238413010_extra","description":"Non-default policy to bump default priority","priority":1,"system":false,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-05-24T12:44:10.000Z","lastUpdated":"2026-05-24T12:44:11.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":false,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"INACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:24 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 988.273625ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:16.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":5},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:25 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.00332275s
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:16.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":5},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:27 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 988.036375ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 957
+        host: oie-00.dne-okta.com
+        body: |
+            {"conditions":{"authProvider":{"provider":"OKTA"},"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}}},"description":"The default policy applies in all situations if no other policy applies.","name":"Default Policy","priority":2,"settings":{"delegation":{"options":{"skipUnlock":false}},"password":{"age":{"expireWarnDays":0,"historyCount":0,"maxAgeDays":0,"minAgeMinutes":0},"complexity":{"dictionary":{"common":{"exclude":false}},"excludeUsername":true,"minLength":8,"minLowerCase":1,"minNumber":1,"minSymbol":0,"minUpperCase":1},"lockout":{"autoUnlockMinutes":0,"maxAttempts":10,"showLockoutFailures":false,"userLockoutNotificationChannels":[]}},"recovery":{"factors":{"okta_call":{"status":"INACTIVE"},"okta_email":{"properties":{"recoveryToken":{"tokenLifetimeMinutes":60}},"status":"ACTIVE"},"okta_sms":{"status":"INACTIVE"},"recovery_question":{"properties":{"complexity":{"minLength":4}},"status":"ACTIVE"}}}},"system":false,"type":"PASSWORD"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:28.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:28 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.115784292s
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:28.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:29 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.009097167s
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00gz45fv7re0ipGen1d7","created":"2026-05-24T12:44:07.000Z","lastUpdated":"2026-05-24T12:44:07.000Z","lastMembershipUpdated":"2026-05-24T12:44:07.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"testAcc_238413010","description":"Group for issue 2804 regression"},"_links":{"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static2.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"owners":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/owners"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:31 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 998.625917ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00pz450r5w7fyJ89R1d7","status":"ACTIVE","name":"testAcc_238413010_extra","description":"Non-default policy to bump default priority","priority":1,"system":false,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-05-24T12:44:10.000Z","lastUpdated":"2026-05-24T12:44:11.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":false,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"INACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:32 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 996.884584ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00ptivnutxnWmDgbz1d7","status":"ACTIVE","name":"Default Policy","description":"The default policy applies in all situations if no other policy applies.","priority":2,"system":true,"conditions":{"people":{"groups":{"include":["00gtivnurvWCrsTPt1d7"]}},"authProvider":{"provider":"OKTA"}},"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-05-24T12:44:28.000Z","settings":{"password":{"complexity":{"minLength":8,"minLowerCase":1,"minUpperCase":1,"minNumber":1,"minSymbol":0,"excludeUsername":true,"dictionary":{"common":{"exclude":false}},"excludeAttributes":[]},"age":{"maxAgeDays":0,"expireWarnDays":0,"minAgeMinutes":0,"historyCount":0},"lockout":{"maxAttempts":10,"autoUnlockMinutes":0,"userLockoutNotificationChannels":[],"showLockoutFailures":false},"breachedProtection":{"expireAfterDays":null,"logoutEnabled":false,"delegatedWorkflowId":null}},"recovery":{"factors":{"recovery_question":{"status":"ACTIVE","properties":{"complexity":{"minLength":4}}},"okta_email":{"status":"ACTIVE","properties":{"recoveryToken":{"tokenLifetimeMinutes":60}}},"okta_sms":{"status":"INACTIVE"},"okta_call":{"status":"INACTIVE"}}},"delegation":{"options":{"skipUnlock":false}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/00ptivnutxnWmDgbz1d7/rules","hints":{"allow":["GET","POST"]}}},"type":"PASSWORD"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Sun, 24 May 2026 12:44:33 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 985.661ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies/00pz450r5w7fyJ89R1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Sun, 24 May 2026 12:44:35 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.078117458s
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00gz45fv7re0ipGen1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Sun, 24 May 2026 12:44:36 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.016514208s


### PR DESCRIPTION
Fixes #2804 
 resourcePolicyPasswordDefaultUpdate() used a stale priority from the Terraform state and called replacePolicyV6, which internally triggers policyActivate — an operation that also fails on system
  policies.


  **Fix**
- Refresh priority and status from the API immediately before each PUT so the request always carries the current, API-assigned value.
- Switch from replacePolicyV6 to ReplacePolicy directly to avoid the unnecessary policyActivate call.
- Populate name, description, status, and priority correctly in resourcePolicyPasswordDefaultRead().
