### PR TITLE
feat: fix papercuts around domain verifications

### DIFF
--- a/docs/resources/domain_verification.md
+++ b/docs/resources/domain_verification.md
@@ -16,7 +16,7 @@ resource "okta_domain" "example" {
 }
 
 resource "okta_domain_verification" "example" {
-  domain_id = okta_domain.test.id
+  domain_id = okta_domain.example.id
 }
 ```
 
@@ -30,5 +30,13 @@ resource "okta_domain_verification" "example" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import okta_domain_verification.example <domain_id>
+```
 
 

--- a/docs/resources/email_domain_verification.md
+++ b/docs/resources/email_domain_verification.md
@@ -19,7 +19,7 @@ resource "okta_email_domain" "example" {
 }
 
 resource "okta_email_domain_verification" "example" {
-  email_domain_id = okta_email_domain.valid.id
+  email_domain_id = okta_email_domain.example.id
 }
 ```
 
@@ -34,4 +34,11 @@ resource "okta_email_domain_verification" "example" {
 
 - `id` (String) The ID of this resource.
 
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import okta_email_domain_verification.example <email_domain_id>
+```
 

--- a/examples/resources/okta_domain_verification/basic.tf
+++ b/examples/resources/okta_domain_verification/basic.tf
@@ -1,0 +1,8 @@
+resource "okta_domain" "test" {
+  name                    = "testAcc-replace_with_uuid.example.com"
+  certificate_source_type = "MANUAL"
+}
+
+resource "okta_domain_verification" "test" {
+  domain_id = okta_domain.test.id
+}

--- a/examples/resources/okta_domain_verification/basic.tf
+++ b/examples/resources/okta_domain_verification/basic.tf
@@ -1,8 +1,18 @@
-resource "okta_domain" "test" {
-  name                    = "testAcc-replace_with_uuid.example.com"
-  certificate_source_type = "MANUAL"
+# This test targets a custom domain that has already been created AND verified
+# out of band (DNS records published + propagated). Verifying an already-verified
+# domain must succeed (the provider detects the VERIFIED status and skips the
+# verify call). A fresh domain cannot be verified inside an acceptance test
+# because there is no opportunity to publish DNS records mid-run.
+#
+# When recording: export TF_VAR_domain_id=<your verified domain id>.
+# After recording: set the default below to the recorded id so replay reproduces
+# the same request URLs.
+variable "domain_id" {
+  type        = string
+  description = "ID of a pre-existing, already-verified Okta custom domain"
+  default     = "OcD14k9oy3uuzBt6Y698"
 }
 
 resource "okta_domain_verification" "test" {
-  domain_id = okta_domain.test.id
+  domain_id = var.domain_id
 }

--- a/examples/resources/okta_domain_verification/import.sh
+++ b/examples/resources/okta_domain_verification/import.sh
@@ -1,0 +1,1 @@
+terraform import okta_domain_verification.example <domain_id>

--- a/examples/resources/okta_domain_verification/resource.tf
+++ b/examples/resources/okta_domain_verification/resource.tf
@@ -3,5 +3,5 @@ resource "okta_domain" "example" {
 }
 
 resource "okta_domain_verification" "example" {
-  domain_id = okta_domain.test.id
+  domain_id = okta_domain.example.id
 }

--- a/examples/resources/okta_email_domain_verification/basic.tf
+++ b/examples/resources/okta_email_domain_verification/basic.tf
@@ -1,0 +1,13 @@
+data "okta_brands" "test" {
+}
+
+resource "okta_email_domain" "test" {
+  brand_id     = tolist(data.okta_brands.test.brands)[0].id
+  domain       = "testAcc-replace_with_uuid.example.com"
+  display_name = "test"
+  user_name    = "fff"
+}
+
+resource "okta_email_domain_verification" "test" {
+  email_domain_id = okta_email_domain.test.id
+}

--- a/examples/resources/okta_email_domain_verification/basic.tf
+++ b/examples/resources/okta_email_domain_verification/basic.tf
@@ -1,13 +1,18 @@
-data "okta_brands" "test" {
-}
-
-resource "okta_email_domain" "test" {
-  brand_id     = tolist(data.okta_brands.test.brands)[0].id
-  domain       = "testAcc-replace_with_uuid.example.com"
-  display_name = "test"
-  user_name    = "fff"
+# This test targets an email domain that has already been created AND verified
+# out of band (DNS records published + propagated). Verifying an already-verified
+# email domain must succeed (the provider detects the VERIFIED status and skips
+# the verify call). A fresh email domain cannot be verified inside an acceptance
+# test because there is no opportunity to publish DNS records mid-run.
+#
+# When recording: export TF_VAR_email_domain_id=<your verified email domain id>.
+# After recording: set the default below to the recorded id so replay reproduces
+# the same request URLs.
+variable "email_domain_id" {
+  type        = string
+  description = "ID of a pre-existing, already-verified Okta email domain"
+  default     = "OeD14kbe6kzsL858H698"
 }
 
 resource "okta_email_domain_verification" "test" {
-  email_domain_id = okta_email_domain.test.id
+  email_domain_id = var.email_domain_id
 }

--- a/examples/resources/okta_email_domain_verification/import.sh
+++ b/examples/resources/okta_email_domain_verification/import.sh
@@ -1,0 +1,1 @@
+terraform import okta_email_domain_verification.example <email_domain_id>

--- a/examples/resources/okta_email_domain_verification/resource.tf
+++ b/examples/resources/okta_email_domain_verification/resource.tf
@@ -6,5 +6,5 @@ resource "okta_email_domain" "example" {
 }
 
 resource "okta_email_domain_verification" "example" {
-  email_domain_id = okta_email_domain.valid.id
+  email_domain_id = okta_email_domain.example.id
 }

--- a/okta/services/idaas/resource_okta_domain_verification.go
+++ b/okta/services/idaas/resource_okta_domain_verification.go
@@ -16,8 +16,20 @@ func resourceDomainVerification() *schema.Resource {
 		CreateContext: resourceDomainVerificationCreate,
 		ReadContext:   utils.ResourceFuncNoOp,
 		DeleteContext: utils.ResourceFuncNoOp,
-		Importer:      nil,
-		Description:   "Verifies the Domain. This is replacement for the `verify` field from the `okta_domain` resource. The resource won't be created if the domain could not be verified. The provider will make several requests to verify the domain until the API returns `VERIFIED` verification status. ",
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				domain, _, err := getOktaClientFromMetadata(meta).Domain.GetDomain(ctx, d.Id())
+				if err != nil {
+					return nil, fmt.Errorf("failed to get domain for import: %v", err)
+				}
+				if !IsDomainValidated(domain.ValidationStatus) {
+					return nil, fmt.Errorf("cannot import domain verification: domain %q is not verified (current validation status: %s)", d.Id(), domain.ValidationStatus)
+				}
+				_ = d.Set("domain_id", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+		Description: "Verifies the Domain. This is replacement for the `verify` field from the `okta_domain` resource. The resource won't be created if the domain could not be verified. The provider will make several requests to verify the domain until the API returns `VERIFIED` verification status. ",
 		Schema: map[string]*schema.Schema{
 			"domain_id": {
 				Type:        schema.TypeString,
@@ -30,6 +42,13 @@ func resourceDomainVerification() *schema.Resource {
 }
 
 func resourceDomainVerificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	domainId := d.Get("domain_id").(string)
+	// Verifying an already-verified domain returns a 400, so check the current
+	// state first and skip verification if it has already been validated.
+	if domain, _, err := getOktaClientFromMetadata(meta).Domain.GetDomain(ctx, domainId); err == nil && domain != nil && IsDomainValidated(domain.ValidationStatus) {
+		d.SetId(domainId)
+		return nil
+	}
 	boc := utils.NewExponentialBackOffWithContext(ctx, 30*time.Second)
 	err := backoff.Retry(func() error {
 		domain, _, err := getOktaClientFromMetadata(meta).Domain.VerifyDomain(ctx, d.Get("domain_id").(string))

--- a/okta/services/idaas/resource_okta_domain_verification_test.go
+++ b/okta/services/idaas/resource_okta_domain_verification_test.go
@@ -1,8 +1,13 @@
 package idaas_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
 	"github.com/okta/terraform-provider-okta/okta/services/idaas"
 )
 
@@ -26,5 +31,42 @@ func TestDomainValidationString(t *testing.T) {
 		if actual != test.expected {
 			t.Errorf("domain validation status failed for status = \"%s\" - Expected: %t, Actual: %t", test.element, test.expected, actual)
 		}
+	}
+}
+
+func TestAccResourceOktaDomainVerification_import(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSDomainVerification, t.Name())
+	config := mgr.GetFixtures("basic.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSDomainVerification)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: importStateIdForDomainVerification(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func importStateIdForDomainVerification(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+		return rs.Primary.Attributes["domain_id"], nil
 	}
 }

--- a/okta/services/idaas/resource_okta_domain_verification_test.go
+++ b/okta/services/idaas/resource_okta_domain_verification_test.go
@@ -34,7 +34,7 @@ func TestDomainValidationString(t *testing.T) {
 	}
 }
 
-func TestAccResourceOktaDomainVerification_import(t *testing.T) {
+func TestAccResourceOktaDomainVerification_alreadyVerified(t *testing.T) {
 	mgr := newFixtureManager("resources", resources.OktaIDaaSDomainVerification, t.Name())
 	config := mgr.GetFixtures("basic.tf", t)
 	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSDomainVerification)

--- a/okta/services/idaas/resource_okta_email_domain_verification.go
+++ b/okta/services/idaas/resource_okta_email_domain_verification.go
@@ -2,6 +2,7 @@ package idaas
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,8 +14,20 @@ func resourceEmailDomainVerification() *schema.Resource {
 		CreateContext: resourceEmailDomainVerificationCreate,
 		ReadContext:   utils.ResourceFuncNoOp,
 		DeleteContext: utils.ResourceFuncNoOp,
-		Importer:      nil,
-		Description:   "Verifies the email domain. The resource won't be created if the email domain could not be verified.",
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				emailDomain, _, err := getOktaV3ClientFromMetadata(meta).EmailDomainAPI.GetEmailDomain(ctx, d.Id()).Execute()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get email domain for import: %v", err)
+				}
+				if !IsDomainValidated(emailDomain.GetValidationStatus()) {
+					return nil, fmt.Errorf("cannot import email domain verification: email domain %q is not verified (current validation status: %s)", d.Id(), emailDomain.GetValidationStatus())
+				}
+				_ = d.Set("email_domain_id", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+		Description: "Verifies the email domain. The resource won't be created if the email domain could not be verified.",
 		Schema: map[string]*schema.Schema{
 			"email_domain_id": {
 				Type:        schema.TypeString,
@@ -27,10 +40,17 @@ func resourceEmailDomainVerification() *schema.Resource {
 }
 
 func resourceEmailDomainVerificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	_, _, err := getOktaV3ClientFromMetadata(meta).EmailDomainAPI.VerifyEmailDomain(ctx, d.Get("email_domain_id").(string)).Execute()
+	emailDomainId := d.Get("email_domain_id").(string)
+	// Verifying an already-verified email domain returns a 400, so check the
+	// current state first and skip verification if it has already been validated.
+	if emailDomain, _, err := getOktaV3ClientFromMetadata(meta).EmailDomainAPI.GetEmailDomain(ctx, emailDomainId).Execute(); err == nil && emailDomain != nil && IsDomainValidated(emailDomain.GetValidationStatus()) {
+		d.SetId(emailDomainId)
+		return nil
+	}
+	_, _, err := getOktaV3ClientFromMetadata(meta).EmailDomainAPI.VerifyEmailDomain(ctx, emailDomainId).Execute()
 	if err != nil {
 		return diag.Errorf("failed to verify email domain: %v", err)
 	}
-	d.SetId(d.Get("email_domain_id").(string))
+	d.SetId(emailDomainId)
 	return nil
 }

--- a/okta/services/idaas/resource_okta_email_domain_verification_test.go
+++ b/okta/services/idaas/resource_okta_email_domain_verification_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/okta/terraform-provider-okta/okta/resources"
 )
 
-func TestAccResourceOktaEmailDomainVerification_import(t *testing.T) {
+func TestAccResourceOktaEmailDomainVerification_alreadyVerified(t *testing.T) {
 	mgr := newFixtureManager("resources", resources.OktaIDaaSEmailDomainVerification, t.Name())
 	config := mgr.GetFixtures("basic.tf", t)
 	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSEmailDomainVerification)

--- a/okta/services/idaas/resource_okta_email_domain_verification_test.go
+++ b/okta/services/idaas/resource_okta_email_domain_verification_test.go
@@ -1,0 +1,48 @@
+package idaas_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/resources"
+)
+
+func TestAccResourceOktaEmailDomainVerification_import(t *testing.T) {
+	mgr := newFixtureManager("resources", resources.OktaIDaaSEmailDomainVerification, t.Name())
+	config := mgr.GetFixtures("basic.tf", t)
+	resourceName := fmt.Sprintf("%s.test", resources.OktaIDaaSEmailDomainVerification)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "email_domain_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: importStateIdForEmailDomainVerification(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func importStateIdForEmailDomainVerification(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+		return rs.Primary.Attributes["email_domain_id"], nil
+	}
+}

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaDomainVerification_alreadyVerified/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaDomainVerification_alreadyVerified/oie-00.yaml
@@ -1,0 +1,69 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"OcD14k9oy3uuzBt6Y698","domain":"custom.example.com","certificateSourceType":"OKTA_MANAGED","validationStatus":"COMPLETED","brandId":"bnd14k9cmuu61Q45r698","dnsRecords":[{"recordType":"TXT","fqdn":"_acme-challenge.custom.example.com","values":["jXXQdcYYZy30uMpjyDyhAgN26j_EvKoHWfRTkuwt9Gk"],"expiration":"2026-07-03T03:38:07.000Z"},{"recordType":"CAA","fqdn":"custom.example.com","values":["0 issue letsencrypt.org"]},{"recordType":"CNAME","fqdn":"custom.example.com","values":["oie-00.customdomains.okta.com"]}],"publicCertificate":{"subject":"CN=custom.example.com","fingerprint":"18:6E:CE:C9:0F:3D:4D:68:3C:63:52:C6:1E:93:30:7C:D6:E2:6A:5D:57:E1:7C:3F:82:9E:64:8E:4D:03:E4:41","expiration":"2026-09-24T02:59:10.000Z"},"_links":{"certificate":{"href":"https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698/certificate","hints":{"allow":["PUT"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698","hints":{"allow":["DELETE"]}},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698/verify","hints":{"allow":["POST"]}},"brand":{"href":"https://oie-00.dne-okta.com/api/v1/brands/bnd14k9cmuu61Q45r698","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 26 Jun 2026 04:30:43 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 802.340834ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"OcD14k9oy3uuzBt6Y698","domain":"custom.example.com","certificateSourceType":"OKTA_MANAGED","validationStatus":"COMPLETED","brandId":"bnd14k9cmuu61Q45r698","dnsRecords":[{"recordType":"TXT","fqdn":"_acme-challenge.custom.example.com","values":["jXXQdcYYZy30uMpjyDyhAgN26j_EvKoHWfRTkuwt9Gk"],"expiration":"2026-07-03T03:38:07.000Z"},{"recordType":"CAA","fqdn":"custom.example.com","values":["0 issue letsencrypt.org"]},{"recordType":"CNAME","fqdn":"custom.example.com","values":["oie-00.customdomains.okta.com"]}],"publicCertificate":{"subject":"CN=custom.example.com","fingerprint":"18:6E:CE:C9:0F:3D:4D:68:3C:63:52:C6:1E:93:30:7C:D6:E2:6A:5D:57:E1:7C:3F:82:9E:64:8E:4D:03:E4:41","expiration":"2026-09-24T02:59:10.000Z"},"_links":{"certificate":{"href":"https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698/certificate","hints":{"allow":["PUT"]}},"self":{"href":"https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698","hints":{"allow":["DELETE"]}},"verify":{"href":"https://oie-00.dne-okta.com/api/v1/domains/OcD14k9oy3uuzBt6Y698/verify","hints":{"allow":["POST"]}},"brand":{"href":"https://oie-00.dne-okta.com/api/v1/brands/bnd14k9cmuu61Q45r698","hints":{"allow":["GET","PUT","DELETE"]}}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 26 Jun 2026 04:30:45 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 646.767791ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaEmailDomainVerification_alreadyVerified/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaEmailDomainVerification_alreadyVerified/oie-00.yaml
@@ -1,0 +1,69 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/email-domains/OeD14kbe6kzsL858H698
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"OeD14kbe6kzsL858H698","validationStatus":"VERIFIED","displayName":"Support","userName":"support","domain":"bar.example.com","validationSubdomain":"mail","dnsValidationRecords":[{"recordType":"TXT","fqdn":"_oktaverification.bar.example.com","verificationValue":"52f087f2ea3e41a5939efb4784111afb"},{"recordType":"cname","fqdn":"mail.bar.example.com","verificationValue":"u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt._domainkey.bar.example.com","verificationValue":"okt.domainkey.u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt2._domainkey.bar.example.com","verificationValue":"okt2.domainkey.u21992032.wl033.sendgrid.net"}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 26 Jun 2026 04:49:04 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 695.405833ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: oie-00.dne-okta.com
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/email-domains/OeD14kbe6kzsL858H698
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"OeD14kbe6kzsL858H698","validationStatus":"VERIFIED","displayName":"Support","userName":"support","domain":"bar.example.com","validationSubdomain":"mail","dnsValidationRecords":[{"recordType":"TXT","fqdn":"_oktaverification.bar.example.com","verificationValue":"52f087f2ea3e41a5939efb4784111afb"},{"recordType":"cname","fqdn":"mail.bar.example.com","verificationValue":"u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt._domainkey.bar.example.com","verificationValue":"okt.domainkey.u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt2._domainkey.bar.example.com","verificationValue":"okt2.domainkey.u21992032.wl033.sendgrid.net"}]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 26 Jun 2026 04:49:06 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 642.837916ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaEmailDomainVerification_alreadyVerified/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaEmailDomainVerification_alreadyVerified/oie-00.yaml
@@ -21,7 +21,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"OeD14kbe6kzsL858H698","validationStatus":"VERIFIED","displayName":"Support","userName":"support","domain":"bar.example.com","validationSubdomain":"mail","dnsValidationRecords":[{"recordType":"TXT","fqdn":"_oktaverification.bar.example.com","verificationValue":"52f087f2ea3e41a5939efb4784111afb"},{"recordType":"cname","fqdn":"mail.bar.example.com","verificationValue":"u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt._domainkey.bar.example.com","verificationValue":"okt.domainkey.u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt2._domainkey.bar.example.com","verificationValue":"okt2.domainkey.u21992032.wl033.sendgrid.net"}]}'
+        body: '{"id":"OeD14kbe6kzsL858H698","validationStatus":"VERIFIED","displayName":"Support","userName":"support","domain":"custom.example.com","validationSubdomain":"mail","dnsValidationRecords":[{"recordType":"TXT","fqdn":"_oktaverification.custom.example.com","verificationValue":"52f087f2ea3e41a5939efb4784111afb"},{"recordType":"cname","fqdn":"mail.custom.example.com","verificationValue":"u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt._domainkey.custom.example.com","verificationValue":"okt.domainkey.u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt2._domainkey.custom.example.com","verificationValue":"okt2.domainkey.u21992032.wl033.sendgrid.net"}]}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -54,7 +54,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"id":"OeD14kbe6kzsL858H698","validationStatus":"VERIFIED","displayName":"Support","userName":"support","domain":"bar.example.com","validationSubdomain":"mail","dnsValidationRecords":[{"recordType":"TXT","fqdn":"_oktaverification.bar.example.com","verificationValue":"52f087f2ea3e41a5939efb4784111afb"},{"recordType":"cname","fqdn":"mail.bar.example.com","verificationValue":"u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt._domainkey.bar.example.com","verificationValue":"okt.domainkey.u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt2._domainkey.bar.example.com","verificationValue":"okt2.domainkey.u21992032.wl033.sendgrid.net"}]}'
+        body: '{"id":"OeD14kbe6kzsL858H698","validationStatus":"VERIFIED","displayName":"Support","userName":"support","domain":"custom.example.com","validationSubdomain":"mail","dnsValidationRecords":[{"recordType":"TXT","fqdn":"_oktaverification.custom.example.com","verificationValue":"52f087f2ea3e41a5939efb4784111afb"},{"recordType":"cname","fqdn":"mail.custom.example.com","verificationValue":"u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt._domainkey.custom.example.com","verificationValue":"okt.domainkey.u21992032.wl033.sendgrid.net"},{"recordType":"cname","fqdn":"okt2._domainkey.custom.example.com","verificationValue":"okt2.domainkey.u21992032.wl033.sendgrid.net"}]}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version


### PR DESCRIPTION
There are two problems with the `okta_domain_verification` and `okta_email_domain_verification` resources right now:

1. If the custom domain / email domain is already verified by DNS, attempting to create these resources (by triggering another verification) will fail with a 400 error. 
2. There's no way to import the current verification status of the domain.

I've attempted to solve both of these problems by
1. Querying the domain verification status before attempting to verify again, so avoiding triggering an API request which unfortunately is not idempotent.
2. Allowing the user to import the domain verification and avoid case (1) altogether if desired.

Fixes #1909 