### PR TITLE
fix: populate okta_app_oauth type on import for preconfigured OIN OIDC apps (GH-2868)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### BUG FIXES
-* Fixed `okta_app_oauth` leaving `type` empty in state when importing preconfigured OIN OIDC apps, which caused the next plan to force replacement of the live app [#2870](https://github.com/okta/terraform-provider-okta/pull/2870) ([#2868](https://github.com/okta/terraform-provider-okta/issues/2868)) by [exitcode0](https://github.com/exitcode0)
-
 ## 6.12.0 (June 10, 2026)
 
 ### FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### BUG FIXES
+* Fixed `okta_app_oauth` leaving `type` empty in state when importing preconfigured OIN OIDC apps, which caused the next plan to force replacement of the live app [#2868](https://github.com/okta/terraform-provider-okta/issues/2868) by [rmcgregor](https://github.com/rmcgregor)
+
 ## 6.12.0 (June 10, 2026)
 
 ### FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### BUG FIXES
-* Fixed `okta_app_oauth` leaving `type` empty in state when importing preconfigured OIN OIDC apps, which caused the next plan to force replacement of the live app [#2868](https://github.com/okta/terraform-provider-okta/issues/2868) by [rmcgregor](https://github.com/rmcgregor)
+* Fixed `okta_app_oauth` leaving `type` empty in state when importing preconfigured OIN OIDC apps, which caused the next plan to force replacement of the live app [#2870](https://github.com/okta/terraform-provider-okta/pull/2870) ([#2868](https://github.com/okta/terraform-provider-okta/issues/2868)) by [rmcgregor](https://github.com/rmcgregor)
 
 ## 6.12.0 (June 10, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### BUG FIXES
-* Fixed `okta_app_oauth` leaving `type` empty in state when importing preconfigured OIN OIDC apps, which caused the next plan to force replacement of the live app [#2870](https://github.com/okta/terraform-provider-okta/pull/2870) ([#2868](https://github.com/okta/terraform-provider-okta/issues/2868)) by [rmcgregor](https://github.com/rmcgregor)
+* Fixed `okta_app_oauth` leaving `type` empty in state when importing preconfigured OIN OIDC apps, which caused the next plan to force replacement of the live app [#2870](https://github.com/okta/terraform-provider-okta/pull/2870) ([#2868](https://github.com/okta/terraform-provider-okta/issues/2868)) by [exitcode0](https://github.com/exitcode0)
 
 ## 6.12.0 (June 10, 2026)
 

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -767,7 +767,32 @@ func resourceAppOAuthRead(ctx context.Context, d *schema.ResourceData, meta inte
 		_ = d.Set("groups_claim", gc)
 	}
 
+	// Populate the immutable, ForceNew "type" attribute. This is handled
+	// separately from setOAuthClientSettingsV6 because that helper early-returns
+	// when settings.OauthClient is nil, which happens for preconfigured OIN OIDC
+	// apps. Leaving "type" unset in state makes a subsequent plan show
+	// `type = "..." # forces replacement` and destroy/recreate a live app
+	// (see GH-2868). setOAuthAppType is also a no-op clobber-guard: it never
+	// overwrites a known "type" with an empty value when the API omits
+	// application_type.
+	setOAuthAppType(d, settings.OauthClient)
+
 	return setOAuthClientSettingsV6(d, settings.OauthClient)
+}
+
+// setOAuthAppType sets the "type" attribute from the OAuth client's
+// application_type. Okta's public GET /apps/{id} omits settings.oauthClient
+// (nil) and/or its application_type for preconfigured OIN OIDC apps, so this
+// only writes "type" when a concrete value is available and otherwise preserves
+// whatever is already in state/config. "type" is Required + ForceNew, so
+// clobbering it with "" would force an unwanted replacement on the next plan.
+func setOAuthAppType(d *schema.ResourceData, oauthClient *v6okta.OpenIdConnectApplicationSettingsClient) {
+	if oauthClient == nil {
+		return
+	}
+	if appType := oauthClient.GetApplicationType(); appType != "" {
+		_ = d.Set("type", appType)
+	}
 }
 
 func flattenGroupsClaim(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]interface{}, error) {
@@ -808,7 +833,9 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 		return nil
 	}
 
-	_ = d.Set("type", oauthClient.GetApplicationType())
+	// "type" is populated by setOAuthAppType (called from resourceAppOAuthRead)
+	// so that preconfigured OIN OIDC apps, which can have a nil oauthClient or an
+	// empty application_type, still round-trip cleanly on import (GH-2868).
 	_ = d.Set("client_uri", oauthClient.GetClientUri())
 	_ = d.Set("logo_uri", oauthClient.GetLogoUri())
 	_ = d.Set("tos_uri", oauthClient.GetTosUri())

--- a/okta/services/idaas/resource_okta_app_oauth.go
+++ b/okta/services/idaas/resource_okta_app_oauth.go
@@ -767,25 +767,17 @@ func resourceAppOAuthRead(ctx context.Context, d *schema.ResourceData, meta inte
 		_ = d.Set("groups_claim", gc)
 	}
 
-	// Populate the immutable, ForceNew "type" attribute. This is handled
-	// separately from setOAuthClientSettingsV6 because that helper early-returns
-	// when settings.OauthClient is nil, which happens for preconfigured OIN OIDC
-	// apps. Leaving "type" unset in state makes a subsequent plan show
-	// `type = "..." # forces replacement` and destroy/recreate a live app
-	// (see GH-2868). setOAuthAppType is also a no-op clobber-guard: it never
-	// overwrites a known "type" with an empty value when the API omits
-	// application_type.
+	// Set "type" separately: setOAuthClientSettingsV6 early-returns on a nil
+	// OauthClient, which preconfigured OIN OIDC apps have (GH-2868).
 	setOAuthAppType(d, settings.OauthClient)
 
 	return setOAuthClientSettingsV6(d, settings.OauthClient)
 }
 
-// setOAuthAppType sets the "type" attribute from the OAuth client's
-// application_type. Okta's public GET /apps/{id} omits settings.oauthClient
-// (nil) and/or its application_type for preconfigured OIN OIDC apps, so this
-// only writes "type" when a concrete value is available and otherwise preserves
-// whatever is already in state/config. "type" is Required + ForceNew, so
-// clobbering it with "" would force an unwanted replacement on the next plan.
+// setOAuthAppType sets "type" from the OAuth client's application_type, but only
+// when present. Preconfigured OIN OIDC apps can return a nil OauthClient or empty
+// application_type; since "type" is Required + ForceNew, overwriting it with ""
+// would force replacement on import (GH-2868).
 func setOAuthAppType(d *schema.ResourceData, oauthClient *v6okta.OpenIdConnectApplicationSettingsClient) {
 	if oauthClient == nil {
 		return
@@ -833,9 +825,7 @@ func setOAuthClientSettingsV6(d *schema.ResourceData, oauthClient *v6okta.OpenId
 		return nil
 	}
 
-	// "type" is populated by setOAuthAppType (called from resourceAppOAuthRead)
-	// so that preconfigured OIN OIDC apps, which can have a nil oauthClient or an
-	// empty application_type, still round-trip cleanly on import (GH-2868).
+	// "type" is handled by setOAuthAppType (GH-2868).
 	_ = d.Set("client_uri", oauthClient.GetClientUri())
 	_ = d.Set("logo_uri", oauthClient.GetLogoUri())
 	_ = d.Set("tos_uri", oauthClient.GetTosUri())

--- a/okta/services/idaas/resource_okta_app_oauth_internal_test.go
+++ b/okta/services/idaas/resource_okta_app_oauth_internal_test.go
@@ -1,0 +1,81 @@
+package idaas
+
+import (
+	"testing"
+
+	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
+)
+
+// TestSetOAuthAppType verifies that the "type" attribute is populated correctly
+// on read/import, including the preconfigured OIN OIDC app cases that regressed
+// in GH-2868 (nil oauthClient or empty application_type). The key invariant is
+// that "type" is Required + ForceNew, so it must never be clobbered with an
+// empty value, otherwise a post-import plan destroys and recreates the live app.
+func TestSetOAuthAppType(t *testing.T) {
+	newClient := func(appType *string) *v6okta.OpenIdConnectApplicationSettingsClient {
+		c := v6okta.NewOpenIdConnectApplicationSettingsClientWithDefaults()
+		c.ApplicationType = appType
+		return c
+	}
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name string
+		// existing is the value already in state/config before read (mimics an
+		// import where the user has declared type, or a prior read).
+		existing    string
+		oauthClient *v6okta.OpenIdConnectApplicationSettingsClient
+		want        string
+	}{
+		{
+			name:        "concrete application_type is set",
+			existing:    "",
+			oauthClient: newClient(strPtr("web")),
+			want:        "web",
+		},
+		{
+			name:        "concrete application_type overwrites existing",
+			existing:    "native",
+			oauthClient: newClient(strPtr("browser")),
+			want:        "browser",
+		},
+		{
+			// Preconfigured OIN app: API omits application_type. We must keep the
+			// declared/existing value rather than clobber it to "" (GH-2868).
+			name:        "empty application_type preserves existing",
+			existing:    "web",
+			oauthClient: newClient(nil),
+			want:        "web",
+		},
+		{
+			// Preconfigured OIN app: API omits oauthClient entirely.
+			name:        "nil oauthClient preserves existing",
+			existing:    "web",
+			oauthClient: nil,
+			want:        "web",
+		},
+		{
+			name:        "empty application_type with no existing stays empty",
+			existing:    "",
+			oauthClient: newClient(strPtr("")),
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := resourceAppOAuth().TestResourceData()
+			if tt.existing != "" {
+				if err := d.Set("type", tt.existing); err != nil {
+					t.Fatalf("failed to seed existing type: %v", err)
+				}
+			}
+
+			setOAuthAppType(d, tt.oauthClient)
+
+			if got := d.Get("type").(string); got != tt.want {
+				t.Errorf("type = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/okta/services/idaas/resource_okta_app_oauth_internal_test.go
+++ b/okta/services/idaas/resource_okta_app_oauth_internal_test.go
@@ -6,11 +6,9 @@ import (
 	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 )
 
-// TestSetOAuthAppType verifies that the "type" attribute is populated correctly
-// on read/import, including the preconfigured OIN OIDC app cases that regressed
-// in GH-2868 (nil oauthClient or empty application_type). The key invariant is
-// that "type" is Required + ForceNew, so it must never be clobbered with an
-// empty value, otherwise a post-import plan destroys and recreates the live app.
+// TestSetOAuthAppType verifies "type" is never clobbered with an empty value
+// when the API omits application_type/oauthClient (GH-2868); "type" is ForceNew,
+// so an empty write would force replacement on import.
 func TestSetOAuthAppType(t *testing.T) {
 	newClient := func(appType *string) *v6okta.OpenIdConnectApplicationSettingsClient {
 		c := v6okta.NewOpenIdConnectApplicationSettingsClientWithDefaults()


### PR DESCRIPTION
Fixes #2868.

### Problem
Importing a preconfigured OIN OIDC app into `okta_app_oauth` leaves the `type` attribute empty in state. Because `type` is `Required` + `ForceNew`, the next `terraform plan` shows `type = "web" # forces replacement` and plans to destroy/recreate the live app, so existing OIN OIDC apps (e.g. ISPM, Okta Privileged Access) can't be imported cleanly. This is the import half left unaddressed by #2721 / #1030 (preconfigured_app create support, v6.7.0).

### Root cause
On Read, `type` was set only inside `setOAuthClientSettingsV6`, which early-returns when `settings.oauthClient` is nil. For preconfigured OIN apps the public `GET /apps/{id}` can omit `oauthClient` (nil) and/or `application_type` (empty), so `type` was never populated.

### Fix
Move `type` population into a dedicated `setOAuthAppType` helper invoked from `resourceAppOAuthRead` independent of the nil-`oauthClient` early-return. It only writes `type` when `application_type` is present and otherwise preserves the existing state/config value, so it never clobbers the `ForceNew` attribute with an empty string. `type` remains `Required` + `ForceNew` (it is genuinely immutable in Okta).

### Tests
Added in-package unit test `TestSetOAuthAppType` covering nil `oauthClient`, empty `application_type`, and concrete-value cases. `go build`, `go vet`, `gofmt`, and the new unit test all pass. Acceptance tests (`TF_ACC`) require a live org and were not run.
