### PR TITLE
fix: ignore window/arm from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - formats:


### PR DESCRIPTION
`Go 1.26.2` dropped support for the `windows/arm`, but   `.goreleaser.yml` was still trying to build for it, causing the error: go: unsupported   GOOS/GOARCH pair windows/arm.

Please see https://go.dev/doc/go1.26#windows