### PR TITLE
fix: prevent nil pointer dereference in idp_saml, idp_social, and idp_oidc when accountLink.filter.groups is null

### DIFF
--- a/examples/resources/okta_idp_saml/account_link_auto.tf
+++ b/examples/resources/okta_idp_saml/account_link_auto.tf
@@ -1,0 +1,35 @@
+resource "okta_app_saml" "test" {
+  label                    = "testAcc_replace_with_uuid"
+  sso_url                  = "http://google.com"
+  recipient                = "http://here.com"
+  destination              = "http://its-about-the-journey.com"
+  audience                 = "http://audience.com"
+  subject_name_id_template = "$${user.userName}"
+  subject_name_id_format   = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+  response_signed          = true
+  signature_algorithm      = "RSA_SHA256"
+  digest_algorithm         = "SHA256"
+  honor_force_authn        = false
+  authn_context_class_ref  = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+}
+
+resource "okta_idp_saml_key" "test" {
+  x5c = [okta_app_saml.test.certificate]
+}
+
+# account_link_action = AUTO without account_link_group_include exercises the code path fixed
+# in OKTA-1131393: on some Okta cells the API returns accountLink.filter.groups = null while
+# filter itself is non-null, which caused a nil pointer dereference in the Read function.
+resource "okta_idp_saml" "test" {
+  name                     = "testAcc_replace_with_uuid"
+  acs_type                 = "INSTANCE"
+  sso_url                  = "https://idp.example.com"
+  sso_destination          = "https://idp.example.com"
+  sso_binding              = "HTTP-POST"
+  username_template        = "idpuser.email"
+  kid                      = okta_idp_saml_key.test.id
+  issuer                   = "https://idp.example.com"
+  request_signature_scope  = "REQUEST"
+  response_signature_scope = "ANY"
+  account_link_action      = "AUTO"
+}

--- a/okta/services/idaas/resource_okta_idp_oidc.go
+++ b/okta/services/idaas/resource_okta_idp_oidc.go
@@ -280,7 +280,7 @@ func resourceIdpRead(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 	if idp.Policy.AccountLink != nil {
 		_ = d.Set("account_link_action", idp.Policy.AccountLink.Action)
-		if idp.Policy.AccountLink.Filter != nil {
+		if idp.Policy.AccountLink.Filter != nil && idp.Policy.AccountLink.Filter.Groups != nil {
 			setMap["account_link_group_include"] = utils.ConvertStringSliceToSet(idp.Policy.AccountLink.Filter.Groups.Include)
 		}
 	}

--- a/okta/services/idaas/resource_okta_idp_saml.go
+++ b/okta/services/idaas/resource_okta_idp_saml.go
@@ -228,7 +228,7 @@ func resourceIdpSamlRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	if idp.Policy.AccountLink != nil {
 		_ = d.Set("account_link_action", idp.Policy.AccountLink.Action)
-		if idp.Policy.AccountLink.Filter != nil {
+		if idp.Policy.AccountLink.Filter != nil && idp.Policy.AccountLink.Filter.Groups != nil {
 			setMap["account_link_group_include"] = utils.ConvertStringSliceToSet(idp.Policy.AccountLink.Filter.Groups.Include)
 		}
 	}

--- a/okta/services/idaas/resource_okta_idp_saml_test.go
+++ b/okta/services/idaas/resource_okta_idp_saml_test.go
@@ -118,6 +118,39 @@ func TestAccResourceOktaIdpSaml_crud(t *testing.T) {
 	})
 }
 
+// TestAccResourceOktaIdpSaml_account_link_auto exercises the Read path when account_link_action
+// is set to AUTO without account_link_group_include. Regression test for OKTA-1131393 where
+// the provider panicked with a nil pointer dereference when the Okta API returned
+// accountLink.filter.groups = null (filter non-null, groups null inside it).
+func TestAccResourceOktaIdpSaml_account_link_auto(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSIdpSaml, t.Name())
+	config := mgr.GetFixtures("account_link_auto.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSIdpSaml)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSIdpSaml, createDoesIdpExist),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", acctest.BuildResourceName(mgr.Seed)),
+					resource.TestCheckResourceAttr(resourceName, "account_link_action", "AUTO"),
+					resource.TestCheckNoResourceAttr(resourceName, "account_link_group_include"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"issuer_mode"},
+			},
+		},
+	})
+}
+
 // TestAccResourceOktaIdpSaml_minimal_example was used to prove that the PR
 // https://github.com/okta/terraform-provider-okta/pull/1355 was correct. This
 // test would fail if the org was missing the mappings api feature. And pass if

--- a/okta/services/idaas/resource_okta_idp_social.go
+++ b/okta/services/idaas/resource_okta_idp_social.go
@@ -232,7 +232,7 @@ func resourceIdpSocialRead(ctx context.Context, d *schema.ResourceData, meta int
 	if idp.Policy.AccountLink != nil {
 		_ = d.Set("account_link_action", idp.Policy.AccountLink.Action)
 
-		if idp.Policy.AccountLink.Filter != nil {
+		if idp.Policy.AccountLink.Filter != nil && idp.Policy.AccountLink.Filter.Groups != nil {
 			setMap["account_link_group_include"] = utils.ConvertStringSliceToSet(idp.Policy.AccountLink.Filter.Groups.Include)
 		}
 	}

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaIdpSaml_account_link_auto/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaIdpSaml_account_link_auto/oie-00.yaml
@@ -1,0 +1,997 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1069
+        host: oie-00.dne-okta.com
+        body: |
+            {"accessibility":{"selfService":false},"credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"}},"label":"testAcc_3131132638","settings":{"app":{},"implicitAssignment":false,"notes":{"admin":null,"enduser":null},"signOn":{"allowMultipleAcsEndpoints":false,"assertionSigned":false,"attributeStatements":[],"audience":"http://audience.com","audienceOverride":"","authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","defaultRelayState":"","destination":"http://its-about-the-journey.com","destinationOverride":"","digestAlgorithm":"SHA256","honorForceAuthn":false,"recipient":"http://here.com","recipientOverride":"","responseSigned":true,"samlSignedRequestEnabled":false,"signatureAlgorithm":"RSA_SHA256","slo":{"enabled":false},"ssoAcsUrl":"http://google.com","ssoAcsUrlOverride":"","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","subjectNameIdTemplate":"${user.userName}"}},"signOnMode":"SAML_2_0","visibility":{"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false}}}
+        form:
+            activate:
+                - "true"
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/apps?activate=true
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz85t4b8okCNkFE1d7","orn":"orn:oktapreview:idp:00otivnuq1X5554yc1d7:apps:oie-00_testacc3131132638_2:0oaz85t4b8okCNkFE1d7","name":"oie-00_testacc3131132638_2","label":"testAcc_3131132638","status":"ACTIVE","lastUpdated":"2026-05-27T19:36:44.000Z","created":"2026-05-27T19:36:44.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3131132638_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":null,"ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3131132638_2/0oaz85t4b8okCNkFE1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3131132638_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3131132638_2/0oaz85t4b8okCNkFE1d7/alnz86fio4UiOrwjD1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuviYmKDYit1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuvg01CxhjA1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/lifecycle/deactivate"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:44 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 2.748488917s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/.well-known/okta-organization
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: '{"id":"00otivnuq1X5554yc1d7","cell":"op3","_links":{"organization":{"href":"https://oie-00.dne-okta.com"}},"pipeline":"idx","settings":{"analyticsCollectionEnabled":false,"bugReportingEnabled":true,"omEnabled":false,"pssoEnabled":true,"desktopMFAEnabled":true,"itpEnabled":true}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:46 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.056578667s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            type:
+                - ACCESS_POLICY
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"rsttivnuus97Z2Ua81d7","status":"ACTIVE","name":"Okta Admin Console","priority":1,"system":false,"conditions":null,"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-01-06T09:19:37.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuus97Z2Ua81d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuus97Z2Ua81d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuus97Z2Ua81d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuus97Z2Ua81d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttivnuuz4MSxGin1d7","status":"ACTIVE","name":"Okta Dashboard","priority":1,"system":false,"conditions":null,"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-01-06T09:19:37.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuuz4MSxGin1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuuz4MSxGin1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuuz4MSxGin1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuuz4MSxGin1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttivnuv2yDnkaOF1d7","status":"ACTIVE","name":"Okta Browser Plugin","priority":1,"system":false,"conditions":null,"created":"2026-01-06T09:19:37.000Z","lastUpdated":"2026-01-06T09:19:37.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuv2yDnkaOF1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuv2yDnkaOF1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuv2yDnkaOF1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuv2yDnkaOF1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttivnuvg01CxhjA1d7","status":"ACTIVE","name":"Any two factors","description":"Require two factors to access.","priority":1,"system":true,"conditions":null,"created":"2026-01-06T09:19:38.000Z","lastUpdated":"2026-01-06T09:19:38.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuvg01CxhjA1d7","hints":{"allow":["GET","PUT"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuvg01CxhjA1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttivnuwgnZVG5Un1d7","status":"ACTIVE","name":"Okta Account Management Policy","description":"This policy defines how users must authenticate for authenticator enrollment, password reset, or unlock account. Password policy rules control whether to enforce this policy for password reset and unlock account.","priority":1,"system":false,"conditions":null,"created":"2026-01-06T09:19:39.000Z","lastUpdated":"2026-01-06T09:19:39.000Z","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuwgnZVG5Un1d7","hints":{"allow":["GET"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuwgnZVG5Un1d7/rules","hints":{"allow":["GET","POST"]}}},"_embedded":{"resourceType":"END_USER_ACCOUNT_MANAGEMENT"},"type":"ACCESS_POLICY"},{"id":"rsttiw5aaeJ48m2Zv1d7","status":"ACTIVE","name":"Case-OKTA-1059814-1","priority":1,"system":false,"conditions":null,"created":"2026-01-06T09:27:38.000Z","lastUpdated":"2026-01-06T09:27:38.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttiw5aaeJ48m2Zv1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttiw5aaeJ48m2Zv1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttiw5aaeJ48m2Zv1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttiw5aaeJ48m2Zv1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttmdzj9uWJqn1Ci1d7","status":"ACTIVE","name":"Microsoft Office 365","priority":1,"system":false,"conditions":null,"created":"2026-01-08T05:12:17.000Z","lastUpdated":"2026-01-08T05:12:17.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttmdzj9uWJqn1Ci1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttmdzj9uWJqn1Ci1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttmdzj9uWJqn1Ci1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttmdzj9uWJqn1Ci1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttns08bchudC1Wi1d7","status":"ACTIVE","name":"Okta End User Settings","priority":1,"system":false,"conditions":null,"created":"2026-01-09T03:44:43.000Z","lastUpdated":"2026-01-09T03:44:43.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttns08bchudC1Wi1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttns08bchudC1Wi1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttns08bchudC1Wi1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttns08bchudC1Wi1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttvifqwwqHh7gPr1d7","status":"ACTIVE","name":"TF - AMichaels Test","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2026-01-16T07:33:53.000Z","lastUpdated":"2026-01-16T07:33:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvifqwwqHh7gPr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvifqwwqHh7gPr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvifqwwqHh7gPr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvifqwwqHh7gPr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rsttvno3t8GBjwDxN1d7","status":"ACTIVE","name":"MFA enroll policy","priority":1,"system":false,"conditions":null,"created":"2026-01-16T10:51:35.000Z","lastUpdated":"2026-01-16T10:51:35.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvno3t8GBjwDxN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvno3t8GBjwDxN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvno3t8GBjwDxN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttvno3t8GBjwDxN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstuibbxieCTOq8vq1d7","status":"ACTIVE","name":"TF - Uber''s Test-22/02/26","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2026-02-01T07:50:33.000Z","lastUpdated":"2026-02-22T12:11:27.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuibbxieCTOq8vq1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuibbxieCTOq8vq1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuibbxieCTOq8vq1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstuibbxieCTOq8vq1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstvl1nal4JFZXBM91d7","status":"ACTIVE","name":"TF - my_policy-dependson-migration","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2026-02-27T10:54:27.000Z","lastUpdated":"2026-02-27T10:54:27.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvl1nal4JFZXBM91d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvl1nal4JFZXBM91d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvl1nal4JFZXBM91d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvl1nal4JFZXBM91d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstvqxkf3jyEYyRVU1d7","status":"ACTIVE","name":"TF - my_policy-dependson-migration-03-03","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2026-03-03T11:52:21.000Z","lastUpdated":"2026-03-03T11:52:21.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvqxkf3jyEYyRVU1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvqxkf3jyEYyRVU1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvqxkf3jyEYyRVU1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstvqxkf3jyEYyRVU1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstw0brwuqFABb5641d7","status":"ACTIVE","name":"TF - my_policy-dependson-migration-03-08","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2026-03-08T21:43:54.000Z","lastUpdated":"2026-03-08T21:43:54.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0brwuqFABb5641d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0brwuqFABb5641d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0brwuqFABb5641d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0brwuqFABb5641d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstw0bt6prAbu63ci1d7","status":"ACTIVE","name":"TF - my_policy-dependson-migration-03-08-2","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2026-03-08T21:44:53.000Z","lastUpdated":"2026-03-08T21:44:53.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0bt6prAbu63ci1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0bt6prAbu63ci1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0bt6prAbu63ci1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw0bt6prAbu63ci1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstw2p3eilUYGOQh51d7","status":"ACTIVE","name":"Panic Test Policy 1","description":"This will panic","priority":1,"system":false,"conditions":null,"created":"2026-03-10T13:00:36.000Z","lastUpdated":"2026-03-10T13:00:36.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2p3eilUYGOQh51d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2p3eilUYGOQh51d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2p3eilUYGOQh51d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2p3eilUYGOQh51d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstw2sa2c4cY7gwlt1d7","status":"ACTIVE","name":"Panic Test Policy","description":"Testing panic handling","priority":1,"system":false,"conditions":null,"created":"2026-03-10T14:08:56.000Z","lastUpdated":"2026-03-10T14:08:56.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2sa2c4cY7gwlt1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2sa2c4cY7gwlt1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2sa2c4cY7gwlt1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstw2sa2c4cY7gwlt1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstx4cogh1GeluqXZ1d7","status":"ACTIVE","name":"Dynamic App Sign-On Policy","description":"Policy with dynamically defined rules","priority":1,"system":false,"conditions":null,"created":"2026-04-04T21:54:48.000Z","lastUpdated":"2026-04-04T21:54:48.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx4cogh1GeluqXZ1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx4cogh1GeluqXZ1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx4cogh1GeluqXZ1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx4cogh1GeluqXZ1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstx68vcp4EM5S7hN1d7","status":"ACTIVE","name":"Partner Admin Portal","priority":1,"system":false,"conditions":null,"created":"2026-04-06T17:23:43.000Z","lastUpdated":"2026-04-06T17:23:43.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx68vcp4EM5S7hN1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx68vcp4EM5S7hN1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx68vcp4EM5S7hN1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstx68vcp4EM5S7hN1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstxmwarevAJ1QINp1d7","status":"ACTIVE","name":"TF - my_policy-dependson-migration-2","description":"Test Policy.","priority":1,"system":false,"conditions":null,"created":"2026-04-16T08:22:07.000Z","lastUpdated":"2026-04-16T08:22:07.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxmwarevAJ1QINp1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxmwarevAJ1QINp1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxmwarevAJ1QINp1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxmwarevAJ1QINp1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstxvqvq6iST5SABI1d7","status":"ACTIVE","name":"Dynamic App Sign-On Policy Uber-22-04","description":"Policy with dynamically defined rules","priority":1,"system":false,"conditions":null,"created":"2026-04-22T15:57:06.000Z","lastUpdated":"2026-04-22T15:57:41.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxvqvq6iST5SABI1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxvqvq6iST5SABI1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxvqvq6iST5SABI1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstxvqvq6iST5SABI1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstym88uzqbWbBTzE1d7","status":"ACTIVE","name":"Dynamic App Sign-On Policy-11May","description":"Policy with dynamically defined rules","priority":1,"system":false,"conditions":null,"created":"2026-05-11T13:06:17.000Z","lastUpdated":"2026-05-11T13:06:17.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstym88uzqbWbBTzE1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstym88uzqbWbBTzE1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstym88uzqbWbBTzE1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstym88uzqbWbBTzE1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"},{"id":"rstyzt540bXaHIvAr1d7","status":"ACTIVE","name":"chains-ordering-test","description":"Reproduces chains key ordering inconsistency","priority":1,"system":false,"conditions":null,"created":"2026-05-21T04:35:57.000Z","lastUpdated":"2026-05-21T04:35:57.000Z","_links":{"mappings":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstyzt540bXaHIvAr1d7/mappings","hints":{"allow":["GET","POST"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstyzt540bXaHIvAr1d7","hints":{"allow":["GET","PUT","DELETE"]}},"rules":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstyzt540bXaHIvAr1d7/rules","hints":{"allow":["GET","POST"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rstyzt540bXaHIvAr1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}},"_embedded":{"resourceType":"APP"},"type":"ACCESS_POLICY"}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:47 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/policies?type=ACCESS_POLICY>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.499323208s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/policies/rsttivnuvg01CxhjA1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 27 May 2026 19:36:48 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.309499333s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz85t4b8okCNkFE1d7","orn":"orn:oktapreview:idp:00otivnuq1X5554yc1d7:apps:oie-00_testacc3131132638_2:0oaz85t4b8okCNkFE1d7","name":"oie-00_testacc3131132638_2","label":"testAcc_3131132638","status":"ACTIVE","lastUpdated":"2026-05-27T19:36:44.000Z","created":"2026-05-27T19:36:44.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3131132638_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":null,"ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3131132638_2/0oaz85t4b8okCNkFE1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3131132638_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3131132638_2/0oaz85t4b8okCNkFE1d7/alnz86fio4UiOrwjD1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuviYmKDYit1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuvg01CxhjA1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/lifecycle/deactivate"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:49 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.091681917s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            kid:
+                - gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8
+        headers:
+            Accept:
+                - application/xml
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/sso/saml/metadata?kid=gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2355
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkz85t4b7vqoFDAw1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYx
+            HDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkz
+            NjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBG
+            cmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlk
+            Y3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIB
+            IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADF
+            IDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIP
+            DmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcg
+            YkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIor
+            oJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWC
+            oQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvE
+            TNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zH
+            PgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YD
+            assFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0r
+            zJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3131132638_2/exkz85t4b7vqoFDAw1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3131132638_2/exkz85t4b7vqoFDAw1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2355"
+            Content-Type:
+                - application/xml;charset=ISO-8859-1
+            Date:
+                - Wed, 27 May 2026 19:36:51 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.259837875s
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/credentials/keys
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"kty":"RSA","created":"2026-05-27T19:36:44.000Z","lastUpdated":"2026-05-27T19:36:44.000Z","expiresAt":"2036-05-27T19:36:44.000Z","kid":"gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8","use":"sig","x5c":["MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkzNjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlkY3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADFIDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIPDmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcgYkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIoroJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWCoQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvETNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zHPgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YDassFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0rzJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g"],"x5t#S256":"FIc5IHatYrGAKne5DXwsHtu4EzGNQwYX9QhvPJFMbD8","e":"AQAB","n":"t1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADFIDrp47vRcP6vz-mG2Os6967_h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb-VWcERhIPDmWlC2b3PZKVaLrv-zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcgYkpTqRGn7vWM8p-Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD-vz4ieUCL4kBtCkGs5GclIfhs1DIoroJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWCoQ"}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:52 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.288761583s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1333
+        host: oie-00.dne-okta.com
+        body: |
+            {"x5c":["MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYx\nHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkz\nNjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBG\ncmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlk\nY3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADF\nIDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIP\nDmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcg\nYkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIor\noJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWC\noQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvE\nTNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zH\nPgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YD\nassFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0r\nzJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g"]}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"kty":"RSA","created":"2026-05-27T19:36:53.000Z","lastUpdated":"2026-05-27T19:36:53.000Z","expiresAt":"2036-05-27T19:36:44.000Z","alg":"RSA","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","use":"sig","x5c":["MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYx\nHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkz\nNjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBG\ncmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlk\nY3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADF\nIDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIP\nDmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcg\nYkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIor\noJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWC\noQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvE\nTNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zH\nPgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YD\nassFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0r\nzJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g"],"x5t#S256":"FIc5IHatYrGAKne5DXwsHtu4EzGNQwYX9QhvPJFMbD8","e":"AQAB","n":"t1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADFIDrp47vRcP6vz-mG2Os6967_h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb-VWcERhIPDmWlC2b3PZKVaLrv-zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcgYkpTqRGn7vWM8p-Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD-vz4ieUCL4kBtCkGs5GclIfhs1DIoroJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWCoQ"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:53 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.144328208s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/a5ec7ecd-4c2d-4360-934d-008b6b1c971f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"kty":"RSA","created":"2026-05-27T19:36:53.000Z","lastUpdated":"2026-05-27T19:36:53.000Z","expiresAt":"2036-05-27T19:36:44.000Z","alg":"RSA","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","use":"sig","x5c":["MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYx\nHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkz\nNjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBG\ncmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlk\nY3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADF\nIDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIP\nDmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcg\nYkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIor\noJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWC\noQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvE\nTNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zH\nPgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YD\nassFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0r\nzJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g"],"x5t#S256":"FIc5IHatYrGAKne5DXwsHtu4EzGNQwYX9QhvPJFMbD8","e":"AQAB","n":"t1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADFIDrp47vRcP6vz-mG2Os6967_h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb-VWcERhIPDmWlC2b3PZKVaLrv-zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcgYkpTqRGn7vWM8p-Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD-vz4ieUCL4kBtCkGs5GclIfhs1DIoroJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWCoQ"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:54 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.073782708s
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 944
+        host: oie-00.dne-okta.com
+        body: |
+            {"issuerMode":"ORG_URL","name":"testAcc_3131132638","policy":{"accountLink":{"action":"AUTO"},"maxClockSkew":0,"provisioning":{"action":"AUTO","conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}},"groups":{"action":"NONE"},"profileMaster":false},"subject":{"matchType":"USERNAME","userNameTemplate":{"template":"idpuser.email"}}},"protocol":{"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"}},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"credentials":{"trust":{"issuer":"https://idp.example.com","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f"}},"endpoints":{"acs":{"binding":"HTTP-POST","type":"INSTANCE"},"sso":{"binding":"HTTP-POST","destination":"https://idp.example.com","url":"https://idp.example.com"}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"type":"SAML2"},"status":"ACTIVE","type":"SAML2"}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/idps
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz862ag3U9RQXOV1d7","name":"testAcc_3131132638","status":"ACTIVE","created":"2026-05-27T19:36:56.000Z","lastUpdated":"2026-05-27T19:36:56.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"},"digest":"SHA-1"},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spitypofwqetjddnmszq","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"9D-0EUCvQKW7qW7oimVRwUuDqpu2ASkPc8W524d1kMw"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oaz862ag3U9RQXOV1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:56 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.623808125s
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz862ag3U9RQXOV1d7","name":"testAcc_3131132638","status":"ACTIVE","created":"2026-05-27T19:36:56.000Z","lastUpdated":"2026-05-27T19:36:56.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"},"digest":"SHA-1"},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spitypofwqetjddnmszq","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"9D-0EUCvQKW7qW7oimVRwUuDqpu2ASkPc8W524d1kMw"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oaz862ag3U9RQXOV1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:57 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.082150042s
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oaz862ag3U9RQXOV1d7
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oaz862ag3U9RQXOV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"prmz862agbSYGUUXd1d7","source":{"id":"0oaz862ag3U9RQXOV1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz862ag3U9RQXOV1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oaz862ag3U9RQXOV1d7/default"}}},"target":{"id":"otytivnus5k8rPk4X1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otytivnus5k8rPk4X1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osctivnus5k8rPk4X1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:58 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.2295245s
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"prmz862agbSYGUUXd1d7","source":{"id":"0oaz862ag3U9RQXOV1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz862ag3U9RQXOV1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oaz862ag3U9RQXOV1d7/default"}}},"target":{"id":"otytivnus5k8rPk4X1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otytivnus5k8rPk4X1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osctivnus5k8rPk4X1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:36:59 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.0784355s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz85t4b8okCNkFE1d7","orn":"orn:oktapreview:idp:00otivnuq1X5554yc1d7:apps:oie-00_testacc3131132638_2:0oaz85t4b8okCNkFE1d7","name":"oie-00_testacc3131132638_2","label":"testAcc_3131132638","status":"ACTIVE","lastUpdated":"2026-05-27T19:36:44.000Z","created":"2026-05-27T19:36:44.000Z","accessibility":{"selfService":false,"errorRedirectUrl":null,"loginRedirectUrl":null},"visibility":{"autoLaunch":false,"autoSubmitToolbar":false,"hide":{"iOS":false,"web":false},"appLinks":{"oie-00_testacc3131132638_2_link":true}},"features":[],"signOnMode":"SAML_2_0","credentials":{"userNameTemplate":{"template":"${source.login}","type":"BUILT_IN"},"signing":{"kid":"gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8"}},"universalLogout":{"status":"DISABLED","supportType":"FULL","identityStack":"NOT_SHARED","protocol":"GLOBAL_TOKEN_REVOCATION"},"settings":{"app":{},"notifications":{"vpn":{"network":{"connection":"DISABLED"},"message":null,"helpUrl":null}},"manualProvisioning":false,"implicitAssignment":false,"emOptInStatus":"NONE","notes":{"admin":null,"enduser":null},"signOn":{"defaultRelayState":null,"ssoAcsUrl":"http://google.com","idpIssuer":"http://www.okta.com/${org.externalKey}","audience":"http://audience.com","recipient":"http://here.com","destination":"http://its-about-the-journey.com","subjectNameIdTemplate":"${user.userName}","subjectNameIdFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress","responseSigned":true,"assertionSigned":false,"signatureAlgorithm":"RSA_SHA256","digestAlgorithm":"SHA256","honorForceAuthn":false,"authnContextClassRef":"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport","spIssuer":null,"requestCompressed":false,"attributeStatements":[],"inlineHooks":[],"assertionEncryption":{"enabled":false},"allowMultipleAcsEndpoints":false,"acsEndpoints":[],"samlSignedRequestEnabled":false,"slo":{"enabled":false}}},"_links":{"help":{"href":"https://oie-00-admin.dne-okta.com/app/oie-00_testacc3131132638_2/0oaz85t4b8okCNkFE1d7/setup/help/SAML_2_0/instructions","type":"text/html"},"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/sso/saml/metadata","type":"application/xml"},"uploadLogo":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/logo","hints":{"allow":["POST"]}},"appLinks":[{"name":"oie-00_testacc3131132638_2_link","href":"https://oie-00.dne-okta.com/home/oie-00_testacc3131132638_2/0oaz85t4b8okCNkFE1d7/alnz86fio4UiOrwjD1d7","type":"text/html"}],"profileEnrollment":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuviYmKDYit1d7"},"policies":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/policies","hints":{"allow":["PUT"]}},"groups":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/groups"},"logo":[{"name":"medium","href":"https://op3static2.oktacdn.com/assets/img/logos/default.6770228fb0dab49a1695ef440a5279bb.png","type":"image/png"}],"accessPolicy":{"href":"https://oie-00.dne-okta.com/api/v1/policies/rsttivnuvg01CxhjA1d7"},"users":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/users"},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/lifecycle/deactivate"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.090475208s
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            kid:
+                - gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8
+        headers:
+            Accept:
+                - application/xml
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/sso/saml/metadata?kid=gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 2355
+        body: |-
+            <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor entityID="http://www.okta.com/exkz85t4b7vqoFDAw1d7" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"><md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEG
+            A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+            MBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYx
+            HDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkz
+            NjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBG
+            cmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlk
+            Y3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIB
+            IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADF
+            IDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIP
+            DmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcg
+            YkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIor
+            oJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWC
+            oQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvE
+            TNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zH
+            PgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YD
+            assFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0r
+            zJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3131132638_2/exkz85t4b7vqoFDAw1d7/sso/saml"/><md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://oie-00.dne-okta.com/app/oie-00_testacc3131132638_2/exkz85t4b7vqoFDAw1d7/sso/saml"/></md:IDPSSODescriptor></md:EntityDescriptor>
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Length:
+                - "2355"
+            Content-Type:
+                - application/xml;charset=ISO-8859-1
+            Date:
+                - Wed, 27 May 2026 19:37:02 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.331214958s
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/credentials/keys
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"kty":"RSA","created":"2026-05-27T19:36:44.000Z","lastUpdated":"2026-05-27T19:36:44.000Z","expiresAt":"2036-05-27T19:36:44.000Z","kid":"gJO-qtayvMv91jMswpunLDA63huCzslnma3ip-2pHq8","use":"sig","x5c":["MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkzNjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlkY3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADFIDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIPDmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcgYkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIoroJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWCoQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvETNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zHPgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YDassFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0rzJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g"],"x5t#S256":"FIc5IHatYrGAKne5DXwsHtu4EzGNQwYX9QhvPJFMbD8","e":"AQAB","n":"t1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADFIDrp47vRcP6vz-mG2Os6967_h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb-VWcERhIPDmWlC2b3PZKVaLrv-zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcgYkpTqRGn7vWM8p-Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD-vz4ieUCL4kBtCkGs5GclIfhs1DIoroJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWCoQ"}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:03 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.24905225s
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/a5ec7ecd-4c2d-4360-934d-008b6b1c971f
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"kty":"RSA","created":"2026-05-27T19:36:53.000Z","lastUpdated":"2026-05-27T19:36:53.000Z","expiresAt":"2036-05-27T19:36:44.000Z","alg":"RSA","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","use":"sig","x5c":["MIIDwjCCAqqgAwIBAgIGAZ5q8HezMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYDVQQGEwJVUzETMBEG\nA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU\nMBIGA1UECwwLU1NPUHJvdmlkZXIxIjAgBgNVBAMMGWRjcC10Zi10ZXN0aW5nLTIwMjYtMDEtMDYx\nHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjYwNTI3MTkzNTQ0WhcNMzYwNTI3MTkz\nNjQ0WjCBoTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBG\ncmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMSIwIAYDVQQDDBlk\nY3AtdGYtdGVzdGluZy0yMDI2LTAxLTA2MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADF\nIDrp47vRcP6vz+mG2Os6967/h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb+VWcERhIP\nDmWlC2b3PZKVaLrv+zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcg\nYkpTqRGn7vWM8p+Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD+vz4ieUCL4kBtCkGs5GclIfhs1DIor\noJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWC\noQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA+TF+POL1VRrN3w1jXuoDBGgG0NsKUmJ3/Jugp/OvE\nTNV4u3yFNKpfELxNRiWukX1ZFsCe3i8h6v1dCgDubrtKCtWcMs9iNpC15GC1XfcXJDWNt5zhf5zH\nPgCm4ffllEIHX8Y721S0wC9kHSD9ZEhlPHpJBoH+MyNPoj7aLqFcEmbjg5f3x1zNW4lmE48aa9YD\nassFr3u1NLrnsKSrVvu2wyhRLF6T1oKyNJU0ex2+feLc3mz40aLfIeiZwhPENMnZJVMULVJAKM0r\nzJO7GepGv/rQN1RL3ef3/r1y8gBQQCzzSXq7q8AjK/vfOJVf0lPjcbioZo5GIPHnlooIP38g"],"x5t#S256":"FIc5IHatYrGAKne5DXwsHtu4EzGNQwYX9QhvPJFMbD8","e":"AQAB","n":"t1kyvKOAsHardX5lE5sdvW6TZ9fw6TEYWADFIDrp47vRcP6vz-mG2Os6967_h3j5nAzb42XvXyYRjKWisEtorDFSBOZk2jhjhVkY3Bb-VWcERhIPDmWlC2b3PZKVaLrv-zfSLRcneKey1yMAKhQEgPlpF2QoAJwhG51ZscDkrjZryjem3K7XtyakaMcgYkpTqRGn7vWM8p-Jc3Q0m85mbcG8lu7gpWfzNOJiha9ILD-vz4ieUCL4kBtCkGs5GclIfhs1DIoroJcehLnvFOOSQ9Bu6qtvwy9rCkQlluPnZd3UHVhRlL9XdsWmaKI3O4nOqeJe7rRM30Pb6856MqWCoQ"}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:04 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.11169025s
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz862ag3U9RQXOV1d7","name":"testAcc_3131132638","status":"ACTIVE","created":"2026-05-27T19:36:56.000Z","lastUpdated":"2026-05-27T19:36:56.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"},"digest":"SHA-1"},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spitypofwqetjddnmszq","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"9D-0EUCvQKW7qW7oimVRwUuDqpu2ASkPc8W524d1kMw"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oaz862ag3U9RQXOV1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:05 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.115066541s
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oaz862ag3U9RQXOV1d7
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oaz862ag3U9RQXOV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"prmz862agbSYGUUXd1d7","source":{"id":"0oaz862ag3U9RQXOV1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz862ag3U9RQXOV1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oaz862ag3U9RQXOV1d7/default"}}},"target":{"id":"otytivnus5k8rPk4X1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otytivnus5k8rPk4X1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osctivnus5k8rPk4X1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:07 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.133495083s
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"prmz862agbSYGUUXd1d7","source":{"id":"0oaz862ag3U9RQXOV1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz862ag3U9RQXOV1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oaz862ag3U9RQXOV1d7/default"}}},"target":{"id":"otytivnus5k8rPk4X1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otytivnus5k8rPk4X1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osctivnus5k8rPk4X1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:08 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.202410667s
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz862ag3U9RQXOV1d7","name":"testAcc_3131132638","status":"ACTIVE","created":"2026-05-27T19:36:56.000Z","lastUpdated":"2026-05-27T19:36:56.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"},"digest":"SHA-1"},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spitypofwqetjddnmszq","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"9D-0EUCvQKW7qW7oimVRwUuDqpu2ASkPc8W524d1kMw"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oaz862ag3U9RQXOV1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/users","hints":{"allow":["GET"]}},"deactivate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/lifecycle/deactivate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:09 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.070171291s
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        form:
+            limit:
+                - "200"
+            sourceId:
+                - 0oaz862ag3U9RQXOV1d7
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/mappings?limit=200&sourceId=0oaz862ag3U9RQXOV1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"prmz862agbSYGUUXd1d7","source":{"id":"0oaz862ag3U9RQXOV1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz862ag3U9RQXOV1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oaz862ag3U9RQXOV1d7/default"}}},"target":{"id":"otytivnus5k8rPk4X1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otytivnus5k8rPk4X1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osctivnus5k8rPk4X1d7"}}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:10 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/mappings?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.114588291s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"prmz862agbSYGUUXd1d7","source":{"id":"0oaz862ag3U9RQXOV1d7","name":"saml_idp","type":"appuser","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/apps/0oaz862ag3U9RQXOV1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/apps/0oaz862ag3U9RQXOV1d7/default"}}},"target":{"id":"otytivnus5k8rPk4X1d7","name":"user","type":"user","_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/meta/types/user/otytivnus5k8rPk4X1d7"},"schema":{"href":"https://oie-00.dne-okta.com/api/v1/meta/schemas/user/osctivnus5k8rPk4X1d7"}}},"properties":{"firstName":{"expression":"source.firstName","pushStatus":"DONT_PUSH"},"lastName":{"expression":"source.lastName","pushStatus":"DONT_PUSH"},"email":{"expression":"source.email","pushStatus":"DONT_PUSH"},"mobilePhone":{"expression":"source.mobilePhone","pushStatus":"DONT_PUSH"},"login":{"expression":"source.userName","pushStatus":"DONT_PUSH"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/mappings/prmz862agbSYGUUXd1d7"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:11 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.165849833s
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"0oaz862ag3U9RQXOV1d7","name":"testAcc_3131132638","status":"INACTIVE","created":"2026-05-27T19:36:56.000Z","lastUpdated":"2026-05-27T19:37:13.000Z","protocol":{"type":"SAML2","endpoints":{"sso":{"url":"https://idp.example.com","binding":"HTTP-POST","destination":"https://idp.example.com"},"acs":{"binding":"HTTP-POST","type":"INSTANCE"}},"algorithms":{"request":{"signature":{"algorithm":"SHA-256","scope":"REQUEST"},"digest":"SHA-1"},"response":{"signature":{"algorithm":"SHA-256","scope":"ANY"}}},"settings":{"nameFormat":"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified","honorPersistentNameId":false},"credentials":{"trust":{"issuer":"https://idp.example.com","audience":"https://www.okta.com/saml2/service-provider/spitypofwqetjddnmszq","kid":"a5ec7ecd-4c2d-4360-934d-008b6b1c971f","revocation":null,"revocationCacheLifetime":0},"signing":{"kid":"9D-0EUCvQKW7qW7oimVRwUuDqpu2ASkPc8W524d1kMw"}}},"policy":{"provisioning":{"action":"AUTO","profileMaster":false,"groups":{"action":"NONE"},"conditions":{"deprovisioned":{"action":"NONE"},"suspended":{"action":"NONE"}}},"accountLink":{"filter":null,"action":"AUTO"},"subject":{"userNameTemplate":{"template":"idpuser.email"},"filter":null,"matchType":"USERNAME","matchAttribute":null},"maxClockSkew":0,"trustClaims":false,"transformedUsernameMatchingEnabled":false},"type":"SAML2","_links":{"metadata":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/metadata.xml","type":"application/xml","hints":{"allow":["GET"]}},"acs":{"href":"https://oie-00.dne-okta.com/sso/saml2/0oaz862ag3U9RQXOV1d7","type":"application/xml","hints":{"allow":["POST"]}},"users":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/users","hints":{"allow":["GET"]}},"activate":{"href":"https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7/lifecycle/activate","hints":{"allow":["POST"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:13 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.160829416s
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/0oaz862ag3U9RQXOV1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 27 May 2026 19:37:14 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.201132333s
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/idps/credentials/keys/a5ec7ecd-4c2d-4360-934d-008b6b1c971f
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 27 May 2026 19:37:15 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.094243167s
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7/lifecycle/deactivate
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 27 May 2026 19:37:16 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 1.284350458s
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/apps/0oaz85t4b8okCNkFE1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Wed, 27 May 2026 19:37:18 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 1.318492708s


### PR DESCRIPTION
Fixes OKTA-1131393

## Problem

`okta_idp_saml`, `okta_idp_social`, and `okta_idp_oidc` resources crashed with a nil pointer dereference during `import`, `plan`, or `apply` on certain Okta cells.

The crash occurred in the Read function of all three resources:

```go
if idp.Policy.AccountLink.Filter != nil {
    setMap["account_link_group_include"] = utils.ConvertStringSliceToSet(
        idp.Policy.AccountLink.Filter.Groups.Include, // panics when Groups is nil
    )
}
```

The guard only checked `Filter != nil`, but not `Filter.Groups != nil`. On the affected cells, the API returns `accountLink.filter.groups = null` while `filter` itself is non-null — for example when the "Exclude admins" checkbox is unchecked:

```
"accountLink": {
  "filter": {
    "groups": null,
    "users": { "excludeAdmins": true }
  },
  "action": "AUTO"
}
```

## Fix

Added `&& idp.Policy.AccountLink.Filter.Groups != nil` to the nil guard in all three affected Read functions:

- `okta/services/idaas/resource_okta_idp_saml.go`
- `okta/services/idaas/resource_okta_idp_social.go`
- `okta/services/idaas/resource_okta_idp_oidc.go`

## Test

Added `TestAccResourceOktaIdpSaml_account_link_auto` — creates an `okta_idp_saml` with `account_link_action = "AUTO"` and no `account_link_group_include` (the customer's exact configuration), then imports it to exercise the Read path where the nil pointer was.