### PR TITLE
fix: surface API errors in okta_group_memberships Update

### DIFF
--- a/okta/services/idaas/resource_okta_group_memberships.go
+++ b/okta/services/idaas/resource_okta_group_memberships.go
@@ -196,12 +196,12 @@ func resourceGroupMembershipsUpdate(ctx context.Context, d *schema.ResourceData,
 
 	err := addGroupMembers(ctx, client, groupId, usersToAdd)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	err = removeGroupMembers(ctx, client, groupId, usersToRemove)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/okta/services/idaas/resource_okta_group_memberships_test.go
+++ b/okta/services/idaas/resource_okta_group_memberships_test.go
@@ -81,8 +81,8 @@ func TestAccResourceOktaGroupMemberships_GH2775(t *testing.T) {
 }
 
 // TestAccResourceOktaGroupMemberships_Issue2866 addresses https://github.com/okta/terraform-provider-okta/issues/2866
-// Verifies that a 403 from Okta during okta_group_memberships Update is surfaced as an apply error
-// rather than being silently swallowed and reported as a successful apply.
+// Verifies that an API error (e.g. 403 E0000006 on a group with an Application Administrator role binding)
+// during okta_group_memberships Update is surfaced as an apply error rather than being silently swallowed.
 func TestAccResourceOktaGroupMemberships_Issue2866(t *testing.T) {
 	step1 := `
 resource "okta_group" "test" {
@@ -118,7 +118,7 @@ resource "okta_group_memberships" "test" {
 			},
 			{
 				Config:      step2,
-				ExpectError: regexp.MustCompile(`E0000006`),
+				ExpectError: regexp.MustCompile(`You do not have permission to perform the requested action`),
 			},
 		},
 	})

--- a/okta/services/idaas/resource_okta_group_memberships_test.go
+++ b/okta/services/idaas/resource_okta_group_memberships_test.go
@@ -3,6 +3,7 @@ package idaas_test
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -74,6 +75,50 @@ func TestAccResourceOktaGroupMemberships_GH2775(t *testing.T) {
 
 					return nil
 				},
+			},
+		},
+	})
+}
+
+// TestAccResourceOktaGroupMemberships_Issue2866 addresses https://github.com/okta/terraform-provider-okta/issues/2866
+// Verifies that a 403 from Okta during okta_group_memberships Update is surfaced as an apply error
+// rather than being silently swallowed and reported as a successful apply.
+func TestAccResourceOktaGroupMemberships_Issue2866(t *testing.T) {
+	step1 := `
+resource "okta_group" "test" {
+  name        = "TestACC Group 2866"
+  description = "Group for issue 2866 test"
+}
+resource "okta_group_memberships" "test" {
+  group_id = okta_group.test.id
+  users    = ["00u2866TESTUSER1d7"]
+}
+`
+	step2 := `
+resource "okta_group" "test" {
+  name        = "TestACC Group 2866"
+  description = "Group for issue 2866 test"
+}
+resource "okta_group_memberships" "test" {
+  group_id = okta_group.test.id
+  users    = ["00u2866TESTUSER1d7", "00u2866TESTUSER2d7"]
+}
+`
+	acctest.OktaResourceTest(t, resource.TestCase{
+		PreCheck:                 acctest.AccPreCheck(t),
+		ErrorCheck:               testAccErrorChecks(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactoriesForTestAcc(t),
+		CheckDestroy:             checkUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: step1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("okta_group_memberships.test", "users.#", "1"),
+				),
+			},
+			{
+				Config:      step2,
+				ExpectError: regexp.MustCompile(`E0000006`),
 			},
 		},
 	})

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/classic-00.yaml
@@ -6,10 +6,10 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 70
+        content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: |
@@ -22,7 +22,7 @@ interactions:
                 - SSWS REDACTED
             Content-Type:
                 - application/json
-        url: https://oie-00.dne-okta.com/api/v1/groups
+        url: https://classic-00.dne-okta.com/api/v1/groups
         method: POST
       response:
         proto: HTTP/2.0
@@ -32,7 +32,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -53,7 +53,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -63,7 +63,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -94,7 +94,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -104,7 +104,48 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -125,49 +166,6 @@ interactions:
         status: 204 No Content
         code: 204
         duration: 200ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 23 Jun 2026 17:00:00 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
-        duration: 200ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -176,7 +174,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -186,7 +184,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -196,7 +194,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
@@ -205,7 +203,7 @@ interactions:
             Date:
                 - Mon, 23 Jun 2026 17:00:00 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
@@ -219,7 +217,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -229,7 +227,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
         method: GET
       response:
         proto: HTTP/2.0
@@ -239,14 +237,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Mon, 23 Jun 2026 17:00:01 GMT
+                - Mon, 23 Jun 2026 17:00:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
@@ -260,7 +258,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -270,7 +268,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
         method: GET
       response:
         proto: HTTP/2.0
@@ -280,16 +278,16 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
         headers:
             Accept-Ch:
                 - Sec-CH-UA-Platform-Version
             Content-Type:
                 - application/json
             Date:
-                - Mon, 23 Jun 2026 17:00:01 GMT
+                - Mon, 23 Jun 2026 17:00:00 GMT
             Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+                - <https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
@@ -303,7 +301,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -313,7 +311,91 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER2d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://classic-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Link:
+                - <https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER2d7
         method: PUT
       response:
         proto: HTTP/2.0
@@ -336,7 +418,7 @@ interactions:
         status: 403 Forbidden
         code: 403
         duration: 200ms
-    - id: 8
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -344,7 +426,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -354,7 +436,7 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -375,7 +457,7 @@ interactions:
         status: 204 No Content
         code: 204
         duration: 200ms
-    - id: 9
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -383,7 +465,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: oie-00.dne-okta.com
+        host: classic-00.dne-okta.com
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -393,7 +475,46 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER2d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: classic-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://classic-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
         method: DELETE
       response:
         proto: HTTP/2.0

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/classic-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/classic-00.yaml
@@ -1,0 +1,416 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 70
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER2d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"errorCode":"E0000006","errorSummary":"You do not have permission to perform the requested action","errorLink":"E0000006","errorId":"oaeKxtVirzPR_6HFPolr3wbNw","errorCauses":[]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 403 Forbidden
+        code: 403
+        duration: 200ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/oie-00.yaml
@@ -1,0 +1,416 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 70
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"}}
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+            Content-Type:
+                - application/json
+        url: https://oie-00.dne-okta.com/api/v1/groups
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER2d7
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"errorCode":"E0000006","errorSummary":"You do not have permission to perform the requested action","errorLink":"E0000006","errorId":"oaeKxtVirzPR_6HFPolr3wbNw","errorCauses":[]}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 403 Forbidden
+        code: 403
+        duration: 200ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms

--- a/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/oie-00.yaml
+++ b/test/fixtures/vcr/idaas/TestAccResourceOktaGroupMemberships_Issue2866/oie-00.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 70
+        content_length: 88
         transfer_encoding: []
         trailer: {}
         host: oie-00.dne-okta.com
@@ -104,6 +104,47 @@ interactions:
                 - application/json
             Authorization:
                 - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
         url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER1d7
         method: PUT
       response:
@@ -124,49 +165,6 @@ interactions:
                 - strict-origin-when-cross-origin
         status: 204 No Content
         code: 204
-        duration: 200ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: oie-00.dne-okta.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Authorization:
-                - SSWS REDACTED
-        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
-        headers:
-            Accept-Ch:
-                - Sec-CH-UA-Platform-Version
-            Content-Type:
-                - application/json
-            Date:
-                - Mon, 23 Jun 2026 17:00:00 GMT
-            Link:
-                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-        status: 200 OK
-        code: 200
         duration: 200ms
     - id: 4
       request:
@@ -246,13 +244,97 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 23 Jun 2026 17:00:01 GMT
+                - Mon, 23 Jun 2026 17:00:00 GMT
             Referrer-Policy:
                 - strict-origin-when-cross-origin
         status: 200 OK
         code: 200
         duration: 200ms
     - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"00u2866TESTUSER1d7","status":"PROVISIONED","created":"2026-06-23T17:00:00.000Z","activated":"2026-06-23T17:00:00.000Z","statusChanged":"2026-06-23T17:00:00.000Z","lastLogin":null,"lastUpdated":"2026-06-23T17:00:00.000Z","passwordChanged":null,"type":{"id":"oty5qwjvh0Vy1j8Kd1d7"},"profile":{"firstName":"TestAcc1","lastName":"User","mobilePhone":null,"secondEmail":null,"login":"testAcc1-2866@example.com","email":"testAcc1-2866@example.com"},"credentials":{"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://oie-00.dne-okta.com/api/v1/users/00u2866TESTUSER1d7"}}}]'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:00 GMT
+            Link:
+                - <https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users?limit=200>; rel="self"
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"00g2866TESTGROUP1d7","created":"2026-06-23T17:00:00.000Z","lastUpdated":"2026-06-23T17:00:00.000Z","lastMembershipUpdated":"2026-06-23T17:00:00.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"TestACC Group 2866","description":"Group for issue 2866 test"},"_links":{"logo":[{"name":"medium","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.30ce6d4085dff29412984e4c191bc874.png","type":"image/png"},{"name":"large","href":"https://op3static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.c3cb8cda8ae0add1b4fe928f5844dbe3.png","type":"image/png"}],"users":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users"},"apps":{"href":"https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/apps"}}}'
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 200 OK
+        code: 200
+        duration: 200ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -295,7 +377,7 @@ interactions:
         status: 200 OK
         code: 200
         duration: 200ms
-    - id: 7
+    - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -336,7 +418,7 @@ interactions:
         status: 403 Forbidden
         code: 403
         duration: 200ms
-    - id: 8
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -375,7 +457,46 @@ interactions:
         status: 204 No Content
         code: 204
         duration: 200ms
-    - id: 9
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: oie-00.dne-okta.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Authorization:
+                - SSWS REDACTED
+        url: https://oie-00.dne-okta.com/api/v1/groups/00g2866TESTGROUP1d7/users/00u2866TESTUSER2d7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Accept-Ch:
+                - Sec-CH-UA-Platform-Version
+            Date:
+                - Mon, 23 Jun 2026 17:00:01 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+        status: 204 No Content
+        code: 204
+        duration: 200ms
+    - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1


### PR DESCRIPTION
Fixes #2866

`resourceGroupMembershipsUpdate` calls `diag.FromErr(err)` for both the `addGroupMembers` and `removeGroupMembers` error paths but discards the return value in both cases. Any API error is therefore
silently swallowed: Terraform writes state as if the membership change landed and reports a clean apply.

A concrete trigger: a group with an Application Administrator role binding causes Okta to return `E0000006` (403) on `PUT /api/v1/groups/{groupId}/users/{userId}` for any user who does not hold that
role. Before this fix, that 403 produces `Apply complete! Resources: 0 added, 1 changed, 0 destroyed.` with no diagnostics. The drift is only discoverable on the next plan, and only if the user notices
the membership never appeared in Okta.

## Changes

- Add `return` before both `diag.FromErr(err)` calls in `resourceGroupMembershipsUpdate` so API errors are propagated and the apply fails with a visible diagnostic.
- Add `TestAccResourceOktaGroupMemberships_Issue2866`: a two-step acceptance test that creates a group with one member (step 1, succeeds) then attempts to add a second member expecting an `E0000006`
error to surface (step 2).

## Testing

- `make build` and `make lint`: clean.
- `OKTA_VCR_TF_ACC=play make test-play-vcr-acc TEST_FILTER=TestAccResourceOktaGroupMemberships_Issue2866`: passes with the fix applied; without the fix the expected error is never surfaced and the apply
reports success instead.