### PR TITLE
release: prepare v6.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.13.0 (June 30, 2026)
+
+### FEATURES
+
+* Added Resource Set data source `okta_iam_resource_set` [#2861](https://github.com/okta/terraform-provider-okta/pull/2861) by [@pranav-okta](https://github.com/pranav-okta)
+* Added Labels, and Resource Owners resources `okta_label`, `okta_resource_owner`, and `okta_resource_owners_catalog_resource` [#2867](https://github.com/okta/terraform-provider-okta/pull/2867) by [@pranav-okta](https://github.com/pranav-okta)
+
 ## 6.12.0 (June 10, 2026)
 
 ### FEATURES

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.12.0"
+      version = "~> 6.13.0"
     }
   }
 }

--- a/examples/data-sources/okta_resource_owner/datasource.tf
+++ b/examples/data-sources/okta_resource_owner/datasource.tf
@@ -1,8 +1,8 @@
 resource "okta_resource_owner" "test" {
-  resource_orns = ["orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oanlpn0tzc7kh9bx1d7"]
+  resource_orns = ["orn:oktapreview:idp:00onkw1sa89bQ0bncd9A:apps:oidc_client:0oabcde0afs9cbx90bup"]
 }
 
 data "okta_resource_owner" "test" {
-  parent_resource_orn = "orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oanlpn0tzc7kh9bx1d7"
+  parent_resource_orn = "orn:oktapreview:idp:00onabc90Ah3T09I1xe0:apps:oidc_client:0oanbc98zc6kh2bx32Pv"
   depends_on          = [okta_resource_owner.test]
 }

--- a/examples/data-sources/okta_resource_owners_catalog_resource/datasource.tf
+++ b/examples/data-sources/okta_resource_owners_catalog_resource/datasource.tf
@@ -1,3 +1,3 @@
 data "okta_resource_owners_catalog_resource" "test" {
-  parent_resource_orn = "orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oanlpn0tzc7kh9bx1d7"
+  parent_resource_orn = "orn:oktapreview:idp:00ontx5xcbCp1Q93I4d8:apps:oidc_client:0oacpcn7nm90ci1be8h5"
 }

--- a/examples/resources/okta_resource_owner/basic.tf
+++ b/examples/resources/okta_resource_owner/basic.tf
@@ -1,3 +1,3 @@
 resource "okta_resource_owner" "test" {
-  resource_orns = ["orn:oktapreview:idp:00onkw1sbuAh3Q06I1d7:apps:oidc_client:0oanlpn0tzc7kh9bx1d7"]
+  resource_orns = ["orn:oktapreview:idp:00onqu8scuB03Vl9xxd7:apps:oidc_client:0oanb8j08zc7gi8cv2c9"]
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "6.12.0"
+	OktaTerraformProviderVersion   = "6.13.0"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.12.0"
+      version = "~> 6.13.0"
     }
   }
 }


### PR DESCRIPTION
## 6.13.0 (June 30, 2026)

### FEATURES

* Added Resource Set data source `okta_iam_resource_set` [#2861](https://github.com/okta/terraform-provider-okta/pull/2861) by [@pranav-okta](https://github.com/pranav-okta)
* Added Labels, and Resource Owners resources `okta_label`, `okta_resource_owner`, and `okta_resource_owners_catalog_resource` [#2867](https://github.com/okta/terraform-provider-okta/pull/2867) by [@pranav-okta](https://github.com/pranav-okta)