### PR TITLE
feat: add DPoP bound access tokens to OAuth apps

### DIFF
--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -84,6 +84,7 @@ resource "okta_app_oauth" "example" {
 - `client_id` (String) OAuth client ID. If set during creation, app is created with this id.
 - `client_uri` (String) URI to a web page providing information about the client.
 - `consent_method` (String) *Early Access Property*. Indicates whether user consent is required or implicit. Valid values: REQUIRED, TRUSTED. Default value is TRUSTED. Note: Enable `API_ACCESS_MANAGEMENT`, `API_ACCESS_MANAGEMENT_CONSENT` feature flags in your org to use this property.
+- `dpop_bound_access_tokens` (Boolean) Indicates that the client application uses Demonstrating Proof-of-Possession (DPoP) for token requests. If `true`, the authorization server rejects token requests from this client that don't contain the DPoP header.
 - `enduser_note` (String) Application notes for end users.
 - `grant_types` (Set of String) List of OAuth 2.0 grant types. Conditional validation params found here https://developer.okta.com/docs/api/resources/apps#credentials-settings-details. Defaults to minimum requirements per app type.
 - `groups_claim` (Block Set, Max: 1) Groups claim for an OpenID Connect client application (argument is ignored when API auth is done with OAuth 2.0 credentials, and is not supported when `preconfigured_app` is set) (see [below for nested schema](#nestedblock--groups_claim))

--- a/examples/resources/okta_app_oauth/dpop_bound_access_tokens.tf
+++ b/examples/resources/okta_app_oauth/dpop_bound_access_tokens.tf
@@ -1,0 +1,8 @@
+resource "okta_app_oauth" "test" {
+  label                    = "testAcc_replace_with_uuid"
+  type                     = "web"
+  dpop_bound_access_tokens = true
+  grant_types              = ["authorization_code"]
+  redirect_uris            = ["https://example.com/callback"]
+  response_types           = ["code"]
+}

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -255,6 +255,12 @@ other arguments that changed will be applied.`,
 				Description: "Require Proof Key for Code Exchange (PKCE) for additional verification key rotation mode. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object",
 				Computed:    true,
 			},
+			"dpop_bound_access_tokens": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates that the client application uses Demonstrating Proof-of-Possession (DPoP) for token requests. If true, the authorization server rejects token requests from this client that don't contain the DPoP header.",
+			},
 			"redirect_uris": {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -820,6 +826,7 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 	_ = d.Set("participate_slo", oauthClient.GetParticipateSlo())
 	_ = d.Set("frontchannel_logout_uri", oauthClient.GetFrontchannelLogoutUri())
 	_ = d.Set("frontchannel_logout_session_required", oauthClient.GetFrontchannelLogoutSessionRequired())
+	_ = d.Set("dpop_bound_access_tokens", oauthClient.GetDpopBoundAccessTokens())
 
 	if refreshToken := oauthClient.GetRefreshToken(); refreshToken.GetRotationType() != "" {
 		_ = d.Set("refresh_token_rotation", refreshToken.GetRotationType())
@@ -1099,6 +1106,16 @@ func buildAppOAuthV6(d *schema.ResourceData, isNew bool) (v6okta.ListApplication
 	// Build OAuth client settings
 	oauthClientSettings := v6okta.NewOpenIdConnectApplicationSettingsClientWithDefaults()
 	oauthClientSettings.SetApplicationType(appType)
+	dpopVal := d.GetRawConfig().GetAttr("dpop_bound_access_tokens")
+	if dpopVal.IsNull() {
+		if isNew {
+			oauthClientSettings.DpopBoundAccessTokens = nil
+		} else {
+			oauthClientSettings.SetDpopBoundAccessTokens(d.Get("dpop_bound_access_tokens").(bool))
+		}
+	} else {
+		oauthClientSettings.SetDpopBoundAccessTokens(dpopVal.True())
+	}
 
 	// Convert grant and response types to v6 format
 	v6GrantTypes := make([]string, len(grantTypes))

--- a/okta/services/idaas/resource_okta_app_oauth_test.go
+++ b/okta/services/idaas/resource_okta_app_oauth_test.go
@@ -564,6 +564,88 @@ resource "okta_app_oauth" "test" {
 	})
 }
 
+func TestAccResourceOktaAppOauth_dpopBoundAccessTokens(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSAppOAuth, t.Name())
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSAppOAuth)
+	enabled := `
+resource "okta_app_oauth" "test" {
+  label                      = "testAcc_replace_with_uuid"
+  type                       = "web"
+  dpop_bound_access_tokens   = true
+  grant_types                = ["authorization_code"]
+  redirect_uris              = ["https://example.com/callback"]
+  response_types             = ["code"]
+  skip_authentication_policy = true
+}
+`
+	disabled := `
+resource "okta_app_oauth" "test" {
+  label                      = "testAcc_replace_with_uuid"
+  type                       = "web"
+  dpop_bound_access_tokens   = false
+  grant_types                = ["authorization_code"]
+  redirect_uris              = ["https://example.com/callback"]
+  response_types             = ["code"]
+  skip_authentication_policy = true
+}
+`
+	omitted := `
+resource "okta_app_oauth" "test" {
+  label                      = "testAcc_replace_with_uuid"
+  type                       = "web"
+  grant_types                = ["authorization_code"]
+  redirect_uris              = ["https://example.com/callback"]
+  response_types             = ["code"]
+  skip_authentication_policy = true
+  enduser_note               = "dpop omitted update"
+}
+`
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSAppOAuth, createDoesOAuthAppExist()),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(enabled),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
+					resource.TestCheckResourceAttr(resourceName, "dpop_bound_access_tokens", "true"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(disabled),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
+					resource.TestCheckResourceAttr(resourceName, "dpop_bound_access_tokens", "false"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(omitted),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
+					resource.TestCheckResourceAttr(resourceName, "dpop_bound_access_tokens", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enduser_note", "dpop omitted update"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return errors.New("failed to import schema into state")
+					}
+					if expected, ok := s[0].Attributes["dpop_bound_access_tokens"]; !ok || expected != "false" {
+						return errors.New("expected imported app to include dpop_bound_access_tokens")
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
 // TestAccResourceOktaAppOauth_config_combinations
 // W.R.T. https://github.com/okta/terraform-provider-okta/issues/1325
 // Documentation of the the API behavior of pkce_required when the app type is
@@ -1072,7 +1154,6 @@ resource "okta_app_oauth" "test" {
 		},
 	})
 }
-
 
 // TestAccResourceOktaAppOauth_preconfigured tests creating and updating OAuth applications
 // using preconfigured apps from the Okta Integration Network (test1-test3), as well as

--- a/okta/services/idaas/resource_okta_app_oauth_test.go
+++ b/okta/services/idaas/resource_okta_app_oauth_test.go
@@ -1155,6 +1155,7 @@ resource "okta_app_oauth" "test" {
 	})
 }
 
+
 // TestAccResourceOktaAppOauth_preconfigured tests creating and updating OAuth applications
 // using preconfigured apps from the Okta Integration Network (test1-test3), as well as
 // custom OAuth apps (test4-test5). groups_claim is not supported for preconfigured apps


### PR DESCRIPTION
## Summary

Adds support for managing `settings.oauthClient.dpop_bound_access_tokens` on `okta_app_oauth`. This exposes DPoP-bound access token configuration for OIDC applications via the new `dpop_bound_access_tokens` argument. This also fixes sort of a bug, because if you were to import existing application that has DPoP as true and then for example add `enduser_note` field with a value, it would silently drop DPoP to false.

## Changes

- Added `dpop_bound_access_tokens` to the `okta_app_oauth` resource schema.
- Sends the value in `settings.oauthClient` on create/update when configured, and preserves existing state when omitted.
- Added acceptance coverage for create, update, omitted config preservation, import, and destroy.

## Testing

```sh
TF_ACC=1 go test ./okta/services/idaas -test.v -run '^TestAccResourceOktaAppOauth_dpopBoundAccessTokens$' -timeout 10m

=== RUN   TestAccResourceOktaAppOauth_dpopBoundAccessTokens
--- PASS: TestAccResourceOktaAppOauth_dpopBoundAccessTokens (14.22s)
PASS
ok      github.com/okta/terraform-provider-okta/okta/services/idaas     15.100s
```

Also tested manually with a locally built binary using dev overrides. Verified that `okta_app_oauth` accepts `dpop_bound_access_tokens`, applies the value to an OAuth app, and preserves the existing value when the argument is omitted from config.