### PR TITLE
feat(app_oauth): add dpop_bound_access_tokens attribute

### DIFF
--- a/docs/resources/app_oauth.md
+++ b/docs/resources/app_oauth.md
@@ -84,6 +84,7 @@ resource "okta_app_oauth" "example" {
 - `client_id` (String) OAuth client ID. If set during creation, app is created with this id.
 - `client_uri` (String) URI to a web page providing information about the client.
 - `consent_method` (String) *Early Access Property*. Indicates whether user consent is required or implicit. Valid values: REQUIRED, TRUSTED. Default value is TRUSTED. Note: Enable `API_ACCESS_MANAGEMENT`, `API_ACCESS_MANAGEMENT_CONSENT` feature flags in your org to use this property.
+- `dpop_bound_access_tokens` (Boolean) Requires the client to send a Demonstrating Proof-of-Possession (DPoP) header when requesting tokens. When true, the authorization server rejects token requests from this client that lack the DPoP header. Defaults to false (the Okta API default) when omitted. Note: when true, the API disallows `client_credentials` and `implicit` in `grant_types`.
 - `enduser_note` (String) Application notes for end users.
 - `grant_types` (Set of String) List of OAuth 2.0 grant types. Conditional validation params found here https://developer.okta.com/docs/api/resources/apps#credentials-settings-details. Defaults to minimum requirements per app type.
 - `groups_claim` (Block Set, Max: 1) Groups claim for an OpenID Connect client application (argument is ignored when API auth is done with OAuth 2.0 credentials, and is not supported when `preconfigured_app` is set) (see [below for nested schema](#nestedblock--groups_claim))

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -255,6 +255,12 @@ other arguments that changed will be applied.`,
 				Description: "Require Proof Key for Code Exchange (PKCE) for additional verification key rotation mode. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object",
 				Computed:    true,
 			},
+			"dpop_bound_access_tokens": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Requires the client to send a Demonstrating Proof-of-Possession (DPoP) header when requesting tokens. When true, the authorization server rejects token requests from this client that lack the DPoP header. Defaults to false (the Okta API default) when omitted. Note: when true, the API disallows `client_credentials` and `implicit` in `grant_types`.",
+			},
 			"redirect_uris": {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -822,6 +828,7 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 	if consentMethod := oauthClient.GetConsentMethod(); consentMethod != "" {
 		_ = d.Set("consent_method", consentMethod)
 	}
+	_ = d.Set("dpop_bound_access_tokens", oauthClient.GetDpopBoundAccessTokens())
 	_ = d.Set("issuer_mode", oauthClient.GetIssuerMode())
 	_ = d.Set("participate_slo", oauthClient.GetParticipateSlo())
 	_ = d.Set("frontchannel_logout_uri", oauthClient.GetFrontchannelLogoutUri())
@@ -1121,6 +1128,11 @@ func buildAppOAuthV6(d *schema.ResourceData, isNew bool) (v6okta.ListApplication
 	}
 	if consentMethod := d.Get("consent_method").(string); consentMethod != "" {
 		oauthClientSettings.SetConsentMethod(consentMethod)
+	}
+
+	dpopVal := d.GetRawConfig().GetAttr("dpop_bound_access_tokens")
+	if !dpopVal.IsNull() {
+		oauthClientSettings.SetDpopBoundAccessTokens(dpopVal.True())
 	}
 
 	if redirectUris := utils.ConvertInterfaceToStringArr(d.Get("redirect_uris")); len(redirectUris) > 0 {

--- a/okta/services/idaas/resource_okta_app_oauth_test.go
+++ b/okta/services/idaas/resource_okta_app_oauth_test.go
@@ -564,6 +564,43 @@ resource "okta_app_oauth" "test" {
 	})
 }
 
+func TestAccResourceOktaAppOauth_dpop_bound_access_tokens(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSAppOAuth, t.Name())
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSAppOAuth)
+	config := `
+resource "okta_app_oauth" "test" {
+  label                    = "testAcc_replace_with_uuid"
+  type                     = "web"
+  grant_types              = ["authorization_code"]
+  redirect_uris            = ["https://example.com/"]
+  response_types           = ["code"]
+  dpop_bound_access_tokens = %t
+}
+`
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkResourceDestroy(resources.OktaIDaaSAppOAuth, createDoesOAuthAppExist()),
+		Steps: []resource.TestStep{
+			{
+				Config: mgr.ConfigReplace(fmt.Sprintf(config, true)),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
+					resource.TestCheckResourceAttr(resourceName, "dpop_bound_access_tokens", "true"),
+				),
+			},
+			{
+				Config: mgr.ConfigReplace(fmt.Sprintf(config, false)),
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, createDoesOAuthAppExist()),
+					resource.TestCheckResourceAttr(resourceName, "dpop_bound_access_tokens", "false"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccResourceOktaAppOauth_config_combinations
 // W.R.T. https://github.com/okta/terraform-provider-okta/issues/1325
 // Documentation of the the API behavior of pkce_required when the app type is


### PR DESCRIPTION
Expose settings.oauthClient.dpopBoundAccessTokens on okta_app_oauth as a read/write boolean. Omitted -> Okta API default (false, surfaced via Computed); explicit value drift-detects an out-of-band Admin-UI flip, using the same GetRawConfig() null-vs-set pattern as pkce_required.

The v6 okta-sdk-golang already models the field
(OpenIdConnectApplicationSettingsClient.DpopBoundAccessTokens), so this is pure schema/build/read plumbing plus an acceptance test.

Fixes #2028