### PR TITLE
chore: configure fork release workflow for internal builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,3 @@
-# This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
-#
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
-# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
-# secret. If you would rather own your own GPG handling, please fork this action
-# or use an alternative one for key handling.
-#
-# You will need to pass the `--batch` flag to `gpg` in your signing step
-# in `goreleaser` to indicate this is being used in a non-interactive mode.
-#
 name: release
 on:
   push:
@@ -16,7 +5,7 @@ on:
       - "v*"
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.BW_RUNNER_GLORG_EKS_PROD_UBUNTU_2404_AMD64_XS) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -39,21 +28,10 @@ jobs:
         run: time make smoke-test-play-vcr-acc
         timeout-minutes: 30
 
-      - name: Import GPG key
-        id: import_gpg
-        uses:
-          crazy-max/ghaction-import-gpg@v7
-          # These secrets will need to be configured for the repository:
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7.2.3
         with:
           version: "v2.12.7"
-          args: release --clean --parallelism 2
+          args: release --clean --parallelism 2 --skip=sign
         env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,22 +46,10 @@ archives:
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
-signs:
-  - artifacts: checksum
-    args:
-      # if you are using this is a GitHub action or some other automated pipeline, you
-      # need to pass the batch flag to indicate its not interactive.
-      - '--batch'
-      - '--local-user'
-      - '{{ .Env.GPG_FINGERPRINT }}' # set this environment variable for your signing key
-      - '--output'
-      - '${signature}'
-      - '--detach-sign'
-      - '${artifact}'
 release:
   # Explicit set the repo to release from. Default is origin.
   github:
-    owner: okta
+    owner: bandwidth
     name: terraform-provider-okta
   # Visit your project's GitHub Releases page to publish this release.
   draft: true


### PR DESCRIPTION
Removes GPG signing, targets bandwidth/terraform-provider-okta for releases. 
These changes are not intended for upstream.