### PR TITLE
fix: prevent group loss when paginating checkIfUserHasGroups past 2 pages

### DIFF
--- a/okta/services/idaas/resource_okta_user_group_memberships.go
+++ b/okta/services/idaas/resource_okta_user_group_memberships.go
@@ -121,9 +121,13 @@ func checkIfUserHasGroups(ctx context.Context, client *sdk.Client, userId string
 	if err := utils.SuppressErrorOn404(resp, err); err != nil {
 		return false, fmt.Errorf("unable to return groups for user (%s) from API", userId)
 	}
-	var nextUserGroups []*sdk.Group
-
 	for resp.HasNextPage() {
+		// NOTE: declare the page slice inside the loop. Decoding into a slice
+		// that already holds non-nil pointers makes encoding/json reuse those
+		// pointers and overwrite the structs in place, which would corrupt the
+		// entries already appended to userGroups.
+		var nextUserGroups []*sdk.Group
+
 		resp, err = resp.Next(ctx, &nextUserGroups)
 
 		if err := utils.SuppressErrorOn404(resp, err); err != nil {

--- a/okta/services/idaas/resource_okta_user_group_memberships_test.go
+++ b/okta/services/idaas/resource_okta_user_group_memberships_test.go
@@ -1,11 +1,19 @@
 package idaas_test
 
 import (
+	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jarcoal/httpmock"
 	"github.com/okta/terraform-provider-okta/okta/acctest"
+	"github.com/okta/terraform-provider-okta/okta/config"
 	"github.com/okta/terraform-provider-okta/okta/resources"
+	"github.com/okta/terraform-provider-okta/okta/services/idaas"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccResourceOktaUserGroupMemberships_crud(t *testing.T) {
@@ -31,4 +39,95 @@ func TestAccResourceOktaUserGroupMemberships_crud(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestUserGroupMembershipsReadPaginationDoesNotDropGroups is a regression test
+// for a pointer aliasing bug in checkIfUserHasGroups.
+//
+// The slice each page was decoded into used to be declared once, outside the
+// pagination loop. encoding/json decodes into a slice that already holds
+// non-nil pointers by reusing those pointers and overwriting the structs in
+// place, so decoding a page silently rewrote groups already appended to the
+// accumulator from an earlier page. Groups the user really is a member of
+// disappeared from the collected set, and the resource then reported the
+// membership as missing.
+//
+// The corruption only begins on the THIRD page: page two decodes into a nil
+// slice, which allocates fresh. So reproducing it needs three pages, with the
+// expected group positioned inside the prefix that page three overwrites
+// (index < len(page three)). Two pages, or a group late in page two, both pass
+// even with the bug present.
+func TestUserGroupMembershipsReadPaginationDoesNotDropGroups(t *testing.T) {
+	t.Setenv("OKTA_ORG_NAME", "test")
+	t.Setenv("OKTA_BASE_URL", "example.com")
+	t.Setenv("OKTA_API_TOKEN", "token")
+
+	const (
+		userID  = "00uTESTUSER00000000"
+		groupID = "00gEXPECTED00000000"
+		cursor1 = "00gCURSOR1000000000"
+		cursor2 = "00gCURSOR2000000000"
+	)
+
+	groupsURL := fmt.Sprintf("https://test.example.com/api/v1/users/%s/groups", userID)
+
+	groupsBody := func(ids ...string) string {
+		out := "["
+		for i, id := range ids {
+			if i > 0 {
+				out += ","
+			}
+			out += fmt.Sprintf(`{"id":%q,"type":"OKTA_GROUP","profile":{"name":%q}}`, id, "group-"+id)
+		}
+		return out + "]"
+	}
+
+	// groupID sits at index 0 of page two, and page three is non-empty, so the
+	// aliasing bug overwrites groupID with page three's first group.
+	pages := map[string]struct {
+		body string
+		next string
+	}{
+		"":      {body: groupsBody("00gPAGE1A0000000000", "00gPAGE1B0000000000"), next: cursor1},
+		cursor1: {body: groupsBody(groupID, "00gPAGE2B0000000000"), next: cursor2},
+		cursor2: {body: groupsBody("00gPAGE3A0000000000"), next: ""},
+	}
+
+	d := schema.TestResourceDataRaw(t, idaas.ProviderResources()[resources.OktaIDaaSUserGroupMemberships].Schema, map[string]interface{}{
+		"user_id": userID,
+		"groups":  []interface{}{groupID},
+	})
+	d.SetId(userID)
+
+	c := config.NewConfig(d)
+	require.NoError(t, c.LoadAPIClient())
+
+	defer httpmock.DeactivateAndReset()
+	httpmock.ActivateNonDefault(c.OktaIDaaSClient.OktaSDKClientV2().GetConfig().HttpClient)
+	httpmock.RegisterResponder("GET", groupsURL, func(req *http.Request) (*http.Response, error) {
+		after := req.URL.Query().Get("after")
+		page, ok := pages[after]
+		if !ok {
+			return nil, fmt.Errorf("unexpected after cursor %q", after)
+		}
+		resp := httpmock.NewStringResponse(http.StatusOK, page.body)
+		resp.Header.Set("Content-Type", "application/json")
+		resp.Request = req
+		resp.Header.Add("Link", fmt.Sprintf(`<%s?limit=200>; rel="self"`, groupsURL))
+		if page.next != "" {
+			resp.Header.Add("Link", fmt.Sprintf(`<%s?after=%s&limit=200>; rel="next"`, groupsURL, page.next))
+		}
+		return resp, nil
+	})
+
+	diags := idaas.ProviderResources()[resources.OktaIDaaSUserGroupMemberships].ReadContext(context.Background(), d, c)
+	require.False(t, diags.HasError(), "read returned errors: %+v", diags)
+
+	// Guard the test itself: all three pages must have been walked, otherwise
+	// the scenario no longer covers the aliasing bug.
+	require.Equal(t, 3, httpmock.GetTotalCallCount(), "expected all three pages to be fetched")
+
+	// Read blanks the ID when it believes the user is missing an expected group.
+	require.Equal(t, userID, d.Id(),
+		"expected group %s was reported missing; it is returned on page two of the user's groups, so a page-three decode dropped it", groupID)
 }


### PR DESCRIPTION
## What

`checkIfUserHasGroups` (used by `okta_user_group_memberships` create/read) declared its per-page slice outside the pagination loop and reused it across pages:

```go
var nextUserGroups []*sdk.Group        // declared once
for resp.HasNextPage() {
    resp, err = resp.Next(ctx, &nextUserGroups)   // decoded into the same slice every time
    ...
    userGroups = append(userGroups, nextUserGroups...)
}
```

`encoding/json` does not allocate new structs when the destination slice already holds non-nil pointers - it follows the existing pointers and overwrites the structs in place. Since `userGroups` holds those same pointers, decoding page 3 silently rewrites the entries copied from page 2.

## Why it matters

Any user with **more than 400 group memberships** (2 pages of the API's 200-per-page limit) triggers this on the third page onward. Groups the user is genuinely a member of vanish from the collected set, `checkIfUserHasGroups` reports them as missing, and `resourceUserGroupMembershipsCreate`'s `backoff.Retry` exhausts with:

```
Error: user (<id>) did not have expected group memberships after multiple checks
```

...even though `addUserToGroups` already succeeded and the group assignment is correct in Okta. `terraform apply` fails deterministically every time for these users - it isn't a flaky eventual-consistency race.

This is the same bug class as #1542 (pagination wasn't looped at all), one layer deeper: the loop is correct, but the accumulation across iterations isn't.

## Fix

Move the slice declaration inside the loop so each page decodes into its own freshly allocated slice:

```go
for resp.HasNextPage() {
    var nextUserGroups []*sdk.Group   // fresh per iteration
    resp, err = resp.Next(ctx, &nextUserGroups)
    ...
    userGroups = append(userGroups, nextUserGroups...)
}
```

## Testing

Added `TestUserGroupMembershipsReadPaginationDoesNotDropGroups`, a unit test (`httpmock`, no `TF_ACC`) that mocks a 3-page `GET /users/{id}/groups` response with the target group on page 2 and asserts it survives to the final result. Verified it fails on `main` (before this fix) with:

```
expected: "<user_id>"
actual:   ""
```

and passes with the fix applied. `go vet` and `gofmt` clean.

Reproduced against my company's real Okta org data with a local build - the failing users have 401-600 group memberships (3 pages), and the missing group falls in the corrupted range as predicted.

Cheers ☀️ 