### PR TITLE
GH-2598 | Defer 429 Retries to SDK for DPoP Requests

### DIFF
--- a/okta/api/api.go
+++ b/okta/api/api.go
@@ -40,8 +40,13 @@ func getV6ClientConfig(c *OktaAPIConfig) (*v6okta.Configuration, *v6okta.APIClie
 		} else {
 			retryableClient.HTTPClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Okta", retryableClient.HTTPClient.Transport)
 		}
-		retryableClient.ErrorHandler = errHandler
-		retryableClient.CheckRetry = checkRetry
+		if c.PrivateKey != "" {
+			retryableClient.CheckRetry = checkRetryDeferOn429
+			retryableClient.ErrorHandler = errHandlerPassThrough429
+		} else {
+			retryableClient.ErrorHandler = errHandler
+			retryableClient.CheckRetry = checkRetry
+		}
 		httpClient = retryableClient.StandardClient()
 		c.Logger.Info(fmt.Sprintf("v6 running with backoff http client, wait min %d, wait max %d, retry max %d", retryableClient.RetryWaitMin, retryableClient.RetryWaitMax, retryableClient.RetryMax))
 	} else {
@@ -156,8 +161,13 @@ func getV5ClientConfig(c *OktaAPIConfig) (*v5okta.Configuration, *v5okta.APIClie
 		} else {
 			retryableClient.HTTPClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Okta", retryableClient.HTTPClient.Transport)
 		}
-		retryableClient.ErrorHandler = errHandler
-		retryableClient.CheckRetry = checkRetry
+		if c.PrivateKey != "" {
+			retryableClient.CheckRetry = checkRetryDeferOn429
+			retryableClient.ErrorHandler = errHandlerPassThrough429
+		} else {
+			retryableClient.ErrorHandler = errHandler
+			retryableClient.CheckRetry = checkRetry
+		}
 		httpClient = retryableClient.StandardClient()
 		c.Logger.Info(fmt.Sprintf("v5 running with backoff http client, wait min %d, wait max %d, retry max %d", retryableClient.RetryWaitMin, retryableClient.RetryWaitMax, retryableClient.RetryMax))
 	} else {
@@ -270,6 +280,35 @@ func errHandler(resp *http.Response, err error, numTries int) (*http.Response, e
 		return resp, fmt.Errorf("%v: giving up after %d attempt(s)", err, numTries)
 	}
 	return resp, nil
+}
+
+// isDPoPRequest reports whether the request that produced resp carried a DPoP proof.
+// PrivateKey auth only emits the Dpop header when the token endpoint returned a
+// DPoP-bound access token, so this distinguishes orgs that enforce DPoP from ones
+// that don't.
+func isDPoPRequest(resp *http.Response) bool {
+	return resp != nil && resp.Request != nil && resp.Request.Header.Get("Dpop") != ""
+}
+
+// checkRetryDeferOn429 returns false on a DPoP-bound 429 so retryablehttp surfaces
+// the response to the SDK's RequestExecutor.doWithRetries, which regenerates the
+// DPoP proof JWT with a fresh `jti` per RFC 9449 before retrying. Non-DPoP requests
+// (and non-429 cases) flow through the standard checkRetry.
+func checkRetryDeferOn429(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests && isDPoPRequest(resp) {
+		return false, nil
+	}
+	return checkRetry(ctx, resp, err)
+}
+
+// errHandlerPassThrough429 returns the raw DPoP-bound 429 response (body open) so
+// the SDK's retry path can read it. Non-DPoP terminal cases delegate to errHandler
+// for the usual SDK-error wrapping.
+func errHandlerPassThrough429(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	if err == nil && resp != nil && resp.StatusCode == http.StatusTooManyRequests && isDPoPRequest(resp) {
+		return resp, nil
+	}
+	return errHandler(resp, err, numTries)
 }
 
 // Used to make http client retry on provided list of response status codes

--- a/okta/api/idaas.go
+++ b/okta/api/idaas.go
@@ -178,8 +178,13 @@ func GetV3ClientConfig(c *OktaAPIConfig) (*okta.Configuration, *okta.APIClient, 
 		} else {
 			retryableClient.HTTPClient.Transport = logging.NewSubsystemLoggingHTTPTransport("Okta", retryableClient.HTTPClient.Transport)
 		}
-		retryableClient.ErrorHandler = errHandler
-		retryableClient.CheckRetry = checkRetry
+		if c.PrivateKey != "" {
+			retryableClient.CheckRetry = checkRetryDeferOn429
+			retryableClient.ErrorHandler = errHandlerPassThrough429
+		} else {
+			retryableClient.ErrorHandler = errHandler
+			retryableClient.CheckRetry = checkRetry
+		}
 		httpClient = retryableClient.StandardClient()
 		c.Logger.Info(fmt.Sprintf("v3 running with backoff http client, wait min %d, wait max %d, retry max %d", retryableClient.RetryWaitMin, retryableClient.RetryWaitMax, retryableClient.RetryMax))
 	} else {


### PR DESCRIPTION
When the provider is configured with `private_key` / `private_key_id` against an org that enforces **DPoP**, requests that hit the Okta rate limiter (HTTP 429) were being retried by `hashicorp/go-retryablehttp` *inside* the HTTP layer —  which simply replays the same request bytes. A DPoP-bound 429 cannot be recovered that way: the server returns a fresh `DPoP-Nonce` that must be re-bound into a newly signed proof JWT (with a fresh `jti`, per RFC 9449) before the next attempt. The naive replay loops on `use_dpop_nonce` errors until retries are exhausted and surfaces a hard failure to the user.


  ## What changed                                                                                                  
                                                                                                                   
  - `okta/api/api.go` / `okta/api/idaas.go` — when `PrivateKey` auth is                                            
    configured, the retryable client is wired with two new policy hooks:                                         
    - `CheckRetry = checkRetryDeferOn429`                                                                          
    - `ErrorHandler = errHandlerPassThrough429`                                                                    
                                                                                                                   
    All other auth modes keep the original `checkRetry` / `errHandler` pair, so                                    
    there is no behavioural change for API-token / OAuth-without-DPoP users.                                       
                                                                                                                   
  - `checkRetryDeferOn429` returns `(false, nil)` when the response is a 429                                       
    *and* the request carried a `Dpop` header. That short-circuits the inner                                       
    retry loop and lets the response bubble up to                                                                  
    `RequestExecutor.doWithRetries`, which evicts the cached access token,                                         
    DPoP nonce, and DPoP keypair and rebuilds the request before the next                                          
    attempt.                                                                                                       
                                                                                                                   
  - `errHandlerPassThrough429` is the matching terminal-path guard: if                                             
    `retryablehttp` exhausts its internal attempts on a DPoP 429, the raw                                        
    response is returned untouched (body open) so the SDK can still read the                                       
    `DPoP-Nonce` header. Every other terminal case delegates to the existing                                       
    `errHandler` and keeps SDK-error wrapping intact.                                                              
                                                                                                                   
  - `isDPoPRequest` is a small helper that detects DPoP-bound traffic by                                           
    inspecting the outbound `Dpop` header — only present when the token                                            
    endpoint actually returned a DPoP-bound access token, so it cleanly                                            
    distinguishes DPoP-enforced orgs from PrivateKey orgs that aren't.      