### PR TITLE
fix: handle 404s gracefully in okta_push_group read, update, and delete

### DIFF
--- a/okta/services/idaas/resource_okta_push_group.go
+++ b/okta/services/idaas/resource_okta_push_group.go
@@ -224,8 +224,14 @@ func (r *pushGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	groupPushMapping, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.GetGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Execute()
+	groupPushMapping, apiResp, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.GetGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Execute()
 	if err != nil {
+		if utils.SuppressErrorOn404_V6(apiResp, err) == nil {
+			// The mapping no longer exists in Okta (deleted out of band); drop it
+			// from state so Terraform plans a recreate instead of erroring.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading Okta push group mapping ", err.Error())
 		return
 	}
@@ -258,10 +264,16 @@ func (r *pushGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	groupPushMapping, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.UpdateGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Body(v6okta.UpdateGroupPushMappingRequest{
+	groupPushMapping, apiResp, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.UpdateGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Body(v6okta.UpdateGroupPushMappingRequest{
 		Status: state.Status.ValueString(),
 	}).Execute()
 	if err != nil {
+		if utils.SuppressErrorOn404_V6(apiResp, err) == nil {
+			// The mapping no longer exists in Okta (deleted out of band); drop it
+			// from state so Terraform plans a recreate instead of erroring.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("failed to update push group mapping: ", err.Error())
 		return
 	}
@@ -290,17 +302,25 @@ func (r *pushGroupResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	if state.Status.ValueString() != "INACTIVE" {
-		_, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.UpdateGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Body(v6okta.UpdateGroupPushMappingRequest{
+		_, apiResp, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.UpdateGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Body(v6okta.UpdateGroupPushMappingRequest{
 			Status: "INACTIVE",
 		}).Execute()
 		if err != nil {
+			if utils.SuppressErrorOn404_V6(apiResp, err) == nil {
+				// The mapping is already gone; nothing left to delete.
+				return
+			}
 			resp.Diagnostics.AddError("failed to delete push group mapping: ", err.Error())
 			return
 		}
 	}
 
-	_, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.DeleteGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).DeleteTargetGroup(state.DeleteTargetGroupOnDestroy.ValueBool()).Execute()
+	apiResp, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.DeleteGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).DeleteTargetGroup(state.DeleteTargetGroupOnDestroy.ValueBool()).Execute()
 	if err != nil {
+		if utils.SuppressErrorOn404_V6(apiResp, err) == nil {
+			// Already deleted outside Terraform — treat as a successful destroy.
+			return
+		}
 		resp.Diagnostics.AddError("failed to delete push group mapping: ", err.Error())
 		return
 	}


### PR DESCRIPTION
Fixes #2807

### Summary

`okta_push_group` discarded the API response on its read, update, and delete calls (`groupPushMapping, _, err := ...`), so a `404 Not Found` returned for a mapping that was deleted out of band (e.g. removed in the Okta Admin UI) surfaced as a hard error. This blocked `terraform plan`/`apply` and `terraform destroy`, forcing a manual `terraform state rm` to recover.

This mirrors the exact failure reported in #2807:

> `"Error reading Okta push group mapping ","detail":"404 Not Found"`

### Changes

Capture the V6 API response on each call and branch on a 404 via `utils.SuppressErrorOn404_V6`:

- **Read** — remove the resource from state (`resp.State.RemoveResource`) so Terraform plans a recreate instead of erroring on refresh/plan.
- **Update** — same: remove from state so Terraform plans a recreate.
- **Delete** — treat an already-gone mapping as a successful destroy, covering both the `INACTIVE` deactivation call and the delete call.

This matches the established 404-handling patterns already in the provider:

- `resource_okta_authenticator_webauthn_custom_aaguid.go` (read → `RemoveResource`)
- `resource_okta_group_owners.go` (update/delete → suppress 404)

### Behavior change

Before: `404` from an out-of-band-deleted mapping → hard error on plan/apply/destroy.
After: Terraform detects the mapping is gone and plans a recreate (read/update) or completes the destroy cleanly (delete) — the behavior requested in #2807.

