### PR TITLE
fix(request_condition): save state before post-create calls

### DIFF
--- a/okta/services/governance/resource_request_condition.go
+++ b/okta/services/governance/resource_request_condition.go
@@ -211,6 +211,20 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	// A failure in the follow-up calls below (activate, priority update)
+	// must not orphan the just-created condition, so save it to state
+	// now rather than only at the end of Create. Copy the plan model so
+	// the planned status/priority in `data` stay intact for that logic.
+	createdState := data
+	resp.Diagnostics.Append(applyRequestConditionToState(ctx, &createdState, requestConditionResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &createdState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Activate the condition if status is set to ACTIVE
 	if !data.Status.IsNull() && data.Status.ValueString() == "ACTIVE" {
 		requestConditionResp, _, err = r.OktaGovernanceClient.OktaGovernanceSDKClient().
@@ -222,6 +236,19 @@ func (r *requestConditionResource) Create(ctx context.Context, req resource.Crea
 				"Error activating Request condition",
 				"Could not activate Request condition after creation: "+err.Error(),
 			)
+			return
+		}
+
+		// Refresh the saved state with the activation result so the recorded
+		// status stays accurate (and Delete deactivates correctly) if the
+		// priority update below fails.
+		createdState = data
+		resp.Diagnostics.Append(applyRequestConditionToState(ctx, &createdState, requestConditionResp)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &createdState)...)
+		if resp.Diagnostics.HasError() {
 			return
 		}
 	}


### PR DESCRIPTION

Fixes #2899

`Create` for `okta_request_condition` makes up to three API calls (create POST, activate when the config sets `status = "ACTIVE"`, and a follow-up priority PATCH), but only persisted state after all of them succeeded. If the POST created the condition and a later call failed (e.g. the transport giving up after repeated 429s in a rate-limited org), Create returned error diagnostics without ever calling `resp.State.Set`:

- Terraform recorded nothing for the resource
- the condition was left orphaned in Okta as an unmanaged INACTIVE draft
- the next `terraform apply` created a duplicate condition on the app

## Changes

- `Create` now persists the created condition to state immediately after the create POST succeeds, before the activate call
- After a successful activation, the saved state is refreshed so the recorded status stays accurate (and `Delete` deactivates correctly) if the priority PATCH afterwards fails
- A copy of the plan model is used for the early saves so the planned `status`/`priority` values remain available to the existing follow-up logic; the successful path still ends with the same final full `resp.State.Set` as before

State saved during Create is preserved by Terraform even when error diagnostics are returned, so a mid-Create failure now marks the resource as tainted (replaced on the next apply) instead of orphaning it. See the [plugin framework Create documentation](https://developer.hashicorp.com/terraform/plugin/framework/resources/create#caveats).

## Testing

- `go build ./...`, `go vet ./okta/services/governance/`, `gofmt` — clean
- Existing VCR acceptance tests replayed locally (`OKTA_VCR_TF_ACC=play OKTA_VCR_CASSETTE=oie-00`):
  - `TestAccRequestConditionResource_Status` (create with `status = "ACTIVE"`, deactivate, reactivate — exercises both new state-save blocks) — PASS
  - `TestAccRequestConditionResource_Issue2780` — PASS
  - `TestAccDataSourceOktaRequestCondition_read`, `TestAccRequestConditionResource_basic`, `TestAccRequestConditionResource_Issue2510`, `TestAccRequestConditionResource_Priority` fail identically on unmodified `master` (pre-existing cassette mismatches), so no regression from this change
- No new HTTP calls are introduced, so existing cassettes replay unchanged
- A deterministic automated test for the mid-Create failure itself isn't practical with the current VCR harness (it would need a hand-crafted cassette where the create POST succeeds and the activate call exhausts transport retries); happy to add one if maintainers can suggest a preferred seam

## Notes

- Aside for maintainers: when replaying governance-only cassettes locally, `vcrManager.Cassettes()` returns early if the idaas cassette directory for the test is missing, so governance tests silently run zero cassettes unless `OKTA_VCR_CASSETTE` is set explicitly. Not addressed in this PR.
