### PR TITLE
data_source_okta_apps: warn instead of silently dropping undecodable applications

### DIFF
--- a/okta/services/idaas/data_source_okta_apps.go
+++ b/okta/services/idaas/data_source_okta_apps.go
@@ -189,9 +189,21 @@ func (d *appsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	// Convert the list of applications to the Terraform schema.
+	skipped := 0
 	for _, app := range applicationList {
 		oktaApp, ok := app.GetActualInstance().(OktaApp)
 		if !ok {
+			// The SDK's ListApplications200ResponseInner union returns a nil
+			// instance for applications whose signOnMode matches none of its
+			// discriminator values -- its UnmarshalJSON ends with "No match
+			// found or unmarshal failed - return nil to allow partial
+			// unmarshalling". Okta first-party applications (Admin Console,
+			// Okta Dashboard, Okta Browser Plugin, Platform Single Sign-On
+			// for macOS) fall into this bucket. Dropping them without a
+			// diagnostic makes the data source silently under-report: a user
+			// cannot distinguish "the org has N applications" from "the org
+			// has more, but N were representable". Count them and say so.
+			skipped++
 			continue
 		}
 
@@ -242,6 +254,19 @@ func (d *appsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			EndUserNote: types.StringValue(userNotes),
 			Visibility:  visibility,
 		})
+	}
+
+	if skipped > 0 {
+		resp.Diagnostics.AddWarning(
+			"Some applications were omitted from the results",
+			fmt.Sprintf(
+				"%d of %d applications returned by the Okta API could not be decoded into a supported application type and were omitted from the results. "+
+					"This typically affects Okta first-party applications (for example the Admin Console, Okta Dashboard, Okta Browser Plugin, or Platform Single Sign-On for macOS), "+
+					"whose signOnMode does not match any discriminator value known to the SDK. "+
+					"These applications exist in the org but cannot currently be read or managed through this data source.",
+				skipped, len(applicationList),
+			),
+		)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)


### PR DESCRIPTION
## Problem

`data.okta_apps` silently omits every application whose type the SDK cannot decode. In practice that is Okta first-party applications — Admin Console, Okta Dashboard, Okta Browser Plugin, Platform Single Sign-On for macOS — which never appear in the results regardless of `active_only`, `q`, or the credential's admin roles.

The mechanism spans both layers:

1. The SDK models the `ListApplications` response as a `oneOf` union discriminated on `signOnMode`. Its `UnmarshalJSON` ends with:
   ```go
   // No match found or unmarshal failed - return nil to allow partial unmarshalling
   return nil
   ```
   so an application with an unrecognised `signOnMode` arrives as an empty union rather than an error.

2. The provider's `Read` then drops it without a trace ([`data_source_okta_apps.go`](https://github.com/okta/terraform-provider-okta/blob/master/okta/services/idaas/data_source_okta_apps.go)):
   ```go
   oktaApp, ok := app.GetActualInstance().(OktaApp)
   if !ok {
       continue
   }
   ```

The result is that a practitioner cannot distinguish *"my org has N applications"* from *"my org has more, but only N were representable"*. We spent several rounds debugging exactly this: an application that is Active in the console, absent from the data source, with status filters, label typos, pagination and admin roles all ruled out empirically before the cause turned out to be the silent drop.

## Change

Count the skipped items and emit one warning diagnostic:

```
Warning: Some applications were omitted from the results

3 of 34 applications returned by the Okta API could not be decoded into a
supported application type and were omitted from the results. This typically
affects Okta first-party applications (for example the Admin Console, Okta
Dashboard, Okta Browser Plugin, or Platform Single Sign-On for macOS), whose
signOnMode does not match any discriminator value known to the SDK. These
applications exist in the org but cannot currently be read or managed through
this data source.
```

Deliberately **not** changed: what the data source returns. Representing these applications would need the SDK to model their types; this PR only makes the existing behaviour observable instead of silent.

## Testing

- `go build ./okta/...` and `go vet ./okta/services/idaas/` clean
- No schema change, no behaviour change for orgs where every application decodes — the warning only fires when items were actually dropped