### PR TITLE
Add use support for OAuth app inline JWKS

### DIFF
--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -42,6 +42,7 @@ resource "okta_app_oauth" "example" {
   jwks {
     kty = "RSA"
     kid = "SIGNING_KEY_RSA"
+    use = "sig"
     e   = "AQAB"
     n   = "xyz"
   }
@@ -49,6 +50,7 @@ resource "okta_app_oauth" "example" {
   jwks {
     kty = "EC"
     kid = "SIGNING_KEY_EC"
+    use = "sig"
     x   = "K37X78mXJHHldZYMzrwipjKR-YZUS2SMye0KindHp6I"
     y   = "8IfvsvXWzbFWOZoVOMwgF5p46mUj3kbOVf9Fk0vVVHo"
   }
@@ -161,6 +163,7 @@ Optional:
 
 - `e` (String) RSA Exponent
 - `n` (String) RSA Modulus
+- `use` (String) Intended use of the public key. Valid values are `sig` and `enc`. Defaults to `sig` for signing keys.
 - `x` (String) X coordinate of the elliptic curve point
 - `y` (String) Y coordinate of the elliptic curve point
 
@@ -290,6 +293,7 @@ resource "okta_app_oauth" "app" {
   jwks {
     kty = local.jwks.kty
     kid = local.jwks.kid
+    use = "sig"
     e   = local.jwks.e
     n   = local.jwks.n
   }

--- a/examples/resources/okta_app_oauth/resource.tf
+++ b/examples/resources/okta_app_oauth/resource.tf
@@ -19,6 +19,7 @@ resource "okta_app_oauth" "example" {
   jwks {
     kty = "RSA"
     kid = "SIGNING_KEY_RSA"
+    use = "sig"
     e   = "AQAB"
     n   = "xyz"
   }
@@ -26,6 +27,7 @@ resource "okta_app_oauth" "example" {
   jwks {
     kty = "EC"
     kid = "SIGNING_KEY_EC"
+    use = "sig"
     x   = "K37X78mXJHHldZYMzrwipjKR-YZUS2SMye0KindHp6I"
     y   = "8IfvsvXWzbFWOZoVOMwgF5p46mUj3kbOVf9Fk0vVVHo"
   }

--- a/examples/resources/okta_app_oauth/service_with_jwks.tf
+++ b/examples/resources/okta_app_oauth/service_with_jwks.tf
@@ -8,6 +8,7 @@ resource "okta_app_oauth" "test" {
   jwks {
     kty = "RSA"
     kid = "SIGNING_KEY_RSA"
+    use = "sig"
     e   = "AQAB"
     n   = "owfoXNHcAlAVpIO41840ZU2tZraLGw3yEr3xZvAti7oEZPUKCytk88IDgH7440JOuz8GC_D6vtduWOqnEt0j0_faJnhKHgfj7DTWBOCxzSdjrM-Uyj6-e_XLFvZXzYsQvt52PnBJUV15G1W9QTjlghT_pFrW0xrTtbO1c281u1HJdPd5BeIyPb0pGbciySlx53OqGyxrAxPAt5P5h-n36HJkVsSQtNvgptLyOwWYkX50lgnh2szbJ0_O581bqkNBy9uqlnVeK1RZDQUl4mk8roWYhsx_JOgjpC3YyeXA6hHsT5xWZos_gNx98AHivNaAjzIzvyVItX2-hP0Aoscfff"
   }
@@ -23,6 +24,7 @@ resource "okta_app_oauth" "test_ec" {
   jwks {
     kty = "EC"
     kid = "SIGNING_KEY_EC"
+    use = "sig"
     x   = "K37X78mXJHHldZYMzrwipjKR-YZUS2SMye0KindHp6I"
     y   = "8IfvsvXWzbFWOZoVOMwgF5p46mUj3kbOVf9Fk0vVVHo"
   }

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -407,6 +407,13 @@ other arguments that changed will be applied.`,
 							Optional:    true,
 							Description: "Y coordinate of the elliptic curve point",
 						},
+						"use": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"sig", "enc"}, false),
+							Description:  "Intended use of the public key. Valid values are `sig` and `enc`. Defaults to `sig` for signing keys.",
+						},
 					},
 				},
 			},
@@ -870,8 +877,13 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 	jwk, ok := oauthClient.GetJwksOk()
 	if ok {
 		jwks := jwk.Keys
+		byKid := make(map[string]map[string]interface{}, len(jwks))
+		apiOrder := make([]string, 0, len(jwks))
+		canReorderByKid := true
 		arr := make([]map[string]interface{}, len(jwks))
 		for i, j := range jwks {
+			var kid string
+
 			// Encryption key response (use=enc)
 			if j.OAuth2ClientJsonEncryptionKeyResponse != nil {
 				arr[i] = map[string]interface{}{
@@ -879,7 +891,10 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 					"kid": j.OAuth2ClientJsonEncryptionKeyResponse.Kid.Get(),
 					"e":   j.OAuth2ClientJsonEncryptionKeyResponse.E,
 					"n":   j.OAuth2ClientJsonEncryptionKeyResponse.N,
-					"use": j.OAuth2ClientJsonEncryptionKeyResponse.Use,
+					"use": "enc",
+				}
+				if v := j.OAuth2ClientJsonEncryptionKeyResponse.Kid.Get(); v != nil {
+					kid = *v
 				}
 			}
 			// Signing key response (RSA or EC)
@@ -893,6 +908,10 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 						"kid": rsaKey.Kid.Get(),
 						"e":   rsaKey.E,
 						"n":   rsaKey.N,
+						"use": oauthAppJwkUse(rsaKey.AdditionalProperties, "sig"),
+					}
+					if v := rsaKey.Kid.Get(); v != nil {
+						kid = *v
 					}
 				}
 				// EC Signing key
@@ -903,10 +922,53 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 						"kid": ecKey.Kid.Get(),
 						"x":   ecKey.X,
 						"y":   ecKey.Y,
+						"use": oauthAppJwkUse(ecKey.AdditionalProperties, "sig"),
+					}
+					if v := ecKey.Kid.Get(); v != nil {
+						kid = *v
 					}
 				}
 			}
+			if arr[i] == nil {
+				continue
+			}
+			if kid == "" {
+				canReorderByKid = false
+				continue
+			}
+			if _, ok := byKid[kid]; ok {
+				canReorderByKid = false
+				continue
+			}
+			byKid[kid] = arr[i]
+			apiOrder = append(apiOrder, kid)
 		}
+
+		if canReorderByKid {
+			ordered := make([]map[string]interface{}, 0, len(jwks))
+			seen := make(map[string]bool, len(jwks))
+			if cfg, ok := d.Get("jwks").([]interface{}); ok {
+				for _, raw := range cfg {
+					m, ok := raw.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					kid, _ := m["kid"].(string)
+					if entry, ok := byKid[kid]; ok && !seen[kid] {
+						ordered = append(ordered, entry)
+						seen[kid] = true
+					}
+				}
+			}
+			for _, kid := range apiOrder {
+				if !seen[kid] {
+					ordered = append(ordered, byKid[kid])
+					seen[kid] = true
+				}
+			}
+			arr = ordered
+		}
+
 		err := utils.SetNonPrimitives(d, map[string]interface{}{"jwks": arr})
 		if err != nil {
 			return diag.Errorf("failed to set OAuth application properties: %v", err)
@@ -1169,16 +1231,16 @@ func buildAppOAuthV6(d *schema.ResourceData, isNew bool) (v6okta.ListApplication
 				var k v6okta.OpenIdConnectApplicationSettingsClientKeysKeysInner
 
 				kty := jwkMap["kty"].(string)
-				use := ""
-				if jwkMap["use"] != nil {
-					use = jwkMap["use"].(string)
-				}
+				use, _ := jwkMap["use"].(string)
 
 				// Determine key type based on kty and use
 				if use == "enc" {
+					if kty != "RSA" {
+						return v6okta.ListApplications200ResponseInner{}, fmt.Errorf("OAuth application JWKS encryption keys must use kty %q, got %q", "RSA", kty)
+					}
 					// Encryption key (RSA only for encryption)
-					// Fields: e, kty, n, use, kid, status
-					key := v6okta.NewOAuth2ClientJsonEncryptionKeyResponseWithDefaults()
+					// Fields: e, kty, n, use, kid
+					key := &v6okta.OAuth2ClientJsonEncryptionKeyResponse{}
 					if e, ok := jwkMap["e"].(string); ok {
 						key.SetE(e)
 					}
@@ -1191,40 +1253,48 @@ func buildAppOAuthV6(d *schema.ResourceData, isNew bool) (v6okta.ListApplication
 						key.SetKid(kid)
 					}
 					k = v6okta.OAuth2ClientJsonEncryptionKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(key)
-				} else if kty == "RSA" {
-					// RSA Signing key
-					// Fields: e, kty, n, kid, status (NO use, NO alg)
-					key := v6okta.NewOAuth2ClientJsonWebKeyRsaResponseWithDefaults()
-					if e, ok := jwkMap["e"].(string); ok {
-						key.SetE(e)
+				} else if use == "" || use == "sig" {
+					if kty == "RSA" {
+						// RSA Signing key
+						// Fields: e, kty, n, kid, use
+						key := &v6okta.OAuth2ClientJsonWebKeyRsaResponse{}
+						if e, ok := jwkMap["e"].(string); ok {
+							key.SetE(e)
+						}
+						if n, ok := jwkMap["n"].(string); ok {
+							key.SetN(n)
+						}
+						key.SetKty(kty)
+						if kid, ok := jwkMap["kid"].(string); ok && kid != "" {
+							key.SetKid(kid)
+						}
+						key.AdditionalProperties = map[string]interface{}{"use": "sig"}
+						// Wrap RSA key in SigningKeyResponse, then in OpenIdConnectApplicationSettingsClientKeysKeysInner
+						signingKey := v6okta.OAuth2ClientJsonWebKeyRsaResponseAsOAuth2ClientJsonSigningKeyResponse(key)
+						k = v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&signingKey)
+					} else if kty == "EC" {
+						// EC Signing key
+						// Fields: kty, x, y, kid, use
+						key := &v6okta.OAuth2ClientJsonWebKeyECResponse{}
+						if x, ok := jwkMap["x"].(string); ok {
+							key.SetX(x)
+						}
+						if y, ok := jwkMap["y"].(string); ok {
+							key.SetY(y)
+						}
+						key.SetKty(kty)
+						if kid, ok := jwkMap["kid"].(string); ok && kid != "" {
+							key.SetKid(kid)
+						}
+						key.AdditionalProperties = map[string]interface{}{"use": "sig"}
+						// Wrap EC key in SigningKeyResponse, then in OpenIdConnectApplicationSettingsClientKeysKeysInner
+						signingKey := v6okta.OAuth2ClientJsonWebKeyECResponseAsOAuth2ClientJsonSigningKeyResponse(key)
+						k = v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&signingKey)
+					} else {
+						return v6okta.ListApplications200ResponseInner{}, fmt.Errorf("OAuth application JWKS signing keys must use kty %q or %q, got %q", "RSA", "EC", kty)
 					}
-					if n, ok := jwkMap["n"].(string); ok {
-						key.SetN(n)
-					}
-					key.SetKty(kty)
-					if kid, ok := jwkMap["kid"].(string); ok && kid != "" {
-						key.SetKid(kid)
-					}
-					// Wrap RSA key in SigningKeyResponse, then in OpenIdConnectApplicationSettingsClientKeysKeysInner
-					signingKey := v6okta.OAuth2ClientJsonWebKeyRsaResponseAsOAuth2ClientJsonSigningKeyResponse(key)
-					k = v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&signingKey)
-				} else if kty == "EC" {
-					// EC Signing key
-					// Fields: kty, x, y, kid, status (NO crv, NO use, NO alg)
-					key := v6okta.NewOAuth2ClientJsonWebKeyECResponseWithDefaults()
-					if x, ok := jwkMap["x"].(string); ok {
-						key.SetX(x)
-					}
-					if y, ok := jwkMap["y"].(string); ok {
-						key.SetY(y)
-					}
-					key.SetKty(kty)
-					if kid, ok := jwkMap["kid"].(string); ok && kid != "" {
-						key.SetKid(kid)
-					}
-					// Wrap EC key in SigningKeyResponse, then in OpenIdConnectApplicationSettingsClientKeysKeysInner
-					signingKey := v6okta.OAuth2ClientJsonWebKeyECResponseAsOAuth2ClientJsonSigningKeyResponse(key)
-					k = v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&signingKey)
+				} else {
+					return v6okta.ListApplications200ResponseInner{}, fmt.Errorf("invalid OAuth application JWKS use %q", use)
 				}
 
 				keyData = append(keyData, k)
@@ -1320,6 +1390,13 @@ func buildAppOAuthV6(d *schema.ResourceData, isNew bool) (v6okta.ListApplication
 	}
 
 	return v6okta.OpenIdConnectApplicationAsListApplications200ResponseInner(app), nil
+}
+
+func oauthAppJwkUse(additionalProperties map[string]interface{}, defaultUse string) string {
+	if use, ok := additionalProperties["use"].(string); ok && use != "" {
+		return use
+	}
+	return defaultUse
 }
 
 func validateGrantTypes(d *schema.ResourceData) error {

--- a/okta/services/idaas/resource_okta_app_oauth_jwks_test.go
+++ b/okta/services/idaas/resource_okta_app_oauth_jwks_test.go
@@ -1,0 +1,304 @@
+package idaas
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAppOAuthV6DefaultsToSigningUseWhenUseOmitted(t *testing.T) {
+	jwks, err := buildOAuthAppJwksForTest(t, []interface{}{
+		map[string]interface{}{
+			"kty": "RSA",
+			"kid": "SIGNING_KEY_RSA",
+			"e":   "AQAB",
+			"n":   "modulus",
+		},
+	})
+
+	require.NoError(t, err)
+	keys := jwks.GetKeys()
+	require.Len(t, keys, 1)
+	require.NotNil(t, keys[0].OAuth2ClientJsonSigningKeyResponse)
+	require.NotNil(t, keys[0].OAuth2ClientJsonSigningKeyResponse.OAuth2ClientJsonWebKeyRsaResponse)
+	require.Nil(t, keys[0].OAuth2ClientJsonEncryptionKeyResponse)
+	require.Equal(t, "sig", keys[0].OAuth2ClientJsonSigningKeyResponse.OAuth2ClientJsonWebKeyRsaResponse.AdditionalProperties["use"])
+
+	body, err := json.Marshal(jwks)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"keys":[{"e":"AQAB","kid":"SIGNING_KEY_RSA","kty":"RSA","n":"modulus","use":"sig"}]}`, string(body))
+}
+
+func TestBuildAppOAuthV6SerializesSigningUse(t *testing.T) {
+	jwks, err := buildOAuthAppJwksForTest(t, []interface{}{
+		map[string]interface{}{
+			"kty": "RSA",
+			"kid": "SIGNING_KEY_RSA",
+			"e":   "AQAB",
+			"n":   "modulus",
+			"use": "sig",
+		},
+	})
+
+	require.NoError(t, err)
+	keys := jwks.GetKeys()
+	require.Len(t, keys, 1)
+	signingKey := keys[0].OAuth2ClientJsonSigningKeyResponse
+	require.NotNil(t, signingKey)
+	require.Equal(t, "sig", signingKey.OAuth2ClientJsonWebKeyRsaResponse.AdditionalProperties["use"])
+
+	body, err := json.Marshal(jwks)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"keys":[{"e":"AQAB","kid":"SIGNING_KEY_RSA","kty":"RSA","n":"modulus","use":"sig"}]}`, string(body))
+}
+
+func TestBuildAppOAuthV6SerializesEcSigningUse(t *testing.T) {
+	jwks, err := buildOAuthAppJwksForTest(t, []interface{}{
+		map[string]interface{}{
+			"kty": "EC",
+			"kid": "SIGNING_KEY_EC",
+			"x":   "x-coordinate",
+			"y":   "y-coordinate",
+			"use": "sig",
+		},
+	})
+
+	require.NoError(t, err)
+	body, err := json.Marshal(jwks)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"keys":[{"kid":"SIGNING_KEY_EC","kty":"EC","use":"sig","x":"x-coordinate","y":"y-coordinate"}]}`, string(body))
+}
+
+func TestBuildAppOAuthV6SerializesEncryptionUse(t *testing.T) {
+	jwks, err := buildOAuthAppJwksForTest(t, []interface{}{
+		map[string]interface{}{
+			"kty": "RSA",
+			"kid": "ENCRYPTION_KEY_RSA",
+			"e":   "AQAB",
+			"n":   "modulus",
+			"use": "enc",
+		},
+	})
+
+	require.NoError(t, err)
+	keys := jwks.GetKeys()
+	require.Len(t, keys, 1)
+	require.NotNil(t, keys[0].OAuth2ClientJsonEncryptionKeyResponse)
+	require.Nil(t, keys[0].OAuth2ClientJsonSigningKeyResponse)
+	require.Equal(t, "enc", keys[0].OAuth2ClientJsonEncryptionKeyResponse.GetUse())
+
+	body, err := json.Marshal(jwks)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"keys":[{"e":"AQAB","kid":"ENCRYPTION_KEY_RSA","kty":"RSA","n":"modulus","use":"enc"}]}`, string(body))
+}
+
+func TestBuildAppOAuthV6RejectsEcEncryptionKey(t *testing.T) {
+	_, err := buildOAuthAppJwksForTest(t, []interface{}{
+		map[string]interface{}{
+			"kty": "EC",
+			"kid": "ENCRYPTION_KEY_EC",
+			"x":   "x",
+			"y":   "y",
+			"use": "enc",
+		},
+	})
+
+	require.EqualError(t, err, `OAuth application JWKS encryption keys must use kty "RSA", got "EC"`)
+}
+
+func TestBuildAppOAuthV6RejectsUnsupportedSigningKeyType(t *testing.T) {
+	_, err := buildOAuthAppJwksForTest(t, []interface{}{
+		map[string]interface{}{
+			"kty": "oct",
+			"kid": "SIGNING_KEY_OCT",
+			"use": "sig",
+		},
+	})
+
+	require.EqualError(t, err, `OAuth application JWKS signing keys must use kty "RSA" or "EC", got "oct"`)
+}
+
+func buildOAuthAppJwksForTest(t *testing.T, jwksData []interface{}) (*v6okta.OpenIdConnectApplicationSettingsClientKeys, error) {
+	t.Helper()
+
+	d := resourceDataWithRawConfigForTest(t, map[string]interface{}{
+		"label":                      "test",
+		"type":                       "service",
+		"response_types":             []interface{}{"token"},
+		"grant_types":                []interface{}{"client_credentials"},
+		"token_endpoint_auth_method": "private_key_jwt",
+		"jwks":                       jwksData,
+	})
+	app, err := buildAppOAuthV6(d, true)
+	if err != nil {
+		return nil, err
+	}
+
+	oidc, err := verifyOidcAppTypeV6(app)
+	if err != nil {
+		return nil, err
+	}
+	if oidc.Settings.OauthClient == nil || oidc.Settings.OauthClient.Jwks == nil {
+		return nil, errors.New("OAuth application JWKS was not set")
+	}
+	return oidc.Settings.OauthClient.Jwks, nil
+}
+
+func resourceDataWithRawConfigForTest(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+
+	sm := schema.InternalMap(resourceAppOAuth().Schema)
+	diff, err := sm.Diff(context.Background(), nil, terraform.NewResourceConfigRaw(raw), nil, nil, true)
+	require.NoError(t, err)
+	diff.RawConfig = cty.ObjectVal(map[string]cty.Value{
+		"auto_key_rotation":        cty.NullVal(cty.Bool),
+		"pkce_required":            cty.NullVal(cty.Bool),
+		"dpop_bound_access_tokens": cty.NullVal(cty.Bool),
+		"client_basic_secret_wo":   cty.NullVal(cty.String),
+	})
+
+	d, err := sm.Data(nil, diff)
+	require.NoError(t, err)
+	return d
+}
+
+func TestSetOAuthClientSettingsV6SetsSigningUse(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAppOAuth().Schema, nil)
+
+	diags := setOAuthClientSettingsV6(d, testOAuthClientSettingsWithSigningJwks())
+	require.False(t, diags.HasError(), diags)
+
+	jwks := d.Get("jwks").([]interface{})
+	require.Len(t, jwks, 1)
+	require.Equal(t, "sig", jwks[0].(map[string]interface{})["use"])
+}
+
+func TestSetOAuthClientSettingsV6NormalizesNullSigningUse(t *testing.T) {
+	var jwks v6okta.OpenIdConnectApplicationSettingsClientKeys
+	err := json.Unmarshal([]byte(`{"keys":[{"e":"AQAB","kid":"remote-key","kty":"RSA","n":"modulus","use":null}]}`), &jwks)
+	require.NoError(t, err)
+
+	oauthClient := v6okta.NewOpenIdConnectApplicationSettingsClientWithDefaults()
+	oauthClient.SetJwks(jwks)
+
+	d := schema.TestResourceDataRaw(t, resourceAppOAuth().Schema, nil)
+	diags := setOAuthClientSettingsV6(d, oauthClient)
+	require.False(t, diags.HasError(), diags)
+
+	stateJwks := d.Get("jwks").([]interface{})
+	require.Len(t, stateJwks, 1)
+	require.Equal(t, "sig", stateJwks[0].(map[string]interface{})["use"])
+}
+
+func TestSetOAuthClientSettingsV6ReordersJwksToMatchConfig(t *testing.T) {
+	raw := map[string]interface{}{
+		"jwks": []interface{}{
+			map[string]interface{}{
+				"kid": "SIGNING_KEY_RSA",
+				"kty": "RSA",
+				"e":   "AQAB",
+				"n":   "modulus",
+				"use": "sig",
+			},
+			map[string]interface{}{
+				"kid": "SIGNING_KEY_EC",
+				"kty": "EC",
+				"x":   "x-coordinate",
+				"y":   "y-coordinate",
+				"use": "sig",
+			},
+		},
+	}
+	d := schema.TestResourceDataRaw(t, resourceAppOAuth().Schema, raw)
+
+	ecKey := v6okta.NewOAuth2ClientJsonWebKeyECResponseWithDefaults()
+	ecKey.SetKid("SIGNING_KEY_EC")
+	ecKey.SetKty("EC")
+	ecKey.SetX("x-coordinate")
+	ecKey.SetY("y-coordinate")
+	ecSigning := v6okta.OAuth2ClientJsonWebKeyECResponseAsOAuth2ClientJsonSigningKeyResponse(ecKey)
+
+	rsaKey := v6okta.NewOAuth2ClientJsonWebKeyRsaResponseWithDefaults()
+	rsaKey.SetKid("SIGNING_KEY_RSA")
+	rsaKey.SetKty("RSA")
+	rsaKey.SetE("AQAB")
+	rsaKey.SetN("modulus")
+	rsaSigning := v6okta.OAuth2ClientJsonWebKeyRsaResponseAsOAuth2ClientJsonSigningKeyResponse(rsaKey)
+
+	jwks := v6okta.NewOpenIdConnectApplicationSettingsClientKeysWithDefaults()
+	jwks.SetKeys([]v6okta.OpenIdConnectApplicationSettingsClientKeysKeysInner{
+		v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&ecSigning),
+		v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&rsaSigning),
+	})
+
+	oauthClient := v6okta.NewOpenIdConnectApplicationSettingsClientWithDefaults()
+	oauthClient.SetJwks(*jwks)
+
+	diags := setOAuthClientSettingsV6(d, oauthClient)
+	require.False(t, diags.HasError(), diags)
+
+	stateJwks := d.Get("jwks").([]interface{})
+	require.Len(t, stateJwks, 2)
+	require.Equal(t, "SIGNING_KEY_RSA", stateJwks[0].(map[string]interface{})["kid"])
+	require.Equal(t, "SIGNING_KEY_EC", stateJwks[1].(map[string]interface{})["kid"])
+}
+
+func TestSetOAuthClientSettingsV6KeepsApiOrderWhenJwksKidCannotBeUniquelyMatched(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAppOAuth().Schema, nil)
+
+	rsaKey := v6okta.NewOAuth2ClientJsonWebKeyRsaResponseWithDefaults()
+	rsaKey.SetKid("DUPLICATE_KEY")
+	rsaKey.SetKty("RSA")
+	rsaKey.SetE("AQAB")
+	rsaKey.SetN("modulus")
+	rsaSigning := v6okta.OAuth2ClientJsonWebKeyRsaResponseAsOAuth2ClientJsonSigningKeyResponse(rsaKey)
+
+	ecKey := v6okta.NewOAuth2ClientJsonWebKeyECResponseWithDefaults()
+	ecKey.SetKid("DUPLICATE_KEY")
+	ecKey.SetKty("EC")
+	ecKey.SetX("x-coordinate")
+	ecKey.SetY("y-coordinate")
+	ecSigning := v6okta.OAuth2ClientJsonWebKeyECResponseAsOAuth2ClientJsonSigningKeyResponse(ecKey)
+
+	jwks := v6okta.NewOpenIdConnectApplicationSettingsClientKeysWithDefaults()
+	jwks.SetKeys([]v6okta.OpenIdConnectApplicationSettingsClientKeysKeysInner{
+		v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&rsaSigning),
+		v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&ecSigning),
+	})
+
+	oauthClient := v6okta.NewOpenIdConnectApplicationSettingsClientWithDefaults()
+	oauthClient.SetJwks(*jwks)
+
+	diags := setOAuthClientSettingsV6(d, oauthClient)
+	require.False(t, diags.HasError(), diags)
+
+	stateJwks := d.Get("jwks").([]interface{})
+	require.Len(t, stateJwks, 2)
+	require.Equal(t, "RSA", stateJwks[0].(map[string]interface{})["kty"])
+	require.Equal(t, "EC", stateJwks[1].(map[string]interface{})["kty"])
+}
+
+func testOAuthClientSettingsWithSigningJwks() *v6okta.OpenIdConnectApplicationSettingsClient {
+	rsaKey := v6okta.NewOAuth2ClientJsonWebKeyRsaResponseWithDefaults()
+	rsaKey.SetKid("remote-key")
+	rsaKey.SetKty("RSA")
+	rsaKey.SetE("AQAB")
+	rsaKey.SetN("modulus")
+
+	signingKey := v6okta.OAuth2ClientJsonWebKeyRsaResponseAsOAuth2ClientJsonSigningKeyResponse(rsaKey)
+	key := v6okta.OAuth2ClientJsonSigningKeyResponseAsOpenIdConnectApplicationSettingsClientKeysKeysInner(&signingKey)
+
+	jwks := v6okta.NewOpenIdConnectApplicationSettingsClientKeysWithDefaults()
+	jwks.SetKeys([]v6okta.OpenIdConnectApplicationSettingsClientKeysKeysInner{key})
+
+	oauthClient := v6okta.NewOpenIdConnectApplicationSettingsClientWithDefaults()
+	oauthClient.SetJwks(*jwks)
+	return oauthClient
+}

--- a/okta/services/idaas/resource_okta_app_oauth_test.go
+++ b/okta/services/idaas/resource_okta_app_oauth_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/acctest"
 	"github.com/okta/terraform-provider-okta/okta/resources"
 	"github.com/okta/terraform-provider-okta/okta/services/idaas"
@@ -326,6 +328,7 @@ func TestAccResourceOktaAppOauth_serviceWithJWKS(t *testing.T) {
 					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
 					resource.TestCheckResourceAttr(resourceName, "jwks.0.kty", "RSA"),
 					resource.TestCheckResourceAttr(resourceName, "jwks.0.kid", "SIGNING_KEY_RSA"),
+					resource.TestCheckResourceAttr(resourceName, "jwks.0.use", "sig"),
 					resource.TestCheckResourceAttr(resourceName, "jwks.0.e", "AQAB"),
 					resource.TestCheckResourceAttr(resourceName, "jwks.0.n", "owfoXNHcAlAVpIO41840ZU2tZraLGw3yEr3xZvAti7oEZPUKCytk88IDgH7440JOuz8GC_D6vtduWOqnEt0j0_faJnhKHgfj7DTWBOCxzSdjrM-Uyj6-e_XLFvZXzYsQvt52PnBJUV15G1W9QTjlghT_pFrW0xrTtbO1c281u1HJdPd5BeIyPb0pGbciySlx53OqGyxrAxPAt5P5h-n36HJkVsSQtNvgptLyOwWYkX50lgnh2szbJ0_O581bqkNBy9uqlnVeK1RZDQUl4mk8roWYhsx_JOgjpC3YyeXA6hHsT5xWZos_gNx98AHivNaAjzIzvyVItX2-hP0Aoscfff"),
 				),
@@ -336,8 +339,67 @@ func TestAccResourceOktaAppOauth_serviceWithJWKS(t *testing.T) {
 					ensureResourceExists(ecResourceName, createDoesOAuthAppExist()),
 					resource.TestCheckResourceAttr(ecResourceName, "jwks.0.kty", "EC"),
 					resource.TestCheckResourceAttr(ecResourceName, "jwks.0.kid", "SIGNING_KEY_EC"),
+					resource.TestCheckResourceAttr(ecResourceName, "jwks.0.use", "sig"),
 					resource.TestCheckResourceAttr(ecResourceName, "jwks.0.x", "K37X78mXJHHldZYMzrwipjKR-YZUS2SMye0KindHp6I"),
 					resource.TestCheckResourceAttr(ecResourceName, "jwks.0.y", "8IfvsvXWzbFWOZoVOMwgF5p46mUj3kbOVf9Fk0vVVHo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOktaAppOauth_jwksUsePreservedWhenAddingKey(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSAppOAuth, t.Name())
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSAppOAuth)
+
+	rsa1 := oauthAppJwkRSA()
+	rsa2 := oauthAppJwkRSA2()
+	ec1 := oauthAppJwkEC()
+	ec2 := oauthAppJwkEC2()
+
+	mixedKeys := map[string]oauthAppJwkExpectation{
+		rsa1.Kid: rsa1,
+		ec1.Kid:  ec1,
+	}
+	expandedKeys := map[string]oauthAppJwkExpectation{
+		rsa1.Kid: rsa1,
+		rsa2.Kid: rsa2,
+		ec1.Kid:  ec1,
+		ec2.Kid:  ec2,
+	}
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSAppOAuth, createDoesOAuthAppExist()),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(oauthAppWithJwksConfig([]oauthAppJwkExpectation{rsa1, ec1})),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
+					resource.TestCheckResourceAttr(resourceName, "jwks.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "jwks.0.kid", rsa1.Kid),
+					resource.TestCheckResourceAttr(resourceName, "jwks.0.use", "sig"),
+					resource.TestCheckResourceAttr(resourceName, "jwks.1.kid", ec1.Kid),
+					resource.TestCheckResourceAttr(resourceName, "jwks.1.use", "sig"),
+					checkOAuthAppJwks(resourceName, mixedKeys),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(oauthAppWithJwksConfig([]oauthAppJwkExpectation{rsa1, ec1, rsa2, ec2})),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
+					resource.TestCheckResourceAttr(resourceName, "jwks.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "jwks.0.kid", rsa1.Kid),
+					resource.TestCheckResourceAttr(resourceName, "jwks.0.use", "sig"),
+					resource.TestCheckResourceAttr(resourceName, "jwks.1.kid", ec1.Kid),
+					resource.TestCheckResourceAttr(resourceName, "jwks.1.use", "sig"),
+					resource.TestCheckResourceAttr(resourceName, "jwks.2.kid", rsa2.Kid),
+					resource.TestCheckResourceAttr(resourceName, "jwks.2.use", "sig"),
+					resource.TestCheckResourceAttr(resourceName, "jwks.3.kid", ec2.Kid),
+					resource.TestCheckResourceAttr(resourceName, "jwks.3.use", "sig"),
+					checkOAuthAppJwks(resourceName, expandedKeys),
 				),
 			},
 		},
@@ -364,6 +426,202 @@ func TestAccResourceOktaAppOauth_serviceWithJWKSURI(t *testing.T) {
 			},
 		},
 	})
+}
+
+type oauthAppJwkExpectation struct {
+	Kty string
+	Kid string
+	Use string
+	E   string
+	N   string
+	X   string
+	Y   string
+}
+
+func oauthAppJwkRSA() oauthAppJwkExpectation {
+	return oauthAppJwkExpectation{
+		Kty: "RSA",
+		Kid: "SIGNING_KEY_RSA",
+		Use: "sig",
+		E:   "AQAB",
+		N:   "owfoXNHcAlAVpIO41840ZU2tZraLGw3yEr3xZvAti7oEZPUKCytk88IDgH7440JOuz8GC_D6vtduWOqnEt0j0_faJnhKHgfj7DTWBOCxzSdjrM-Uyj6-e_XLFvZXzYsQvt52PnBJUV15G1W9QTjlghT_pFrW0xrTtbO1c281u1HJdPd5BeIyPb0pGbciySlx53OqGyxrAxPAt5P5h-n36HJkVsSQtNvgptLyOwWYkX50lgnh2szbJ0_O581bqkNBy9uqlnVeK1RZDQUl4mk8roWYhsx_JOgjpC3YyeXA6hHsT5xWZos_gNx98AHivNaAjzIzvyVItX2-hP0Aoscfff",
+	}
+}
+
+func oauthAppJwkRSA2() oauthAppJwkExpectation {
+	return oauthAppJwkExpectation{
+		Kty: "RSA",
+		Kid: "SIGNING_KEY_RSA_2",
+		Use: "sig",
+		E:   "AQAB",
+		N:   "rn3forF-5wn2dPulKfanijxAqZ3GhkFfv8SmxvWnatHrJ10eV-Tfb7ijc52qy5W9X1dZuHM1GqeqoTBjP9RgImLHJ8Y4elwSWaI-XWHSvfey1TXIvJA6cCCaURjVV-hwHhRWBz9E0zL_pOJmbsB66rsxLVrkldgtlRlf4Bb-4xBtbMu3xK78A38WgwwNFVDnvYGRzW4J3cFx3gndQ94BlZUxBpoiOpxx1-oCaVYcDCjkvHcvMDO8orvZAKbg8qudAfWa4L1PHdfZxYGifFWS9Z8hEKmn3Bt43JxpZQDhfFhHPR3FdSuiI6FySwWT8wlyn8XcAmCb-fS2Z-ScjxGrVw",
+	}
+}
+
+func oauthAppJwkEC() oauthAppJwkExpectation {
+	return oauthAppJwkExpectation{
+		Kty: "EC",
+		Kid: "SIGNING_KEY_EC",
+		Use: "sig",
+		X:   "K37X78mXJHHldZYMzrwipjKR-YZUS2SMye0KindHp6I",
+		Y:   "8IfvsvXWzbFWOZoVOMwgF5p46mUj3kbOVf9Fk0vVVHo",
+	}
+}
+
+func oauthAppJwkEC2() oauthAppJwkExpectation {
+	return oauthAppJwkExpectation{
+		Kty: "EC",
+		Kid: "SIGNING_KEY_EC_2",
+		Use: "sig",
+		X:   "6W5vGNPWhkhubooDOK_6Y2wLnT086jEZZEDRXKtxHuM",
+		Y:   "1hpsUnXd1LZQEvbGia_k4jIeOwZMFMIorV488GqNXcA",
+	}
+}
+
+func oauthAppWithJwksConfig(keys []oauthAppJwkExpectation) string {
+	var blocks strings.Builder
+	for _, k := range keys {
+		switch k.Kty {
+		case "RSA":
+			fmt.Fprintf(&blocks, `
+  jwks {
+    kty = %q
+    kid = %q
+    use = %q
+    e   = %q
+    n   = %q
+  }
+`, k.Kty, k.Kid, k.Use, k.E, k.N)
+		case "EC":
+			fmt.Fprintf(&blocks, `
+  jwks {
+    kty = %q
+    kid = %q
+    use = %q
+    x   = %q
+    y   = %q
+  }
+`, k.Kty, k.Kid, k.Use, k.X, k.Y)
+		default:
+			panic(fmt.Sprintf("unsupported test JWKS kty %q", k.Kty))
+		}
+	}
+
+	return fmt.Sprintf(`
+resource "okta_app_oauth" "test" {
+  label                      = "testAcc_replace_with_uuid"
+  type                       = "service"
+  response_types             = ["token"]
+  grant_types                = ["client_credentials"]
+  token_endpoint_auth_method = "private_key_jwt"
+  skip_authentication_policy = true
+  enduser_note               = "inline jwks acceptance"
+%s
+}
+`, blocks.String())
+}
+
+func checkOAuthAppJwks(resourceName string, expected map[string]oauthAppJwkExpectation) resource.TestCheckFunc {
+	if os.Getenv("OKTA_VCR_TF_ACC") == "play" {
+		return func(_ *terraform.State) error {
+			return nil
+		}
+	}
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		appResp, _, err := iDaaSAPIClientForTestUtil.OktaSDKClientV6().ApplicationAPI.GetApplication(context.Background(), rs.Primary.ID).Execute()
+		if err != nil {
+			return err
+		}
+		if appResp == nil || appResp.OpenIdConnectApplication == nil {
+			return fmt.Errorf("expected %s to be an OpenID Connect application", resourceName)
+		}
+
+		settings := appResp.OpenIdConnectApplication.GetSettings()
+		oauthClient := settings.GetOauthClient()
+		jwks, ok := oauthClient.GetJwksOk()
+		if !ok || jwks == nil {
+			return fmt.Errorf("expected %s to have inline JWKS", resourceName)
+		}
+
+		actual := make(map[string]oauthAppJwkExpectation)
+		for _, key := range jwks.GetKeys() {
+			jwk, err := oauthAppJwkFromResponse(key)
+			if err != nil {
+				return err
+			}
+			actual[jwk.Kid] = jwk
+		}
+
+		if len(actual) != len(expected) {
+			return fmt.Errorf("expected %d JWKS keys, got %d: %#v", len(expected), len(actual), actual)
+		}
+		for kid, expectedJwk := range expected {
+			actualJwk, ok := actual[kid]
+			if !ok {
+				return fmt.Errorf("expected JWKS key %q to exist, got %#v", kid, actual)
+			}
+			if actualJwk != expectedJwk {
+				return fmt.Errorf("unexpected JWKS key %q: expected %#v, got %#v", kid, expectedJwk, actualJwk)
+			}
+		}
+
+		return nil
+	}
+}
+
+func oauthAppJwkFromResponse(key v6okta.OpenIdConnectApplicationSettingsClientKeysKeysInner) (oauthAppJwkExpectation, error) {
+	if key.OAuth2ClientJsonEncryptionKeyResponse != nil {
+		enc := key.OAuth2ClientJsonEncryptionKeyResponse
+		return oauthAppJwkExpectation{
+			Kty: enc.GetKty(),
+			Kid: enc.GetKid(),
+			Use: enc.GetUse(),
+			E:   enc.GetE(),
+			N:   enc.GetN(),
+		}, nil
+	}
+
+	if key.OAuth2ClientJsonSigningKeyResponse == nil {
+		return oauthAppJwkExpectation{}, errors.New("expected JWKS key response to contain a signing or encryption key")
+	}
+
+	signingKey := key.OAuth2ClientJsonSigningKeyResponse
+	if signingKey.OAuth2ClientJsonWebKeyRsaResponse != nil {
+		rsa := signingKey.OAuth2ClientJsonWebKeyRsaResponse
+		use, ok := rsa.AdditionalProperties["use"].(string)
+		if !ok || use == "" {
+			return oauthAppJwkExpectation{}, fmt.Errorf("RSA JWKS key %q has empty or non-string use: %#v", rsa.GetKid(), rsa.AdditionalProperties["use"])
+		}
+		return oauthAppJwkExpectation{
+			Kty: rsa.GetKty(),
+			Kid: rsa.GetKid(),
+			Use: use,
+			E:   rsa.GetE(),
+			N:   rsa.GetN(),
+		}, nil
+	}
+	if signingKey.OAuth2ClientJsonWebKeyECResponse != nil {
+		ec := signingKey.OAuth2ClientJsonWebKeyECResponse
+		use, ok := ec.AdditionalProperties["use"].(string)
+		if !ok || use == "" {
+			return oauthAppJwkExpectation{}, fmt.Errorf("EC JWKS key %q has empty or non-string use: %#v", ec.GetKid(), ec.AdditionalProperties["use"])
+		}
+		return oauthAppJwkExpectation{
+			Kty: ec.GetKty(),
+			Kid: ec.GetKid(),
+			Use: use,
+			X:   ec.GetX(),
+			Y:   ec.GetY(),
+		}, nil
+	}
+
+	return oauthAppJwkExpectation{}, errors.New("expected signing JWKS key response to contain an RSA or EC key")
 }
 
 // createDoesAppExist is a compatibility wrapper for other test files
@@ -1072,7 +1330,6 @@ resource "okta_app_oauth" "test" {
 		},
 	})
 }
-
 
 // TestAccResourceOktaAppOauth_preconfigured tests creating and updating OAuth applications
 // using preconfigured apps from the Okta Integration Network (test1-test3), as well as

--- a/templates/resources/app_oauth.md.tmpl
+++ b/templates/resources/app_oauth.md.tmpl
@@ -127,6 +127,7 @@ resource "okta_app_oauth" "app" {
   jwks {
     kty = local.jwks.kty
     kid = local.jwks.kid
+    use = "sig"
     e   = local.jwks.e
     n   = local.jwks.n
   }


### PR DESCRIPTION
## Summary

Adds `use` support to the `okta_app_oauth.jwks` block. This fixes an issue where inline signing keys used with `private_key_jwt` would lose `use = "sig|enc"` and set it to `null` which would break the key after an OAuth app update because the provider did not expose or send the field.

## Changes

- Adds `jwks.use` with valid values `sig` and `enc`.
- Sends `use = "sig"` for RSA/EC signing keys.
- Sends `use = "enc"` for RSA encryption keys.
- Reads `use` from Okta API responses back into Terraform state.
- Normalizes missing/null signing `use` to `sig`.
- Preserves configured JWKS order by matching keys by `kid` to avoid TypeList positional drift when Okta returns keys in a different order.
- Updates docs and examples.

## Testing

- `go test ./okta/services/idaas`
- Manual local-provider test with `terraform apply` against Okta:
  - created OAuth service app with inline RSA JWKS and `use = "sig"`
  - added another generated RSA JWKS key
  - removed one key and verified final planned `after.jwks`
  - verified Okta API response kept `use = "sig"`

Real-infra acceptance test:

```sh
TF_ACC=1 go test ./okta/services/idaas \
  -v -run '^TestAccResourceOktaAppOauth_jwksUsePreservedWhenAddingKey$' \
  -timeout 10m