### PR TITLE
feat: add skip_authentication_policy attribute to app resources documentation

### DIFF
--- a/docs/resources/app_bookmark.md
+++ b/docs/resources/app_bookmark.md
@@ -45,6 +45,7 @@ resource "okta_app_bookmark" "example" {
 - `hide_web` (Boolean) Do not display application icon to users
 - `logo` (String) Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.
 - `request_integration` (Boolean) Would you like Okta to add an integration for this app?
+- `skip_authentication_policy` (Boolean) When set to true, the provider will not assign or read the authentication policy for this application. This can be useful when the caller lacks the permissions to read or manage policies, or to reduce API calls against the `/api/v1/apps` rate limit.
 - `status` (String) Status of application. By default, it is `ACTIVE`
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -109,6 +109,7 @@ resource "okta_app_oauth" "example" {
 - `refresh_token_leeway` (Number) *Early Access Property* Grace period for token rotation, required with grant types refresh_token
 - `refresh_token_rotation` (String) *Early Access Property* Refresh token rotation behavior, required with grant types refresh_token
 - `response_types` (Set of String) List of OAuth 2.0 response type strings. Valid values are any combination of: `code`, `token`, and `id_token`.
+- `skip_authentication_policy` (Boolean) When set to true, the provider will not assign or read the authentication policy for this application. This can be useful when the caller lacks the permissions to read or manage policies, or to reduce API calls against the `/api/v1/apps` rate limit.
 - `status` (String) Status of application. By default, it is `ACTIVE`
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `token_endpoint_auth_method` (String) Requested authentication method for the token endpoint, valid values include:  'client_secret_basic', 'client_secret_post', 'client_secret_jwt', 'private_key_jwt', 'none', etc.

--- a/docs/resources/app_saml.md
+++ b/docs/resources/app_saml.md
@@ -231,6 +231,7 @@ resource "okta_app_saml" "test" {
 - `single_logout_certificate` (String) x509 encoded certificate that the Service Provider uses to sign Single Logout requests. Note: should be provided without `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`, see [official documentation](https://developer.okta.com/docs/reference/api/apps/#service-provider-certificate).
 - `single_logout_issuer` (String) The issuer of the Service Provider that generates the Single Logout request
 - `single_logout_url` (String) The location where the logout response is sent
+- `skip_authentication_policy` (Boolean) When set to true, the provider will not assign or read the authentication policy for this application. This can be useful when the caller lacks the permissions to read or manage policies, or to reduce API calls against the `/api/v1/apps` rate limit.
 - `sp_issuer` (String) SAML SP issuer ID
 - `sso_url` (String) Single Sign On URL
 - `status` (String) Status of application. By default, it is `ACTIVE`


### PR DESCRIPTION
## Summary
Adds the missing `skip_authentication_policy` argument documentation for:
- `okta_app_bookmark`
- `okta_app_oauth`
- `okta_app_saml`

The argument was added in #2428 and is already implemented in the resource schemas and examples, but it was missing from the Registry-facing resource docs.

Note: `go generate` was attempted, but it currently fails on an unrelated missing example file for `okta_api_service_integration`.