### PR TITLE
fix: Set push group destroy default on import

### DIFF
--- a/docs/resources/push_group.md
+++ b/docs/resources/push_group.md
@@ -86,3 +86,12 @@ Import is supported using the following syntax:
 ```shell
 terraform import okta_push_group.example <app_id>/<push_group_mapping_id>
 ```
+
+~> **NOTE:** `delete_target_group_on_destroy` is not part of the Okta API response, it
+only exists as a query parameter on the delete call. Import therefore sets it to the
+documented default of `true`. Set it to `false` in configuration and apply if the target
+group should survive a destroy.
+
+~> **NOTE:** `target_group_name` is also not returned by the API, so it stays unset after
+import. Changing it forces replacement, so leave it out of the configuration of an
+imported mapping unless you intend the mapping to be recreated.

--- a/okta/services/idaas/resource_okta_push_group.go
+++ b/okta/services/idaas/resource_okta_push_group.go
@@ -338,6 +338,13 @@ func (r *pushGroupResource) ImportState(ctx context.Context, req resource.Import
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_id"), appId)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), mappingId)...)
+
+	// delete_target_group_on_destroy only exists as a query parameter on the delete
+	// call, so Okta never returns it and it cannot be read back. Seed it with the
+	// schema default so an imported mapping starts out the same as a created one,
+	// instead of leaving state null (which shows up as a spurious plan diff and
+	// makes Delete send deleteTargetGroup=false).
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("delete_target_group_on_destroy"), true)...)
 }
 
 func mapPushGroupResourceToState(groupPushMapping *v6okta.GroupPushMapping, state *pushGroupResourceModel) diag.Diagnostics {
@@ -347,6 +354,15 @@ func mapPushGroupResourceToState(groupPushMapping *v6okta.GroupPushMapping, stat
 	state.TargetGroupId = types.StringPointerValue(groupPushMapping.TargetGroupId)
 	state.Status = types.StringPointerValue(groupPushMapping.Status)
 	state.AppConfig = types.ObjectNull(appConfigAttrTypes)
+
+	// delete_target_group_on_destroy has no counterpart in the API response, so the
+	// incoming value (plan on create/update, prior state on read) is authoritative and
+	// must not be overwritten here. A null only happens for state written by an import
+	// on a provider version that did not set the attribute; fall back to the documented
+	// default there so those mappings destroy the same way created ones do.
+	if state.DeleteTargetGroupOnDestroy.IsNull() {
+		state.DeleteTargetGroupOnDestroy = types.BoolValue(true)
+	}
 
 	// Preserve app_config in state only when the API returns at least one concrete value.
 	// Some mappings return an empty app_config envelope, which must stay null in state.

--- a/okta/services/idaas/resource_okta_push_group_test.go
+++ b/okta/services/idaas/resource_okta_push_group_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/okta/terraform-provider-okta/okta/acctest"
 	"github.com/okta/terraform-provider-okta/okta/resources"
 )
@@ -40,6 +41,42 @@ func TestAccResourceOktaPushGroup_crud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "source_group_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "target_group_id"),
 				),
+			},
+		},
+	})
+}
+
+// Importing a mapping must produce the same state a created one has, including
+// delete_target_group_on_destroy, which the API never returns. See issue #2827.
+func TestAccResourceOktaPushGroup_import(t *testing.T) {
+	resourceName := fmt.Sprintf("%s.sample", resources.OktaIDaaSPushGroup)
+	mgr := newFixtureManager("resources", resources.OktaIDaaSPushGroup, t.Name())
+	config := mgr.GetFixtures("okta_push_group.tf", t)
+
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "delete_target_group_on_destroy", "true"),
+				),
+			},
+			{
+				Config:       config,
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["app_id"], rs.Primary.ID), nil
+				},
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/templates/resources/push_group.md.tmpl
+++ b/templates/resources/push_group.md.tmpl
@@ -48,3 +48,12 @@ Optional:
 Import is supported using the following syntax:
 
 {{codefile "shell" "examples/resources/okta_push_group/import.sh"}}
+
+~> **NOTE:** `delete_target_group_on_destroy` is not part of the Okta API response, it
+only exists as a query parameter on the delete call. Import therefore sets it to the
+documented default of `true`. Set it to `false` in configuration and apply if the target
+group should survive a destroy.
+
+~> **NOTE:** `target_group_name` is also not returned by the API, so it stays unset after
+import. Changing it forces replacement, so leave it out of the configuration of an
+imported mapping unless you intend the mapping to be recreated.


### PR DESCRIPTION
Fixes #2827

`delete_target_group_on_destroy` is declared `Optional` + `Computed` with `Default: booldefault.StaticBool(true)`, but nothing in the read path ever writes it. `ImportState` sets only `app_id` and `id`, and `mapPushGroupResourceToState` (shared by `Create`, `Read` and `Update`) does not touch the attribute. After `terraform import` the value is therefore null in state.

That has two effects:

- The next plan proposes writing the default, which is the spurious in-place diff reported in the issue.
- `Delete` passes the state value straight to the API as `DeleteTargetGroup(state.DeleteTargetGroupOnDestroy.ValueBool())`, and `ValueBool()` on a null `types.Bool` returns `false`. An imported mapping that has not been through an apply destroys with `deleteTargetGroup=false`, while the same configuration created by Terraform destroys with `deleteTargetGroup=true`. Whether the downstream target group is removed depends on how the resource entered state rather than on the configuration.

The attribute has no counterpart in the API response, it only exists as a query parameter on the delete call, so it cannot be read back from Okta. The fix is to make imported state carry the documented default instead of null.

## Changes

- `ImportState` now seeds `delete_target_group_on_destroy` with `true` alongside `app_id` and `id`, so an imported mapping starts out in the same shape as a created one.
- `mapPushGroupResourceToState` falls back to `true` only when the incoming value is null. On create and update the value comes from the plan, and on read from prior state, and in all of those cases it is already known, so an operator's explicit `false` is never overwritten. The guard exists so that state written by an import on an earlier provider version heals on the next refresh, including the refresh that precedes a destroy, rather than only after an intervening apply.
- Added `TestAccResourceOktaPushGroup_import`, which applies the existing fixture and then imports the mapping with `ImportStateVerify`.
- Documented in the resource's import section that `delete_target_group_on_destroy` is seeded with the default at import, and that `target_group_name` stays unset.

Doing this in both places is deliberate. `ImportState` is where the import-specific default belongs and makes the intent obvious at the point of import; the null guard in the shared mapper is what covers state that predates this change.

`target_group_name` is intentionally left alone. It is a genuine import gap, and the note above is only documentation, but it is not fixable here: `GroupPushMapping` in the v6 SDK has no `targetGroupName` field, so there is nothing to read back. Deriving it from the target group's current name would be a guess, and the attribute is `RequiresReplace`, so guessing wrong would propose destroying a live mapping. That seems worth a separate discussion rather than folding into this fix.

No 404 handling is included here, since #2853 and #2892 already cover that in this file.

## Testing

- `gofmt -l` on the changed files, `go build ./...`, `go vet ./okta/...` — clean. `golangci-lint fmt` could not run locally: the installed binary is built with go1.25 and the module targets go1.26.2.
- `make test` (unit tests) — pass, no failures.
- Existing VCR acceptance test replayed locally with `OKTA_VCR_TF_ACC=play`: `TestAccResourceOktaPushGroup_crud` passes, both before and after the change. `TestAccResourceOktaPushGroup_ad` and the new import test are skipped in play mode, as they have no cassettes.
- No acceptance tests were run against a live org; I do not have credentials for one.
- The new import test therefore has no recorded cassette and will be skipped by `make test-play-vcr-acc`. It was verified against the existing `TestAccResourceOktaPushGroup_crud` cassette by temporarily inserting the same import step into that test:
  - on unmodified `master` the step fails with `ImportStateVerify attributes not equivalent`, the difference being the missing `delete_target_group_on_destroy = true`
  - with this change the import step passes
  - that arrangement is not committed, because the extra requests exhaust the existing cassette and break the following step on replay
- Happy to fold the import coverage into `TestAccResourceOktaPushGroup_crud` instead if a maintainer can re-record `TestAccResourceOktaPushGroup_crud/classic-00.yaml`, or to drop the new test if you would rather record `TestAccResourceOktaPushGroup_import` separately.
