### PR TITLE
okta_push_group: remove from state on 404 instead of erroring during read

### DIFF
--- a/okta/services/idaas/resource_okta_push_group.go
+++ b/okta/services/idaas/resource_okta_push_group.go
@@ -3,6 +3,7 @@ package idaas
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -224,8 +225,12 @@ func (r *pushGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	groupPushMapping, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.GetGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Execute()
+	groupPushMapping, httpResp, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.GetGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Execute()
 	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error reading Okta push group mapping ", err.Error())
 		return
 	}
@@ -290,17 +295,23 @@ func (r *pushGroupResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	if state.Status.ValueString() != "INACTIVE" {
-		_, _, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.UpdateGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Body(v6okta.UpdateGroupPushMappingRequest{
+		_, httpResp, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.UpdateGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).Body(v6okta.UpdateGroupPushMappingRequest{
 			Status: "INACTIVE",
 		}).Execute()
 		if err != nil {
+			if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+				return
+			}
 			resp.Diagnostics.AddError("failed to delete push group mapping: ", err.Error())
 			return
 		}
 	}
 
-	_, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.DeleteGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).DeleteTargetGroup(state.DeleteTargetGroupOnDestroy.ValueBool()).Execute()
+	httpResp, err := r.config.OktaIDaaSClient.OktaSDKClientV6().GroupPushMappingAPI.DeleteGroupPushMapping(ctx, state.AppId.ValueString(), state.ID.ValueString()).DeleteTargetGroup(state.DeleteTargetGroupOnDestroy.ValueBool()).Execute()
 	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			return
+		}
 		resp.Diagnostics.AddError("failed to delete push group mapping: ", err.Error())
 		return
 	}

--- a/okta/services/idaas/resource_okta_push_group_test.go
+++ b/okta/services/idaas/resource_okta_push_group_test.go
@@ -1,10 +1,13 @@
 package idaas_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	v6okta "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/okta/acctest"
 	"github.com/okta/terraform-provider-okta/okta/resources"
 )
@@ -43,6 +46,60 @@ func TestAccResourceOktaPushGroup_crud(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceOktaPushGroup_disappears(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.sample", resources.OktaIDaaSPushGroup)
+	mgr := newFixtureManager("resources", resources.OktaIDaaSPushGroup, t.Name())
+	config := mgr.GetFixtures("okta_push_group.tf", t)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
+				),
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					clickOpsDeletePushGroupMapping(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func clickOpsDeletePushGroupMapping(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		appID := rs.Primary.Attributes["app_id"]
+		mappingID := rs.Primary.ID
+		client := iDaaSAPIClientForTestUtil.OktaSDKClientV6()
+		ctx := context.Background()
+
+		// Okta requires the mapping be INACTIVE before it can be deleted.
+		if _, _, err := client.GroupPushMappingAPI.UpdateGroupPushMapping(ctx, appID, mappingID).
+			Body(v6okta.UpdateGroupPushMappingRequest{Status: "INACTIVE"}).Execute(); err != nil {
+			return fmt.Errorf("API: unable to deactivate push group mapping %q: %+v", mappingID, err)
+		}
+		// Delete the target group too, or it's left orphaned in Okta.
+		if _, err := client.GroupPushMappingAPI.DeleteGroupPushMapping(ctx, appID, mappingID).
+			DeleteTargetGroup(true).Execute(); err != nil {
+			return fmt.Errorf("API: unable to delete push group mapping %q: %+v", mappingID, err)
+		}
+		return nil
+	}
 }
 
 func TestAccResourceOktaPushGroup_ad(t *testing.T) {


### PR DESCRIPTION
### Problem

When an `okta_push_group` mapping (or its source group) is deleted outside Terraform, the next `plan`/`refresh` fails hard:

```
Error: Error reading Okta push group mapping … 404 Not Found
```

Because the resource is never dropped from state, the plan cannot proceed, and the only recovery is a manual `terraform state rm`. This is especially painful on locked-down/high-integrity backends where ad-hoc state surgery is restricted. `Delete` has the same gap — it errors if the mapping is already gone.

### Root cause

`pushGroupResource.Read` discards the HTTP response and treats every error from `GetGroupPushMapping` as fatal — there is no not-found branch, so a deleted mapping surfaces as a plan error instead of being reconciled as drift. `Delete` likewise treats a 404 as a failure rather than an already-deleted no-op.

### Fix

- `Read`: on `http.StatusNotFound`, call `resp.State.RemoveResource(ctx)` and return.
- `Delete`: treat a `404` from either the deactivate or delete call as already-deleted (return without error) — making delete idempotent.

Non-404 errors are unchanged.

### Precedent

This is the behavior the plugin framework documents for `Read`:

> Ignore returning errors that signify the resource is no longer existent, call the response state `RemoveResource()` method, and return early.

— [plugin-framework Read recommendations](https://developer.hashicorp.com/terraform/plugin/framework/resources/read)

Resources in this provider already follow it — e.g. `okta_identity_source_group` and `okta_group_owners` call `resp.State.RemoveResource(ctx)` on a 404 in `Read` and tolerate a 404 in `Delete`. It's also the standard convention across the ecosystem: the SDKv2 `googleworkspace_group` resource, for instance, drops itself from state on a 404 (`d.SetId("")`). This change brings `okta_push_group` in line.

### Test

Adds `TestAccResourceOktaPushGroup_disappears`, which deletes the mapping out-of-band via the API and asserts the refresh removes it from state and yields a non-empty plan. Without the fix this step errors on the 404.

### Notes

- No schema, config, or default-value changes; the behavior change is limited to the deleted-outside-Terraform case.
- No documentation changes required.
- CHANGELOG intentionally not modified, per the contributing guide (the provider team updates it at merge time).