### PR TITLE
prepare release 6.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.14.0 (Jul 30, 2026)
+
+### FEATURES
+* Adds support for office365Client config in `okta_ap_signon_policy_rule` resource [#2644](https://github.com/okta/terraform-provider-okta/pull/2644) by [aditya-okta](https://github.com/aditya-okta)
+
 ## 6.13.0 (June 30, 2026)
 
 ### FEATURES

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.13.0"
+      version = "~> 6.14.0"
     }
   }
 }

--- a/okta/version/version.go
+++ b/okta/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	OktaTerraformProviderVersion   = "6.13.0"
+	OktaTerraformProviderVersion   = "6.14.0"
 	OktaTerraformProviderUserAgent = "okta-terraform/" + OktaTerraformProviderVersion
 )

--- a/templates/index.md
+++ b/templates/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     okta = {
       source = "okta/okta"
-      version = "~> 6.13.0"
+      version = "~> 6.14.0"
     }
   }
 }


### PR DESCRIPTION
## 6.14.0 (Jul 30, 2026)

### FEATURES
* Adds support for office365Client config in `okta_ap_signon_policy_rule` resource [#2644](https://github.com/okta/terraform-provider-okta/pull/2644) by [aditya-okta](https://github.com/aditya-okta)
* Adds new resources for oauthv1 clients [#2886](https://github.com/okta/terraform-provider-okta/pull/2886) by [pranav-okta](https://github.com/pranav-okta)
